### PR TITLE
feat: Add NFT transfer and balance actions

### DIFF
--- a/cdp-agentkit-core/python/CHANGELOG.md
+++ b/cdp-agentkit-core/python/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Added `get_balance_nft` action.
+- Added `transfer_nft` action.
+
 ## [0.0.8] - 2025-01-13
 
 ### Added

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
@@ -15,6 +15,7 @@ from cdp_agentkit_core.actions.wow.create_token import WowCreateTokenAction
 from cdp_agentkit_core.actions.wow.sell_token import WowSellTokenAction
 from cdp_agentkit_core.actions.wrap_eth import WrapEthAction
 
+
 # WARNING: All new CdpAction subclasses must be imported above, otherwise they will not be discovered
 # by get_all_cdp_actions(). The import ensures the class is registered as a subclass of CdpAction.
 def get_all_cdp_actions() -> list[type[CdpAction]]:

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
@@ -2,6 +2,7 @@ from cdp_agentkit_core.actions.cdp_action import CdpAction
 from cdp_agentkit_core.actions.deploy_nft import DeployNftAction
 from cdp_agentkit_core.actions.deploy_token import DeployTokenAction
 from cdp_agentkit_core.actions.get_balance import GetBalanceAction
+from cdp_agentkit_core.actions.get_balance_nft import GetBalanceNftAction
 from cdp_agentkit_core.actions.get_wallet_details import GetWalletDetailsAction
 from cdp_agentkit_core.actions.mint_nft import MintNftAction
 from cdp_agentkit_core.actions.register_basename import RegisterBasenameAction
@@ -13,7 +14,6 @@ from cdp_agentkit_core.actions.wow.buy_token import WowBuyTokenAction
 from cdp_agentkit_core.actions.wow.create_token import WowCreateTokenAction
 from cdp_agentkit_core.actions.wow.sell_token import WowSellTokenAction
 from cdp_agentkit_core.actions.wrap_eth import WrapEthAction
-
 
 # WARNING: All new CdpAction subclasses must be imported above, otherwise they will not be discovered
 # by get_all_cdp_actions(). The import ensures the class is registered as a subclass of CdpAction.
@@ -33,6 +33,7 @@ __all__ = [
     "DeployNftAction",
     "DeployTokenAction",
     "GetBalanceAction",
+    "GetBalanceNftAction",
     "GetWalletDetailsAction",
     "MintNftAction",
     "RegisterBasenameAction",

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
@@ -8,6 +8,7 @@ from cdp_agentkit_core.actions.register_basename import RegisterBasenameAction
 from cdp_agentkit_core.actions.request_faucet_funds import RequestFaucetFundsAction
 from cdp_agentkit_core.actions.trade import TradeAction
 from cdp_agentkit_core.actions.transfer import TransferAction
+from cdp_agentkit_core.actions.transfer_nft import TransferNftAction
 from cdp_agentkit_core.actions.wow.buy_token import WowBuyTokenAction
 from cdp_agentkit_core.actions.wow.create_token import WowCreateTokenAction
 from cdp_agentkit_core.actions.wow.sell_token import WowSellTokenAction
@@ -38,6 +39,7 @@ __all__ = [
     "RequestFaucetFundsAction",
     "TradeAction",
     "TransferAction",
+    "TransferNftAction",
     "WowBuyTokenAction",
     "WowCreateTokenAction",
     "WowSellTokenAction",

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/get_balance_nft.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/get_balance_nft.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 
 from cdp_agentkit_core.actions import CdpAction
 
-
 GET_BALANCE_NFT_PROMPT = """
 This tool will get the NFTs (ERC721 tokens) owned by the wallet for a specific NFT contract.
 
@@ -15,16 +14,16 @@ It takes the following inputs:
 - address: (Optional) The address to check NFT balance for. If not provided, uses the wallet's default address
 """
 
+
 class GetBalanceNftInput(BaseModel):
     """Input argument schema for get NFT balance action."""
-    contract_address: str = Field(
-        ...,
-        description="The NFT contract address to check balance for"
-    )
+
+    contract_address: str = Field(..., description="The NFT contract address to check balance for")
     address: str | None = Field(
         None,
-        description="The address to check NFT balance for. If not provided, uses the wallet's default address"
+        description="The address to check NFT balance for. If not provided, uses the wallet's default address",
     )
+
 
 def get_balance_nft(
     wallet: Wallet,
@@ -40,17 +39,13 @@ def get_balance_nft(
 
     Returns:
         str: A message containing the NFT balance details.
+
     """
     try:
         check_address = address if address is not None else wallet.default_address.address_id
-        
+
         owned_tokens = SmartContract.read(
-            wallet.network_id,
-            contract_address,
-            "tokensOfOwner",
-            args={
-                "owner": check_address
-            }
+            wallet.network_id, contract_address, "tokensOfOwner", args={"owner": check_address}
         )
 
         if not owned_tokens:
@@ -61,6 +56,7 @@ def get_balance_nft(
 
     except Exception as e:
         return f"Error getting NFT balance for address {check_address} in contract {contract_address}: {e!s}"
+
 
 class GetBalanceNftAction(CdpAction):
     """Get NFT balance action."""

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/get_balance_nft.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/get_balance_nft.py
@@ -1,0 +1,71 @@
+from collections.abc import Callable
+
+from cdp import Wallet
+from cdp.smart_contract import SmartContract
+from pydantic import BaseModel, Field
+
+from cdp_agentkit_core.actions import CdpAction
+
+
+GET_BALANCE_NFT_PROMPT = """
+This tool will get the NFTs (ERC721 tokens) owned by the wallet for a specific NFT contract.
+
+It takes the following inputs:
+- contract_address: The NFT contract address to check
+- address: (Optional) The address to check NFT balance for. If not provided, uses the wallet's default address
+"""
+
+class GetBalanceNftInput(BaseModel):
+    """Input argument schema for get NFT balance action."""
+    contract_address: str = Field(
+        ...,
+        description="The NFT contract address to check balance for"
+    )
+    address: str | None = Field(
+        None,
+        description="The address to check NFT balance for. If not provided, uses the wallet's default address"
+    )
+
+def get_balance_nft(
+    wallet: Wallet,
+    contract_address: str,
+    address: str | None = None,
+) -> str:
+    """Get NFT balance for a specific contract.
+
+    Args:
+        wallet (Wallet): The wallet to check balance from.
+        contract_address (str): The NFT contract address.
+        address (str | None): The address to check balance for. Defaults to wallet's default address.
+
+    Returns:
+        str: A message containing the NFT balance details.
+    """
+    try:
+        check_address = address if address is not None else wallet.default_address.address_id
+        
+        owned_tokens = SmartContract.read(
+            wallet.network_id,
+            contract_address,
+            "tokensOfOwner",
+            args={
+                "owner": check_address
+            }
+        )
+
+        if not owned_tokens:
+            return f"Address {check_address} owns no NFTs in contract {contract_address}"
+
+        token_list = ", ".join(str(token_id) for token_id in owned_tokens)
+        return f"Address {check_address} owns {len(owned_tokens)} NFTs in contract {contract_address}.\nToken IDs: {token_list}"
+
+    except Exception as e:
+        return f"Error getting NFT balance for address {check_address} in contract {contract_address}: {e!s}"
+
+class GetBalanceNftAction(CdpAction):
+    """Get NFT balance action."""
+
+    name: str = "get_balance_nft"
+    description: str = GET_BALANCE_NFT_PROMPT
+    args_schema: type[BaseModel] | None = GetBalanceNftInput
+    func: Callable[..., str] = get_balance_nft

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/transfer_nft.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/transfer_nft.py
@@ -1,0 +1,75 @@
+from collections.abc import Callable
+
+from cdp import Wallet
+from pydantic import BaseModel, Field
+
+from cdp_agentkit_core.actions import CdpAction
+
+TRANSFER_NFT_PROMPT = """
+This tool will transfer an NFT (ERC721 token) from the wallet to another onchain address.
+
+It takes the following inputs:
+- contract_address: The NFT contract address
+- token_id: The ID of the specific NFT to transfer
+- destination: Where to send the NFT (can be an onchain address, ENS 'example.eth', or Basename 'example.base.eth')
+
+Important notes:
+- Ensure you have ownership of the NFT before attempting transfer
+- Ensure there is sufficient native token balance for gas fees
+- The wallet must either own the NFT or have approval to transfer it
+"""
+
+class TransferNftInput(BaseModel):
+    """Input argument schema for NFT transfer action."""
+    contract_address: str = Field(
+        ..., 
+        description="The NFT contract address to interact with"
+    )
+    token_id: str = Field(
+        ...,
+        description="The ID of the NFT to transfer"
+    )
+    destination: str = Field(
+        ...,
+        description="The destination to transfer the NFT, e.g. `0x58dBecc0894Ab4C24F98a0e684c989eD07e4e027`, `example.eth`, `example.base.eth`"
+    )
+
+def transfer_nft(
+    wallet: Wallet, 
+    contract_address: str, 
+    token_id: str, 
+    destination: str
+) -> str:
+    """Transfer an NFT (ERC721 token) to a destination address.
+
+    Args:
+        wallet (Wallet): The wallet to transfer the NFT from.
+        contract_address (str): The NFT contract address.
+        token_id (str): The ID of the NFT to transfer.
+        destination (str): The destination to transfer the NFT.
+
+    Returns:
+        str: A message containing the transfer details.
+    """
+    try:
+        transfer_result = wallet.invoke_contract(
+            contract_address=contract_address,
+            method="transferFrom",
+            args={
+                "from": wallet.default_address.address_id,
+                "to": destination,
+                "tokenId": token_id
+            }
+        ).wait()
+    except Exception as e:
+        return f"Error transferring the NFT (contract: {contract_address}, ID: {token_id}) from {wallet.default_address.address_id} to {destination}): {e!s}"
+
+    return f"Transferred NFT (ID: {token_id}) from contract {contract_address} to {destination}.\nTransaction hash: {transfer_result.transaction_hash}\nTransaction link: {transfer_result.transaction_link}"
+
+class TransferNftAction(CdpAction):
+    """Transfer NFT action."""
+
+    name: str = "transfer_nft"
+    description: str = TRANSFER_NFT_PROMPT
+    args_schema: type[BaseModel] | None = TransferNftInput
+    func: Callable[..., str] = transfer_nft

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/transfer_nft.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/transfer_nft.py
@@ -19,31 +19,28 @@ Important notes:
 - The wallet must either own the NFT or have approval to transfer it
 """
 
+
 class TransferNftInput(BaseModel):
     """Input argument schema for NFT transfer action."""
-    contract_address: str = Field(
-        ..., 
-        description="The NFT contract address to interact with"
-    )
-    token_id: str = Field(
-        ...,
-        description="The ID of the NFT to transfer"
-    )
+
+    contract_address: str = Field(..., description="The NFT contract address to interact with")
+    token_id: str = Field(..., description="The ID of the NFT to transfer")
     destination: str = Field(
         ...,
-        description="The destination to transfer the NFT, e.g. `0x58dBecc0894Ab4C24F98a0e684c989eD07e4e027`, `example.eth`, `example.base.eth`"
+        description="The destination to transfer the NFT, e.g. `0x58dBecc0894Ab4C24F98a0e684c989eD07e4e027`, `example.eth`, `example.base.eth`",
     )
     from_address: str = Field(
         default=None,
-        description="The address to transfer from. If not provided, defaults to the wallet's default address"
+        description="The address to transfer from. If not provided, defaults to the wallet's default address",
     )
 
+
 def transfer_nft(
-    wallet: Wallet, 
-    contract_address: str, 
-    token_id: str, 
+    wallet: Wallet,
+    contract_address: str,
+    token_id: str,
     destination: str,
-    from_address: str | None = None
+    from_address: str | None = None,
 ) -> str:
     """Transfer an NFT (ERC721 token) to a destination address.
 
@@ -56,22 +53,20 @@ def transfer_nft(
 
     Returns:
         str: A message containing the transfer details.
+
     """
     try:
         from_addr = from_address if from_address is not None else wallet.default_address.address_id
         transfer_result = wallet.invoke_contract(
             contract_address=contract_address,
             method="transferFrom",
-            args={
-                "from": from_addr,
-                "to": destination,
-                "tokenId": token_id
-            }
+            args={"from": from_addr, "to": destination, "tokenId": token_id},
         ).wait()
     except Exception as e:
         return f"Error transferring the NFT (contract: {contract_address}, ID: {token_id}) from {from_addr} to {destination}): {e!s}"
 
     return f"Transferred NFT (ID: {token_id}) from contract {contract_address} to {destination}.\nTransaction hash: {transfer_result.transaction_hash}\nTransaction link: {transfer_result.transaction_link}"
+
 
 class TransferNftAction(CdpAction):
     """Transfer NFT action."""

--- a/cdp-agentkit-core/python/tests/actions/test_get_balance_nft.py
+++ b/cdp-agentkit-core/python/tests/actions/test_get_balance_nft.py
@@ -67,7 +67,9 @@ def test_get_balance_nft_no_tokens(wallet_factory):
             MOCK_CONTRACT_ADDRESS,
         )
 
-        expected_response = f"Address {MOCK_ADDRESS} owns no NFTs in contract {MOCK_CONTRACT_ADDRESS}"
+        expected_response = (
+            f"Address {MOCK_ADDRESS} owns no NFTs in contract {MOCK_CONTRACT_ADDRESS}"
+        )
         assert action_response == expected_response
 
 

--- a/cdp-agentkit-core/python/tests/actions/test_get_balance_nft.py
+++ b/cdp-agentkit-core/python/tests/actions/test_get_balance_nft.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+import pytest
+
+from cdp_agentkit_core.actions.get_balance_nft import (
+    GetBalanceNftInput,
+    get_balance_nft,
+)
+
+MOCK_CONTRACT_ADDRESS = "0xvalidContractAddress"
+MOCK_ADDRESS = "0xvalidAddress"
+MOCK_TOKEN_IDS = [1, 2, 3]
+
+
+def test_get_balance_nft_input_model_valid():
+    """Test that GetBalanceNftInput accepts valid parameters."""
+    input_model = GetBalanceNftInput(
+        contract_address=MOCK_CONTRACT_ADDRESS,
+        address=MOCK_ADDRESS,
+    )
+
+    assert input_model.contract_address == MOCK_CONTRACT_ADDRESS
+    assert input_model.address == MOCK_ADDRESS
+
+
+def test_get_balance_nft_input_model_missing_optional():
+    """Test that GetBalanceNftInput works with only required parameters."""
+    input_model = GetBalanceNftInput(
+        contract_address=MOCK_CONTRACT_ADDRESS,
+    )
+
+    assert input_model.contract_address == MOCK_CONTRACT_ADDRESS
+    assert input_model.address is None
+
+
+def test_get_balance_nft_input_model_missing_required():
+    """Test that GetBalanceNftInput raises error when required params are missing."""
+    with pytest.raises(ValueError):
+        GetBalanceNftInput()
+
+
+def test_get_balance_nft_success(wallet_factory):
+    """Test successful NFT balance check."""
+    mock_wallet = wallet_factory()
+    mock_wallet.network_id = "base-sepolia"
+    mock_wallet.default_address.address_id = MOCK_ADDRESS
+
+    with patch("cdp.smart_contract.SmartContract.read", return_value=MOCK_TOKEN_IDS):
+        action_response = get_balance_nft(
+            mock_wallet,
+            MOCK_CONTRACT_ADDRESS,
+        )
+
+        expected_response = f"Address {MOCK_ADDRESS} owns {len(MOCK_TOKEN_IDS)} NFTs in contract {MOCK_CONTRACT_ADDRESS}.\nToken IDs: 1, 2, 3"
+        assert action_response == expected_response
+
+
+def test_get_balance_nft_no_tokens(wallet_factory):
+    """Test NFT balance check when no tokens are owned."""
+    mock_wallet = wallet_factory()
+    mock_wallet.network_id = "base-sepolia"
+    mock_wallet.default_address.address_id = MOCK_ADDRESS
+
+    with patch("cdp.smart_contract.SmartContract.read", return_value=[]):
+        action_response = get_balance_nft(
+            mock_wallet,
+            MOCK_CONTRACT_ADDRESS,
+        )
+
+        expected_response = f"Address {MOCK_ADDRESS} owns no NFTs in contract {MOCK_CONTRACT_ADDRESS}"
+        assert action_response == expected_response
+
+
+def test_get_balance_nft_with_address(wallet_factory):
+    """Test NFT balance check with specific address."""
+    mock_wallet = wallet_factory()
+    mock_wallet.network_id = "base-sepolia"
+    custom_address = "0xcustomAddress"
+
+    with patch("cdp.smart_contract.SmartContract.read", return_value=MOCK_TOKEN_IDS):
+        action_response = get_balance_nft(
+            mock_wallet,
+            MOCK_CONTRACT_ADDRESS,
+            custom_address,
+        )
+
+        expected_response = f"Address {custom_address} owns {len(MOCK_TOKEN_IDS)} NFTs in contract {MOCK_CONTRACT_ADDRESS}.\nToken IDs: 1, 2, 3"
+        assert action_response == expected_response
+
+
+def test_get_balance_nft_api_error(wallet_factory):
+    """Test NFT balance check when API error occurs."""
+    mock_wallet = wallet_factory()
+    mock_wallet.network_id = "base-sepolia"
+    mock_wallet.default_address.address_id = MOCK_ADDRESS
+
+    with patch("cdp.smart_contract.SmartContract.read", side_effect=Exception("API error")):
+        action_response = get_balance_nft(
+            mock_wallet,
+            MOCK_CONTRACT_ADDRESS,
+        )
+
+        expected_response = f"Error getting NFT balance for address {MOCK_ADDRESS} in contract {MOCK_CONTRACT_ADDRESS}: API error"
+        assert action_response == expected_response

--- a/cdp-agentkit-core/python/tests/actions/test_transfer_nft.py
+++ b/cdp-agentkit-core/python/tests/actions/test_transfer_nft.py
@@ -1,0 +1,101 @@
+from unittest.mock import patch
+
+import pytest
+
+from cdp_agentkit_core.actions.transfer_nft import (
+    TransferNftInput,
+    transfer_nft,
+)
+
+MOCK_CONTRACT_ADDRESS = "0xvalidContractAddress"
+MOCK_DESTINATION = "0xvalidAddress"
+MOCK_TOKEN_ID = "1000"
+
+
+def test_transfer_nft_input_model_valid():
+    """Test that TransferNftInput accepts valid parameters."""
+    input_model = TransferNftInput(
+        contract_address=MOCK_CONTRACT_ADDRESS,
+        token_id=MOCK_TOKEN_ID,
+        destination=MOCK_DESTINATION,
+    )
+
+    assert input_model.contract_address == MOCK_CONTRACT_ADDRESS
+    assert input_model.token_id == MOCK_TOKEN_ID
+    assert input_model.destination == MOCK_DESTINATION
+
+
+def test_transfer_nft_input_model_missing_params():
+    """Test that TransferNftInput raises error when params are missing."""
+    with pytest.raises(ValueError):
+        TransferNftInput()
+
+
+def test_transfer_nft_success(wallet_factory, contract_invocation_factory):
+    """Test successful NFT transfer with valid parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_invocation = contract_invocation_factory()
+    
+    # Set the mock wallet address
+    mock_wallet.address = "0xdefaultAddress"
+    
+    # Set the mock transaction properties
+    mock_contract_invocation.transaction_hash = "0xvalidTransactionHash"
+    mock_contract_invocation.transaction_link = "https://basescan.org/tx/0xvalidTransactionHash"
+
+    with (
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_invocation
+        ) as mock_invoke_contract,
+        patch.object(
+            mock_contract_invocation, "wait", return_value=mock_contract_invocation
+        ) as mock_contract_invocation_wait,
+    ):
+        action_response = transfer_nft(
+            mock_wallet, 
+            MOCK_CONTRACT_ADDRESS, 
+            MOCK_TOKEN_ID, 
+            MOCK_DESTINATION
+        )
+
+        expected_response = f"Transferred NFT (ID: {MOCK_TOKEN_ID}) from contract {MOCK_CONTRACT_ADDRESS} to {MOCK_DESTINATION}.\nTransaction hash: {mock_contract_invocation.transaction_hash}\nTransaction link: {mock_contract_invocation.transaction_link}"
+        assert action_response == expected_response
+        mock_invoke_contract.assert_called_once_with(
+            contract_address=MOCK_CONTRACT_ADDRESS,
+            method="transferFrom",
+            args={
+                "from": mock_wallet.address,
+                "to": MOCK_DESTINATION,
+                "tokenId": MOCK_TOKEN_ID,
+            },
+        )
+        mock_contract_invocation_wait.assert_called_once_with()
+
+
+def test_transfer_nft_api_error(wallet_factory):
+    """Test NFT transfer when API error occurs."""
+    mock_wallet = wallet_factory()
+    mock_wallet.address = "0xdefaultAddress"  # Set the wallet address
+
+    with patch.object(
+        mock_wallet, "invoke_contract", side_effect=Exception("API error")
+    ) as mock_invoke_contract:
+        action_response = transfer_nft(
+            mock_wallet, 
+            MOCK_CONTRACT_ADDRESS, 
+            MOCK_TOKEN_ID, 
+            MOCK_DESTINATION
+        )
+
+        expected_response = f"Error transferring the NFT (contract: {MOCK_CONTRACT_ADDRESS}, ID: {MOCK_TOKEN_ID}) from {mock_wallet.address} to {MOCK_DESTINATION}): API error"
+
+        assert action_response == expected_response
+        mock_invoke_contract.assert_called_once_with(
+            contract_address=MOCK_CONTRACT_ADDRESS,
+            method="transferFrom",
+            args={
+                "from": mock_wallet.address,
+                "to": MOCK_DESTINATION,
+                "tokenId": MOCK_TOKEN_ID,
+            },
+        ) 

--- a/cdp-agentkit-core/python/tests/actions/test_transfer_nft.py
+++ b/cdp-agentkit-core/python/tests/actions/test_transfer_nft.py
@@ -35,10 +35,10 @@ def test_transfer_nft_success(wallet_factory, contract_invocation_factory):
     """Test successful NFT transfer with valid parameters."""
     mock_wallet = wallet_factory()
     mock_contract_invocation = contract_invocation_factory()
-    
+
     # Set the mock wallet address
     mock_wallet.address = "0xdefaultAddress"
-    
+
     # Set the mock transaction properties
     mock_contract_invocation.transaction_hash = "0xvalidTransactionHash"
     mock_contract_invocation.transaction_link = "https://basescan.org/tx/0xvalidTransactionHash"
@@ -52,10 +52,7 @@ def test_transfer_nft_success(wallet_factory, contract_invocation_factory):
         ) as mock_contract_invocation_wait,
     ):
         action_response = transfer_nft(
-            mock_wallet, 
-            MOCK_CONTRACT_ADDRESS, 
-            MOCK_TOKEN_ID, 
-            MOCK_DESTINATION
+            mock_wallet, MOCK_CONTRACT_ADDRESS, MOCK_TOKEN_ID, MOCK_DESTINATION
         )
 
         expected_response = f"Transferred NFT (ID: {MOCK_TOKEN_ID}) from contract {MOCK_CONTRACT_ADDRESS} to {MOCK_DESTINATION}.\nTransaction hash: {mock_contract_invocation.transaction_hash}\nTransaction link: {mock_contract_invocation.transaction_link}"
@@ -81,10 +78,7 @@ def test_transfer_nft_api_error(wallet_factory):
         mock_wallet, "invoke_contract", side_effect=Exception("API error")
     ) as mock_invoke_contract:
         action_response = transfer_nft(
-            mock_wallet, 
-            MOCK_CONTRACT_ADDRESS, 
-            MOCK_TOKEN_ID, 
-            MOCK_DESTINATION
+            mock_wallet, MOCK_CONTRACT_ADDRESS, MOCK_TOKEN_ID, MOCK_DESTINATION
         )
 
         expected_response = f"Error transferring the NFT (contract: {MOCK_CONTRACT_ADDRESS}, ID: {MOCK_TOKEN_ID}) from {mock_wallet.address} to {MOCK_DESTINATION}): API error"
@@ -98,4 +92,4 @@ def test_transfer_nft_api_error(wallet_factory):
                 "to": MOCK_DESTINATION,
                 "tokenId": MOCK_TOKEN_ID,
             },
-        ) 
+        )

--- a/cdp-langchain/python/cdp_langchain/agent_toolkits/cdp_toolkit.py
+++ b/cdp-langchain/python/cdp_langchain/agent_toolkits/cdp_toolkit.py
@@ -53,6 +53,7 @@ class CdpToolkit(BaseToolkit):
 
             get_wallet_details
             get_balance
+            get_balance_nft
             request_faucet_funds
             transfer
             transfer_nft

--- a/cdp-langchain/python/cdp_langchain/agent_toolkits/cdp_toolkit.py
+++ b/cdp-langchain/python/cdp_langchain/agent_toolkits/cdp_toolkit.py
@@ -55,6 +55,7 @@ class CdpToolkit(BaseToolkit):
             get_balance
             request_faucet_funds
             transfer
+            transfer_nft
             trade
             deploy_token
             mint_nft


### PR DESCRIPTION
### What changed? Why?

Added two new actions for NFT (ERC721) support:

- TransferNftAction: Transfer NFTs between addresses

- GetBalanceNftAction: Check NFT ownership and balances

These actions enable agents to handle NFT operations similar to existing ERC20 functionality.
