### PR TITLE
chore: Fix Generated Python Docs Path

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -68,7 +68,7 @@ jobs:
           poetry run make docs
           cd docs
           poetry run make html
-          cd ../..
+          cd ../../..
           mkdir -p docs/cdp-agentkit-core/python
           cp -r cdp-agentkit-core/python/docs/_build/html/* docs/cdp-agentkit-core/python
 
@@ -92,7 +92,7 @@ jobs:
           poetry run make docs
           cd docs
           poetry run make html
-          cd ../..
+          cd ../../..
           mkdir -p docs/cdp-langchain/python
           cp -r cdp-langchain/python/docs/_build/html/* docs/cdp-langchain/python
 
@@ -116,7 +116,7 @@ jobs:
           poetry run make docs
           cd docs
           poetry run make html
-          cd ../..
+          cd ../../..
           mkdir -p docs/twitter-langchain/python
           cp -r twitter-langchain/python/docs/_build/html/* docs/twitter-langchain/python
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 ## Documentation
 
 - [CDP Agentkit Documentation](https://docs.cdp.coinbase.com/agentkit/docs/welcome)
-- [API Reference: CDP Agentkit Core Python](https://coinbase.github.io/cdp-agentkit/cdp-agentkit-core/python/index.html)
-- [API Reference: CDP Agentkit LangChain Extension Python](https://coinbase.github.io/cdp-agentkit/cdp-langchain/python/index.html)
-- [API Reference: CDP Agentkit Core Node.js](https://coinbase.github.io/cdp-agentkit/cdp-agentkit-core/typescript/index.html)
-- [API Reference: CDP Agentkit LangChain Extension Node.js](https://coinbase.github.io/cdp-agentkit/cdp-langchain/typescript/index.html)
+- [API Reference: CDP Agentkit Core Python](https://coinbase.github.io/agentkit/cdp-agentkit-core/python/index.html)
+- [API Reference: CDP Agentkit LangChain Extension Python](https://coinbase.github.io/agentkit/cdp-langchain/python/index.html)
+- [API Reference: CDP Agentkit Core Node.js](https://coinbase.github.io/agentkit/cdp-agentkit-core/typescript/index.html)
+- [API Reference: CDP Agentkit LangChain Extension Node.js](https://coinbase.github.io/agentkit/cdp-langchain/typescript/index.html)
 
 ## Security and bug reports
 

--- a/cdp-agentkit-core/python/docs/index.rst
+++ b/cdp-agentkit-core/python/docs/index.rst
@@ -1,7 +1,7 @@
 CDP Agentkit - Core Documentation
 =================================
 
-.. include:: README.md
+.. include:: ../README.md
    :parser: myst_parser.sphinx_
 
 .. toctree::

--- a/cdp-langchain/python/docs/index.rst
+++ b/cdp-langchain/python/docs/index.rst
@@ -1,7 +1,7 @@
 CDP Agentkit - LangChain Documentation
 ======================================
 
-.. include:: README.md
+.. include:: ../README.md
    :parser: myst_parser.sphinx_
 
 .. toctree::

--- a/twitter-langchain/python/docs/index.rst
+++ b/twitter-langchain/python/docs/index.rst
@@ -1,7 +1,7 @@
 CDP Agentkit - Twitter LangChain Documentation
 ==============================================
 
-.. include:: README.md
+.. include:: ../README.md
    :parser: myst_parser.sphinx_
 
 .. toctree::


### PR DESCRIPTION
### What changed? Why?
- Fix GH Pages generated Python docs path

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
