### PR TITLE
feat(morpho-markets): supply & withdraw collat + borrow and repay morpho actions

### DIFF
--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py
@@ -4,8 +4,12 @@ from cdp_agentkit_core.actions.deploy_token import DeployTokenAction
 from cdp_agentkit_core.actions.get_balance import GetBalanceAction
 from cdp_agentkit_core.actions.get_wallet_details import GetWalletDetailsAction
 from cdp_agentkit_core.actions.mint_nft import MintNftAction
+from cdp_agentkit_core.actions.morpho.borrow import MorphoBorrowAction
 from cdp_agentkit_core.actions.morpho.deposit import MorphoDepositAction
+from cdp_agentkit_core.actions.morpho.repay import MorphoRepayAction
+from cdp_agentkit_core.actions.morpho.supply_collateral import MorphoSupplyCollateralAction
 from cdp_agentkit_core.actions.morpho.withdraw import MorphoWithdrawAction
+from cdp_agentkit_core.actions.morpho.withdraw_collateral import MorphoWithdrawCollateralAction
 from cdp_agentkit_core.actions.register_basename import RegisterBasenameAction
 from cdp_agentkit_core.actions.request_faucet_funds import RequestFaucetFundsAction
 from cdp_agentkit_core.actions.trade import TradeAction
@@ -46,4 +50,8 @@ __all__ = [
     "WrapEthAction",
     "MorphoDepositAction",
     "MorphoWithdrawAction",
+    "MorphoWithdrawCollateralAction",
+    "MorphoSupplyCollateralAction",
+    "MorphoBorrowAction",
+    "MorphoRepayAction",
 ]

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/borrow.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/borrow.py
@@ -1,0 +1,106 @@
+from collections.abc import Callable
+from decimal import Decimal
+
+from cdp import Asset, Wallet
+from pydantic import BaseModel
+
+from cdp_agentkit_core.actions import CdpAction
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+from cdp_agentkit_core.actions.morpho.utils import approve
+
+
+class MorphoBorrowInput(BaseModel):
+    """Input schema for Morpho Markets borrow action."""
+
+    market_params: dict
+    assets: str
+    shares: str
+    on_behalf: str
+    receiver: str
+
+
+BORROW_PROMPT = """
+This tool allows borrowing assets from a Morpho market. It takes:
+
+- market_params: The market parameters including:
+  - loanToken: The address of the loan token
+  - collateralToken: The address of the collateral token
+  - oracle: The address of the oracle
+  - irm: The address of the interest rate model
+  - lltv: The liquidation LTV (loan-to-value ratio)
+- assets: The amount of assets to borrow in whole units
+  Examples for WETH:
+  - 1 WETH
+  - 0.1 WETH
+  - 0.01 WETH
+- shares: The amount of shares to borrow (use "0" to borrow using assets amount)
+- on_behalf: The address to borrow on behalf of
+- receiver: The address to receive the borrowed assets
+"""
+
+
+def borrow_from_morpho(
+    wallet: Wallet,
+    market_params: dict,
+    assets: str,
+    shares: str,
+    on_behalf: str,
+    receiver: str,
+) -> str:
+    """Borrow assets from a Morpho market.
+
+    Args:
+        wallet (Wallet): The wallet to execute the borrow from
+        market_params (dict): The market parameters
+        assets (str): The amount of assets to borrow in whole units (e.g., 0.01 WETH)
+        shares (str): The amount of shares to borrow
+        on_behalf (str): The address to borrow on behalf of
+        receiver (str): The address to receive the borrowed assets
+
+    Returns:
+        str: A success message with transaction hash or error message
+    """
+
+    if (assets == "0" and shares == "0") or (assets != "0" and shares != "0"):
+        return "Error: Exactly one of 'assets' or 'shares' must be zero, the other number has to be positive"
+
+    try:
+        # TODO We are going to need to verify that a collateral position has been provided.
+
+        token_asset = Asset.fetch(wallet.network_id, market_params["loanToken"])
+        # Validate that exactly one of assets or shares is zero
+
+        atomic_assets = (
+            str(int(token_asset.to_atomic_amount(Decimal(assets)))) if assets != "0" else "0"
+        )
+        atomic_shares = (
+            str(int(token_asset.to_atomic_amount(Decimal(shares)))) if shares != "0" else "0"
+        )
+        borrow_args = {
+            "marketParams": market_params,
+            "assets": atomic_assets,
+            "shares": atomic_shares,
+            "onBehalf": on_behalf,
+            "receiver": receiver,
+        }
+
+        invocation = wallet.invoke_contract(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="borrow",
+            abi=BLUE_ABI,
+            args=borrow_args,
+        ).wait()
+
+        return f"Borrowed {assets} from Morpho market with transaction hash: {invocation.transaction_hash} and transaction link: {invocation.transaction_link}"
+
+    except Exception as e:
+        return f"Error borrowing from Morpho Blue: {e!s}"
+
+
+class MorphoBorrowAction(CdpAction):
+    """Morpho Blue borrow action."""
+
+    name: str = "morpho_borrow"
+    description: str = BORROW_PROMPT
+    args_schema: type[BaseModel] = MorphoBorrowInput
+    func: Callable[..., str] = borrow_from_morpho

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/constants.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/constants.py
@@ -38,3 +38,107 @@ METAMORPHO_ABI = [
         "type": "function",
     },
 ]
+
+
+BLUE_ABI = [
+    {
+        "inputs": [
+            {
+                "name": "marketParams",
+                "type": "tuple",
+                "internalType": "struct MarketParams",
+                "components": [
+                    {"name": "loanToken", "type": "address", "internalType": "address"},
+                    {"name": "collateralToken", "type": "address", "internalType": "address"},
+                    {"name": "oracle", "type": "address", "internalType": "address"},
+                    {"name": "irm", "type": "address", "internalType": "address"},
+                    {"name": "lltv", "type": "uint256", "internalType": "uint256"},
+                ],
+            },
+            {"name": "assets", "type": "uint256", "internalType": "uint256"},
+            {"name": "shares", "type": "uint256", "internalType": "uint256"},
+            {"name": "onBehalf", "type": "address", "internalType": "address"},
+            {"name": "receiver", "type": "address", "internalType": "address"},
+        ],
+        "name": "borrow",
+        "outputs": [
+            {"name": "", "type": "uint256", "internalType": "uint256"},
+            {"name": "", "type": "uint256", "internalType": "uint256"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "name": "marketParams",
+                "type": "tuple",
+                "internalType": "struct MarketParams",
+                "components": [
+                    {"name": "loanToken", "type": "address", "internalType": "address"},
+                    {"name": "collateralToken", "type": "address", "internalType": "address"},
+                    {"name": "oracle", "type": "address", "internalType": "address"},
+                    {"name": "irm", "type": "address", "internalType": "address"},
+                    {"name": "lltv", "type": "uint256", "internalType": "uint256"},
+                ],
+            },
+            {"name": "assets", "type": "uint256", "internalType": "uint256"},
+            {"name": "shares", "type": "uint256", "internalType": "uint256"},
+            {"name": "onBehalf", "type": "address", "internalType": "address"},
+            {"name": "data", "type": "bytes", "internalType": "bytes"},
+        ],
+        "name": "repay",
+        "outputs": [
+            {"name": "", "type": "uint256", "internalType": "uint256"},
+            {"name": "", "type": "uint256", "internalType": "uint256"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "name": "marketParams",
+                "type": "tuple",
+                "internalType": "struct MarketParams",
+                "components": [
+                    {"name": "loanToken", "type": "address", "internalType": "address"},
+                    {"name": "collateralToken", "type": "address", "internalType": "address"},
+                    {"name": "oracle", "type": "address", "internalType": "address"},
+                    {"name": "irm", "type": "address", "internalType": "address"},
+                    {"name": "lltv", "type": "uint256", "internalType": "uint256"},
+                ],
+            },
+            {"name": "assets", "type": "uint256", "internalType": "uint256"},
+            {"name": "onBehalf", "type": "address", "internalType": "address"},
+            {"name": "data", "type": "bytes", "internalType": "bytes"},
+        ],
+        "name": "supplyCollateral",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "name": "marketParams",
+                "type": "tuple",
+                "internalType": "struct MarketParams",
+                "components": [
+                    {"name": "loanToken", "type": "address", "internalType": "address"},
+                    {"name": "collateralToken", "type": "address", "internalType": "address"},
+                    {"name": "oracle", "type": "address", "internalType": "address"},
+                    {"name": "irm", "type": "address", "internalType": "address"},
+                    {"name": "lltv", "type": "uint256", "internalType": "uint256"},
+                ],
+            },
+            {"name": "assets", "type": "uint256", "internalType": "uint256"},
+            {"name": "onBehalf", "type": "address", "internalType": "address"},
+            {"name": "receiver", "type": "address", "internalType": "address"},
+        ],
+        "name": "withdrawCollateral",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/repay.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/repay.py
@@ -1,0 +1,107 @@
+from collections.abc import Callable
+from decimal import Decimal
+
+from cdp import Asset, Wallet
+from pydantic import BaseModel
+
+from cdp_agentkit_core.actions import CdpAction
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+from cdp_agentkit_core.actions.morpho.utils import approve
+
+
+class MorphoRepayInput(BaseModel):
+    """Input schema for Morpho Markets repay action."""
+
+    market_params: dict
+    assets: str
+    shares: str
+    on_behalf: str
+
+
+REPAY_PROMPT = """
+This tool allows repaying borrowed assets to a Morpho market. It takes:
+
+- market_params: The market parameters including:
+  - loanToken: The address of the loan token
+  - collateralToken: The address of the collateral token
+  - oracle: The address of the oracle
+  - irm: The address of the interest rate model
+  - lltv: The liquidation LTV (loan-to-value ratio)
+- assets: The amount of assets to repay in whole units
+  Examples for WETH:
+  - 1 WETH
+  - 0.1 WETH
+  - 0.01 WETH
+- shares: The amount of shares to repay (use "0" to repay using assets amount)
+- on_behalf: The address to repay on behalf of
+"""
+
+
+def repay_to_morpho(
+    wallet: Wallet,
+    market_params: dict,
+    assets: str,
+    shares: str,
+    on_behalf: str,
+) -> str:
+    """Repay assets to a Morpho market.
+
+    Args:
+        wallet (Wallet): The wallet to execute the repay from
+        market_params (dict): The market parameters
+        assets (str): The amount of assets to repay in whole units (e.g., 0.01 WETH)
+        shares (str): The amount of shares to repay
+        on_behalf (str): The address to repay on behalf of
+
+    Returns:
+        str: A success message with transaction hash or error message
+    """
+    if (assets == "0" and shares == "0") or (assets != "0" and shares != "0"):
+        return "Error: Exactly one of 'assets' or 'shares' must be zero, the other number has to be positive"
+
+    try:
+        token_asset = Asset.fetch(wallet.network_id, market_params["loanToken"])
+
+        atomic_assets = (
+            str(int(token_asset.to_atomic_amount(Decimal(assets)))) if assets != "0" else "0"
+        )
+        atomic_shares = (
+            str(int(token_asset.to_atomic_amount(Decimal(shares)))) if shares != "0" else "0"
+        )
+
+        # Approve spending of tokens by Morpho if repaying with assets
+        if atomic_assets != "0":
+            approval_response = approve(
+                wallet, market_params["loanToken"], MORPHO_BASE_ADDRESS, atomic_assets
+            )
+            if approval_response.startswith("Error"):  # Check if approval failed
+                return f"Error repaying to Morpho Blue: {approval_response}"
+
+        repay_args = {
+            "marketParams": market_params,
+            "assets": atomic_assets,
+            "shares": atomic_shares,
+            "onBehalf": on_behalf,
+            "data": "0x",  # Empty bytes
+        }
+
+        invocation = wallet.invoke_contract(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="repay",
+            abi=BLUE_ABI,
+            args=repay_args,
+        ).wait()
+
+        return f"Repaid {assets if assets != '0' else shares + ' shares'} to Morpho market with transaction hash: {invocation.transaction_hash} and transaction link: {invocation.transaction_link}"
+
+    except Exception as e:
+        return f"Error repaying to Morpho Blue: {e!s}"
+
+
+class MorphoRepayAction(CdpAction):
+    """Morpho Blue repay action."""
+
+    name: str = "morpho_repay"
+    description: str = REPAY_PROMPT
+    args_schema: type[BaseModel] = MorphoRepayInput
+    func: Callable[..., str] = repay_to_morpho

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/supply_collateral.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/supply_collateral.py
@@ -1,0 +1,98 @@
+from collections.abc import Callable
+from decimal import Decimal
+
+from cdp import Asset, Wallet
+from pydantic import BaseModel
+
+from cdp_agentkit_core.actions import CdpAction
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+from cdp_agentkit_core.actions.morpho.utils import approve
+
+
+class MorphoSupplyCollateralInput(BaseModel):
+    """Input schema for Morpho Markets supply collateral action."""
+
+    market_params: dict
+    assets: str
+    on_behalf: str
+
+
+SUPPLY_COLLATERAL_PROMPT = """
+This tool allows supplying collateral to a Morpho market. It takes:
+
+- market_params: The market parameters including:
+  - loanToken: The address of the loan token
+  - collateralToken: The address of the collateral token
+  - oracle: The address of the oracle
+  - irm: The address of the interest rate model
+  - lltv: The liquidation LTV (loan-to-value ratio)
+- assets: The amount of collateral to supply in whole units
+  Examples for WETH:
+  - 1 WETH
+  - 0.1 WETH
+  - 0.01 WETH
+- on_behalf: The address to supply collateral for
+"""
+
+
+def supply_collateral_to_morpho(
+    wallet: Wallet,
+    market_params: dict,
+    assets: str,
+    on_behalf: str,
+) -> str:
+    """Supply collateral to a Morpho market.
+
+    Args:
+        wallet (Wallet): The wallet to execute the supply from
+        market_params (dict): The market parameters
+        assets (str): The amount of assets to supply in whole units (e.g., 0.01 WETH)
+        on_behalf (str): The address to supply collateral for
+
+    Returns:
+        str: A success message with transaction hash or error message
+    """
+    if float(assets) <= 0:
+        return "Error: Assets amount must be greater than 0"
+
+    if market_params["collateralToken"] == "0x0000000000000000000000000000000000000000":
+        return "Error: Can't supply collateral to 'idle' markets"
+
+    try:
+        token_asset = Asset.fetch(wallet.network_id, market_params["collateralToken"])
+        atomic_assets = str(int(token_asset.to_atomic_amount(Decimal(assets))))
+
+        # Approve Morpho Blue contract to spend tokens
+        approval_result = approve(
+            wallet, market_params["collateralToken"], MORPHO_BASE_ADDRESS, atomic_assets
+        )
+        if approval_result.startswith("Error"):
+            return f"Error approving Morpho Blue as spender: {approval_result}"
+
+        supply_args = {
+            "marketParams": market_params,
+            "assets": atomic_assets,
+            "onBehalf": on_behalf,
+            "data": "0x",  # Empty bytes
+        }
+
+        invocation = wallet.invoke_contract(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="supplyCollateral",
+            abi=BLUE_ABI,
+            args=supply_args,
+        ).wait()
+
+        return f"Supplied {assets} as collateral to Morpho market with transaction hash: {invocation.transaction_hash} and transaction link: {invocation.transaction_link}"
+
+    except Exception as e:
+        return f"Error supplying collateral to Morpho Blue: {e!s}"
+
+
+class MorphoSupplyCollateralAction(CdpAction):
+    """Morpho Blue supply collateral action."""
+
+    name: str = "morpho_supply_collateral"
+    description: str = SUPPLY_COLLATERAL_PROMPT
+    args_schema: type[BaseModel] = MorphoSupplyCollateralInput
+    func: Callable[..., str] = supply_collateral_to_morpho

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/utils.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/utils.py
@@ -33,3 +33,47 @@ def approve(wallet: Wallet, token_address: str, spender: str, amount: int) -> st
 
     except Exception as e:
         return f"Error approving tokens: {e!s}"
+
+
+# Pre-implementing the force approve for tokens like USDT.
+def force_approve(wallet: Wallet, token_address: str, spender: str, amount: int) -> str:
+    """Force approve by first setting allowance to 0 and then to the desired amount.
+
+    Args:
+        wallet (Wallet): The wallet to execute the approval from
+        token_address (str): The address of the token contract
+        spender (str): The address of the spender
+        amount (int): The amount of tokens to approve
+
+    Returns:
+        str: A success message with transaction hash or error message
+
+    """
+    try:
+        # First set approval to 0
+        zero_approval = wallet.invoke_contract(
+            contract_address=token_address,
+            method="approve",
+            abi=ERC20_APPROVE_ABI,
+            args={
+                "spender": spender,
+                "value": "0",
+            },
+        ).wait()
+
+        # Then set to desired amount
+        amount_str = str(amount)
+        final_approval = wallet.invoke_contract(
+            contract_address=token_address,
+            method="approve",
+            abi=ERC20_APPROVE_ABI,
+            args={
+                "spender": spender,
+                "value": amount_str,
+            },
+        ).wait()
+
+        return f"Force approved {amount} tokens for {spender} with transaction hashes: {zero_approval.transaction_hash} (zero approval) and {final_approval.transaction_hash} (final approval) and transaction links: {zero_approval.transaction_link} (zero approval) and {final_approval.transaction_link} (final approval)"
+
+    except Exception as e:
+        return f"Error force approving tokens: {e!s}"

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/withdraw_collateral.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/morpho/withdraw_collateral.py
@@ -1,0 +1,91 @@
+from collections.abc import Callable
+from decimal import Decimal
+
+from cdp import Asset, Wallet
+from pydantic import BaseModel
+
+from cdp_agentkit_core.actions import CdpAction
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+
+
+class MorphoWithdrawCollateralInput(BaseModel):
+    """Input schema for Morpho Markets withdraw collateral action."""
+
+    market_params: dict
+    assets: str
+    on_behalf: str
+    receiver: str
+
+
+WITHDRAW_COLLATERAL_PROMPT = """
+This tool allows withdrawing collateral from a Morpho market. It takes:
+
+- market_params: The market parameters including:
+  - loanToken: The address of the loan token
+  - collateralToken: The address of the collateral token
+  - oracle: The address of the oracle
+  - irm: The address of the interest rate model
+  - lltv: The liquidation LTV (loan-to-value ratio)
+- assets: The amount of collateral to withdraw in whole units
+  Examples for WETH:
+  - 1 WETH
+  - 0.1 WETH
+  - 0.01 WETH
+- on_behalf: The address to withdraw collateral from
+- receiver: The address to receive the withdrawn collateral
+"""
+
+
+def withdraw_collateral_from_morpho(
+    wallet: Wallet,
+    market_params: dict,
+    assets: str,
+    on_behalf: str,
+    receiver: str,
+) -> str:
+    """Withdraw collateral from a Morpho market.
+
+    Args:
+        wallet (Wallet): The wallet to execute the withdrawal from
+        market_params (dict): The market parameters
+        assets (str): The amount of assets to withdraw in whole units (e.g., 0.01 WETH)
+        on_behalf (str): The address to withdraw collateral from
+        receiver (str): The address to receive the withdrawn collateral
+
+    Returns:
+        str: A success message with transaction hash or error message
+    """
+    if float(assets) <= 0:
+        return "Error: Assets amount must be greater than 0"
+
+    try:
+        token_asset = Asset.fetch(wallet.network_id, market_params["collateralToken"])
+        atomic_assets = str(int(token_asset.to_atomic_amount(Decimal(assets))))
+
+        withdraw_args = {
+            "marketParams": market_params,
+            "assets": atomic_assets,
+            "onBehalf": on_behalf,
+            "receiver": receiver,
+        }
+
+        invocation = wallet.invoke_contract(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="withdrawCollateral",
+            abi=BLUE_ABI,
+            args=withdraw_args,
+        ).wait()
+
+        return f"Withdrawn {assets} collateral from Morpho market with transaction hash: {invocation.transaction_hash} and transaction link: {invocation.transaction_link}"
+
+    except Exception as e:
+        return f"Error withdrawing collateral from Morpho Blue: {e!s}"
+
+
+class MorphoWithdrawCollateralAction(CdpAction):
+    """Morpho Blue withdraw collateral action."""
+
+    name: str = "morpho_withdraw_collateral"
+    description: str = WITHDRAW_COLLATERAL_PROMPT
+    args_schema: type[BaseModel] = MorphoWithdrawCollateralInput
+    func: Callable[..., str] = withdraw_collateral_from_morpho

--- a/cdp-agentkit-core/python/tests/actions/morpho/test_borrow.py
+++ b/cdp-agentkit-core/python/tests/actions/morpho/test_borrow.py
@@ -1,0 +1,171 @@
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+from cdp_agentkit_core.actions.morpho.borrow import (
+    MorphoBorrowInput,
+    borrow_from_morpho,
+)
+
+MOCK_NETWORK_ID = "base"
+MOCK_WALLET_ADDRESS = "0x1234567890123456789012345678901234567890"
+MOCK_RECEIVER_ADDRESS = "0x2234567890123456789012345678901234567890"
+MOCK_DECIMALS = 18
+MOCK_ASSETS = "1"
+MOCK_SHARES = "0"
+MOCK_ASSETS_WEI = "1000000000000000000"
+
+# Market parameters for the specific market
+MOCK_MARKET_PARAMS = {
+    "loanToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "collateralToken": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    "oracle": "0x663BECd10daE6C4A3Dcd89F1d76c1174199639B9",
+    "irm": "0x46415998764C29aB2a25CbeA6254146D50D22687",
+    "lltv": "860000000000000000",
+}
+
+
+def test_borrow_input_model_valid():
+    """Test that MorphoBorrowInput accepts valid parameters."""
+    input_model = MorphoBorrowInput(
+        market_params=MOCK_MARKET_PARAMS,
+        assets=MOCK_ASSETS,
+        shares=MOCK_SHARES,
+        on_behalf=MOCK_WALLET_ADDRESS,
+        receiver=MOCK_RECEIVER_ADDRESS,
+    )
+
+    assert input_model.market_params == MOCK_MARKET_PARAMS
+    assert input_model.assets == MOCK_ASSETS
+    assert input_model.shares == MOCK_SHARES
+    assert input_model.on_behalf == MOCK_WALLET_ADDRESS
+    assert input_model.receiver == MOCK_RECEIVER_ADDRESS
+
+
+def test_borrow_input_model_missing_params():
+    """Test that MorphoBorrowInput raises error when params are missing."""
+    with pytest.raises(ValueError):
+        MorphoBorrowInput()
+
+
+def test_borrow_success(wallet_factory, contract_invocation_factory, asset_factory):
+    """Test successful borrow with valid parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_instance = contract_invocation_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.borrow.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_instance
+        ) as mock_invoke,
+        patch.object(
+            mock_contract_instance, "wait", return_value=mock_contract_instance
+        ) as mock_contract_wait,
+    ):
+        action_response = borrow_from_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_SHARES,
+            MOCK_WALLET_ADDRESS,
+            MOCK_RECEIVER_ADDRESS,
+        )
+
+        expected_response = f"Borrowed {MOCK_ASSETS} from Morpho market with transaction hash: {mock_contract_instance.transaction_hash} and transaction link: {mock_contract_instance.transaction_link}"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["loanToken"])
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+        mock_invoke.assert_called_once_with(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="borrow",
+            abi=BLUE_ABI,
+            args={
+                "marketParams": MOCK_MARKET_PARAMS,
+                "assets": MOCK_ASSETS_WEI,
+                "shares": "0",
+                "onBehalf": MOCK_WALLET_ADDRESS,
+                "receiver": MOCK_RECEIVER_ADDRESS,
+            },
+        )
+        mock_contract_wait.assert_called_once_with()
+
+
+def test_borrow_api_error(wallet_factory, asset_factory):
+    """Test borrow when API error occurs."""
+    mock_wallet = wallet_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.borrow.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(mock_wallet, "invoke_contract", side_effect=Exception("API error")),
+    ):
+        action_response = borrow_from_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_SHARES,
+            MOCK_WALLET_ADDRESS,
+            MOCK_RECEIVER_ADDRESS,
+        )
+
+        expected_response = "Error borrowing from Morpho Blue: API error"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["loanToken"])
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+
+def test_borrow_invalid_assets_shares(wallet_factory):
+    """Test borrow with invalid assets and shares combinations."""
+    mock_wallet = wallet_factory()
+
+    # Test when both assets and shares are zero
+    response = borrow_from_morpho(
+        mock_wallet,
+        MOCK_MARKET_PARAMS,
+        "0",
+        "0",
+        MOCK_WALLET_ADDRESS,
+        MOCK_RECEIVER_ADDRESS,
+    )
+    assert (
+        response
+        == "Error: Exactly one of 'assets' or 'shares' must be zero, the other number has to be positive"
+    )
+
+    # Test when both assets and shares are non-zero
+    response = borrow_from_morpho(
+        mock_wallet,
+        MOCK_MARKET_PARAMS,
+        "1",
+        "1",
+        MOCK_WALLET_ADDRESS,
+        MOCK_RECEIVER_ADDRESS,
+    )
+    assert (
+        response
+        == "Error: Exactly one of 'assets' or 'shares' must be zero, the other number has to be positive"
+    )

--- a/cdp-agentkit-core/python/tests/actions/morpho/test_repay.py
+++ b/cdp-agentkit-core/python/tests/actions/morpho/test_repay.py
@@ -1,0 +1,345 @@
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+from cdp_agentkit_core.actions.morpho.repay import (
+    MorphoRepayInput,
+    repay_to_morpho,
+)
+
+MOCK_NETWORK_ID = "base"
+MOCK_WALLET_ADDRESS = "0x1234567890123456789012345678901234567890"
+MOCK_DECIMALS = 18
+MOCK_ASSETS = "1"
+MOCK_SHARES = "0"
+MOCK_ASSETS_WEI = "1000000000000000000"
+
+# Market parameters for the specific market
+MOCK_MARKET_PARAMS = {
+    "loanToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "collateralToken": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    "oracle": "0x663BECd10daE6C4A3Dcd89F1d76c1174199639B9",
+    "irm": "0x46415998764C29aB2a25CbeA6254146D50D22687",
+    "lltv": "860000000000000000",
+}
+
+
+def test_repay_input_model_valid():
+    """Test that MorphoRepayInput accepts valid parameters."""
+    input_model = MorphoRepayInput(
+        market_params=MOCK_MARKET_PARAMS,
+        assets=MOCK_ASSETS,
+        shares=MOCK_SHARES,
+        on_behalf=MOCK_WALLET_ADDRESS,
+    )
+
+    assert input_model.market_params == MOCK_MARKET_PARAMS
+    assert input_model.assets == MOCK_ASSETS
+    assert input_model.shares == MOCK_SHARES
+    assert input_model.on_behalf == MOCK_WALLET_ADDRESS
+
+
+def test_repay_input_model_missing_params():
+    """Test that MorphoRepayInput raises error when params are missing."""
+    with pytest.raises(ValueError):
+        MorphoRepayInput()
+
+
+def test_repay_success(wallet_factory, contract_invocation_factory, asset_factory):
+    """Test successful repay with valid parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_instance = contract_invocation_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.approve",
+            return_value="Approval successful",
+        ) as mock_approve,
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_instance
+        ) as mock_invoke,
+        patch.object(
+            mock_contract_instance, "wait", return_value=mock_contract_instance
+        ) as mock_contract_wait,
+    ):
+        action_response = repay_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_SHARES,
+            MOCK_WALLET_ADDRESS,
+        )
+
+        expected_response = f"Repaid {MOCK_ASSETS} to Morpho market with transaction hash: {mock_contract_instance.transaction_hash} and transaction link: {mock_contract_instance.transaction_link}"
+        assert action_response == expected_response
+
+        mock_approve.assert_called_once_with(
+            mock_wallet,
+            MOCK_MARKET_PARAMS["loanToken"],
+            MORPHO_BASE_ADDRESS,
+            MOCK_ASSETS_WEI,
+        )
+
+        mock_get_asset.assert_called_once_with(MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["loanToken"])
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+        mock_invoke.assert_called_once_with(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="repay",
+            abi=BLUE_ABI,
+            args={
+                "marketParams": MOCK_MARKET_PARAMS,
+                "assets": MOCK_ASSETS_WEI,
+                "shares": "0",
+                "onBehalf": MOCK_WALLET_ADDRESS,
+                "data": "0x",
+            },
+        )
+        mock_contract_wait.assert_called_once_with()
+
+
+def test_repay_api_error(wallet_factory, asset_factory):
+    """Test repay when API error occurs."""
+    mock_wallet = wallet_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.approve",
+            return_value="Approval successful",
+        ),
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(mock_wallet, "invoke_contract", side_effect=Exception("API error")),
+    ):
+        action_response = repay_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_SHARES,
+            MOCK_WALLET_ADDRESS,
+        )
+
+        expected_response = "Error repaying to Morpho Blue: API error"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["loanToken"])
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+
+def test_repay_approval_failure(wallet_factory, asset_factory):
+    """Test repay when approval fails."""
+    mock_wallet = wallet_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.approve",
+            return_value="Error: Approval failed",
+        ) as mock_approve,
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+    ):
+        action_response = repay_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_SHARES,
+            MOCK_WALLET_ADDRESS,
+        )
+
+        expected_response = "Error repaying to Morpho Blue: Error: Approval failed"
+        assert action_response == expected_response
+
+        mock_approve.assert_called_once_with(
+            mock_wallet,
+            MOCK_MARKET_PARAMS["loanToken"],
+            MORPHO_BASE_ADDRESS,
+            MOCK_ASSETS_WEI,
+        )
+
+        mock_get_asset.assert_called_once_with(MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["loanToken"])
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+
+def test_repay_invalid_assets_shares(wallet_factory):
+    """Test repay with invalid assets and shares combinations."""
+    mock_wallet = wallet_factory()
+
+    # Test when both assets and shares are zero
+    response = repay_to_morpho(
+        mock_wallet,
+        MOCK_MARKET_PARAMS,
+        "0",
+        "0",
+        MOCK_WALLET_ADDRESS,
+    )
+    assert (
+        response
+        == "Error: Exactly one of 'assets' or 'shares' must be zero, the other number has to be positive"
+    )
+
+    # Test when both assets and shares are non-zero
+    response = repay_to_morpho(
+        mock_wallet,
+        MOCK_MARKET_PARAMS,
+        "1",
+        "1",
+        MOCK_WALLET_ADDRESS,
+    )
+    assert (
+        response
+        == "Error: Exactly one of 'assets' or 'shares' must be zero, the other number has to be positive"
+    )
+
+
+def test_repay_success_with_assets(wallet_factory, contract_invocation_factory, asset_factory):
+    """Test successful repay with valid asset parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_instance = contract_invocation_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.approve",
+            return_value="Approval successful",
+        ) as mock_approve,
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_instance
+        ) as mock_invoke,
+        patch.object(
+            mock_contract_instance, "wait", return_value=mock_contract_instance
+        ) as mock_contract_wait,
+    ):
+        action_response = repay_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            "0",
+            MOCK_WALLET_ADDRESS,
+        )
+
+        mock_approve.assert_called_once_with(
+            mock_wallet,
+            MOCK_MARKET_PARAMS["loanToken"],
+            MORPHO_BASE_ADDRESS,
+            MOCK_ASSETS_WEI,
+        )
+
+        expected_response = f"Repaid {MOCK_ASSETS} to Morpho market with transaction hash: {mock_contract_instance.transaction_hash} and transaction link: {mock_contract_instance.transaction_link}"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["loanToken"])
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+        mock_invoke.assert_called_once_with(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="repay",
+            abi=BLUE_ABI,
+            args={
+                "marketParams": MOCK_MARKET_PARAMS,
+                "assets": MOCK_ASSETS_WEI,
+                "shares": "0",
+                "onBehalf": MOCK_WALLET_ADDRESS,
+                "data": "0x",
+            },
+        )
+        mock_contract_wait.assert_called_once_with()
+
+
+def test_repay_success_with_shares(wallet_factory, contract_invocation_factory, asset_factory):
+    """Test successful repay with valid shares parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_instance = contract_invocation_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.approve",
+            return_value="Approval successful",
+        ) as mock_approve,
+        patch(
+            "cdp_agentkit_core.actions.morpho.repay.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_instance
+        ) as mock_invoke,
+        patch.object(
+            mock_contract_instance, "wait", return_value=mock_contract_instance
+        ) as mock_contract_wait,
+    ):
+        action_response = repay_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            "0",
+            MOCK_ASSETS,
+            MOCK_WALLET_ADDRESS,
+        )
+
+        mock_approve.assert_not_called()
+
+        expected_response = f"Repaid {MOCK_ASSETS} shares to Morpho market with transaction hash: {mock_contract_instance.transaction_hash} and transaction link: {mock_contract_instance.transaction_link}"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["loanToken"])
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+        mock_invoke.assert_called_once_with(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="repay",
+            abi=BLUE_ABI,
+            args={
+                "marketParams": MOCK_MARKET_PARAMS,
+                "assets": "0",
+                "shares": MOCK_ASSETS_WEI,
+                "onBehalf": MOCK_WALLET_ADDRESS,
+                "data": "0x",
+            },
+        )
+        mock_contract_wait.assert_called_once_with()

--- a/cdp-agentkit-core/python/tests/actions/morpho/test_supply_collateral.py
+++ b/cdp-agentkit-core/python/tests/actions/morpho/test_supply_collateral.py
@@ -1,0 +1,190 @@
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+from cdp_agentkit_core.actions.morpho.supply_collateral import (
+    MorphoSupplyCollateralInput,
+    supply_collateral_to_morpho,
+)
+
+MOCK_NETWORK_ID = "base"
+MOCK_WALLET_ADDRESS = "0x1234567890123456789012345678901234567890"
+MOCK_DECIMALS = 18
+MOCK_ASSETS = "1"
+MOCK_ASSETS_WEI = "1000000000000000000"
+
+# Market parameters for the specific market
+MOCK_MARKET_PARAMS = {
+    "loanToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "collateralToken": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    "oracle": "0x663BECd10daE6C4A3Dcd89F1d76c1174199639B9",
+    "irm": "0x46415998764C29aB2a25CbeA6254146D50D22687",
+    "lltv": "860000000000000000",
+}
+
+
+def test_supply_collateral_input_model_valid():
+    """Test that MorphoSupplyCollateralInput accepts valid parameters."""
+    input_model = MorphoSupplyCollateralInput(
+        market_params=MOCK_MARKET_PARAMS,
+        assets=MOCK_ASSETS_WEI,
+        on_behalf=MOCK_WALLET_ADDRESS,
+    )
+
+    assert input_model.market_params == MOCK_MARKET_PARAMS
+    assert input_model.assets == MOCK_ASSETS_WEI
+    assert input_model.on_behalf == MOCK_WALLET_ADDRESS
+
+
+def test_supply_collateral_input_model_missing_params():
+    """Test that MorphoSupplyCollateralInput raises error when params are missing."""
+    with pytest.raises(ValueError):
+        MorphoSupplyCollateralInput()
+
+
+def test_supply_collateral_success(wallet_factory, contract_invocation_factory, asset_factory):
+    """Test successful supply collateral with valid parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_instance = contract_invocation_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.supply_collateral.approve",
+            return_value="Approval successful",
+        ) as mock_approve,
+        patch(
+            "cdp_agentkit_core.actions.morpho.supply_collateral.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_instance
+        ) as mock_invoke,
+        patch.object(
+            mock_contract_instance, "wait", return_value=mock_contract_instance
+        ) as mock_contract_wait,
+    ):
+        action_response = supply_collateral_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_WALLET_ADDRESS,
+        )
+
+        expected_response = f"Supplied {MOCK_ASSETS} as collateral to Morpho market with transaction hash: {mock_contract_instance.transaction_hash} and transaction link: {mock_contract_instance.transaction_link}"
+        assert action_response == expected_response
+
+        mock_approve.assert_called_once_with(
+            mock_wallet,
+            MOCK_MARKET_PARAMS["collateralToken"],
+            MORPHO_BASE_ADDRESS,
+            MOCK_ASSETS_WEI,
+        )
+
+        mock_get_asset.assert_called_once_with(
+            MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["collateralToken"]
+        )
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+        mock_invoke.assert_called_once_with(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="supplyCollateral",
+            abi=BLUE_ABI,
+            args={
+                "marketParams": MOCK_MARKET_PARAMS,
+                "assets": MOCK_ASSETS_WEI,
+                "onBehalf": MOCK_WALLET_ADDRESS,
+                "data": "0x",
+            },
+        )
+        mock_contract_wait.assert_called_once_with()
+
+
+def test_supply_collateral_api_error(wallet_factory, asset_factory):
+    """Test supply collateral when API error occurs."""
+    mock_wallet = wallet_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.supply_collateral.approve",
+            return_value="Approval successful",
+        ),
+        patch(
+            "cdp_agentkit_core.actions.morpho.supply_collateral.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(mock_wallet, "invoke_contract", side_effect=Exception("API error")),
+    ):
+        action_response = supply_collateral_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_WALLET_ADDRESS,
+        )
+
+        expected_response = "Error supplying collateral to Morpho Blue: API error"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(
+            MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["collateralToken"]
+        )
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+
+def test_supply_collateral_approval_failure(wallet_factory, asset_factory):
+    """Test supply collateral when approval fails."""
+    mock_wallet = wallet_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.supply_collateral.approve",
+            return_value="Error: Approval failed",
+        ) as mock_approve,
+        patch(
+            "cdp_agentkit_core.actions.morpho.supply_collateral.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+    ):
+        action_response = supply_collateral_to_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_WALLET_ADDRESS,
+        )
+
+        expected_response = "Error approving Morpho Blue as spender: Error: Approval failed"
+        assert action_response == expected_response
+
+        mock_approve.assert_called_once_with(
+            mock_wallet,
+            MOCK_MARKET_PARAMS["collateralToken"],
+            MORPHO_BASE_ADDRESS,
+            MOCK_ASSETS_WEI,
+        )
+
+        mock_get_asset.assert_called_once_with(
+            MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["collateralToken"]
+        )
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))

--- a/cdp-agentkit-core/python/tests/actions/morpho/test_withdraw_collateral.py
+++ b/cdp-agentkit-core/python/tests/actions/morpho/test_withdraw_collateral.py
@@ -1,0 +1,150 @@
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from cdp_agentkit_core.actions.morpho.constants import BLUE_ABI, MORPHO_BASE_ADDRESS
+from cdp_agentkit_core.actions.morpho.withdraw_collateral import (
+    MorphoWithdrawCollateralInput,
+    withdraw_collateral_from_morpho,
+)
+
+MOCK_NETWORK_ID = "base"
+MOCK_WALLET_ADDRESS = "0x1234567890123456789012345678901234567890"
+MOCK_RECEIVER_ADDRESS = "0x2234567890123456789012345678901234567890"
+MOCK_DECIMALS = 18
+MOCK_ASSETS = "1"
+MOCK_ASSETS_WEI = "1000000000000000000"
+
+# Market parameters for the specific market
+MOCK_MARKET_PARAMS = {
+    "loanToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "collateralToken": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    "oracle": "0x663BECd10daE6C4A3Dcd89F1d76c1174199639B9",
+    "irm": "0x46415998764C29aB2a25CbeA6254146D50D22687",
+    "lltv": "860000000000000000",
+}
+
+
+def test_withdraw_collateral_input_model_valid():
+    """Test that MorphoWithdrawCollateralInput accepts valid parameters."""
+    input_model = MorphoWithdrawCollateralInput(
+        market_params=MOCK_MARKET_PARAMS,
+        assets=MOCK_ASSETS,
+        on_behalf=MOCK_WALLET_ADDRESS,
+        receiver=MOCK_RECEIVER_ADDRESS,
+    )
+
+    assert input_model.market_params == MOCK_MARKET_PARAMS
+    assert input_model.assets == MOCK_ASSETS
+    assert input_model.on_behalf == MOCK_WALLET_ADDRESS
+    assert input_model.receiver == MOCK_RECEIVER_ADDRESS
+
+
+def test_withdraw_collateral_input_model_missing_params():
+    """Test that MorphoWithdrawCollateralInput raises error when params are missing."""
+    with pytest.raises(ValueError):
+        MorphoWithdrawCollateralInput()
+
+
+def test_withdraw_collateral_success(wallet_factory, contract_invocation_factory, asset_factory):
+    """Test successful withdraw collateral with valid parameters."""
+    mock_wallet = wallet_factory()
+    mock_contract_instance = contract_invocation_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.withdraw_collateral.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(
+            mock_wallet, "invoke_contract", return_value=mock_contract_instance
+        ) as mock_invoke,
+        patch.object(
+            mock_contract_instance, "wait", return_value=mock_contract_instance
+        ) as mock_contract_wait,
+    ):
+        action_response = withdraw_collateral_from_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_WALLET_ADDRESS,
+            MOCK_RECEIVER_ADDRESS,
+        )
+
+        expected_response = f"Withdrawn {MOCK_ASSETS} collateral from Morpho market with transaction hash: {mock_contract_instance.transaction_hash} and transaction link: {mock_contract_instance.transaction_link}"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(
+            MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["collateralToken"]
+        )
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+        mock_invoke.assert_called_once_with(
+            contract_address=MORPHO_BASE_ADDRESS,
+            method="withdrawCollateral",
+            abi=BLUE_ABI,
+            args={
+                "marketParams": MOCK_MARKET_PARAMS,
+                "assets": MOCK_ASSETS_WEI,
+                "onBehalf": MOCK_WALLET_ADDRESS,
+                "receiver": MOCK_RECEIVER_ADDRESS,
+            },
+        )
+        mock_contract_wait.assert_called_once_with()
+
+
+def test_withdraw_collateral_api_error(wallet_factory, asset_factory):
+    """Test withdraw collateral when API error occurs."""
+    mock_wallet = wallet_factory()
+    mock_wallet.default_address.address_id = MOCK_WALLET_ADDRESS
+    mock_wallet.network_id = MOCK_NETWORK_ID
+    mock_asset = asset_factory(decimals=MOCK_DECIMALS)
+
+    with (
+        patch(
+            "cdp_agentkit_core.actions.morpho.withdraw_collateral.Asset.fetch",
+            return_value=mock_asset,
+        ) as mock_get_asset,
+        patch.object(
+            mock_asset, "to_atomic_amount", return_value=MOCK_ASSETS_WEI
+        ) as mock_to_atomic_amount,
+        patch.object(mock_wallet, "invoke_contract", side_effect=Exception("API error")),
+    ):
+        action_response = withdraw_collateral_from_morpho(
+            mock_wallet,
+            MOCK_MARKET_PARAMS,
+            MOCK_ASSETS,
+            MOCK_WALLET_ADDRESS,
+            MOCK_RECEIVER_ADDRESS,
+        )
+
+        expected_response = "Error withdrawing collateral from Morpho Blue: API error"
+        assert action_response == expected_response
+
+        mock_get_asset.assert_called_once_with(
+            MOCK_NETWORK_ID, MOCK_MARKET_PARAMS["collateralToken"]
+        )
+
+        mock_to_atomic_amount.assert_called_once_with(Decimal(MOCK_ASSETS))
+
+
+def test_withdraw_collateral_invalid_assets(wallet_factory):
+    """Test withdraw collateral with invalid assets amount."""
+    mock_wallet = wallet_factory()
+
+    response = withdraw_collateral_from_morpho(
+        mock_wallet,
+        MOCK_MARKET_PARAMS,
+        "0",
+        MOCK_WALLET_ADDRESS,
+        MOCK_RECEIVER_ADDRESS,
+    )
+    assert response == "Error: Assets amount must be greater than 0"


### PR DESCRIPTION
### What changed? Why?

Add action `morpho_borrow` to borrow from a Morpho Market on Base
Add action `morpho_repay` to repay to a Morpho Market on Base
Add action `morpho_supply_collateral` to supply collateral to a Morpho Market on Base
Add action `morpho_withdraw_collateral` to withdraw collateral from a Morpho Market on Base

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
