### PR TITLE
fix: fix README broken link to SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 ## Security and bug reports
 
 The AgentKit team takes security seriously.
-See [SECURITY.md](../SECURITY.md) for more information.
+See [SECURITY.md](SECURITY.md) for more information.
 
 ## License
 


### PR DESCRIPTION
### What changed? Why?

- Fixed a broken link pointing to SECURITY.md in the README.md file.
