### PR TITLE
fix: correct typo in base mainnet description across multiple files

### DIFF
--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/wow/buy_token.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/wow/buy_token.py
@@ -25,7 +25,7 @@ Important notes:
 - Minimum purchase amount is 100000000000000 wei (0.0000001 ETH)
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 """
 
 

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/wow/create_token.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/wow/create_token.py
@@ -22,7 +22,7 @@ Important notes:
 - Uses a bonding curve - no upfront liquidity needed
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 """
 
 

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/wow/sell_token.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/wow/sell_token.py
@@ -24,7 +24,7 @@ Important notes:
 - Minimum purchase amount is 100000000000000 wei (0.0000001 ETH)
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 """
 
 

--- a/cdp-agentkit-core/python/cdp_agentkit_core/actions/wrap_eth.py
+++ b/cdp-agentkit-core/python/cdp_agentkit_core/actions/wrap_eth.py
@@ -45,7 +45,7 @@ Important notes:
 - Minimum purchase amount is 100000000000000 wei (0.0000001 WETH)
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 """
 
 

--- a/cdp-agentkit-core/typescript/src/actions/cdp/defi/wow/actions/buy_token.ts
+++ b/cdp-agentkit-core/typescript/src/actions/cdp/defi/wow/actions/buy_token.ts
@@ -21,7 +21,7 @@ Important notes:
 - Minimum purchase amount is 100000000000000 wei (0.0000001 ETH)
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 `;
 
 /**

--- a/cdp-agentkit-core/typescript/src/actions/cdp/defi/wow/actions/create_token.ts
+++ b/cdp-agentkit-core/typescript/src/actions/cdp/defi/wow/actions/create_token.ts
@@ -16,7 +16,7 @@ Important notes:
 - Uses a bonding curve - no upfront liquidity needed
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 `;
 
 /**

--- a/cdp-agentkit-core/typescript/src/actions/cdp/defi/wow/actions/sell_token.ts
+++ b/cdp-agentkit-core/typescript/src/actions/cdp/defi/wow/actions/sell_token.ts
@@ -20,7 +20,7 @@ Important notes:
 - Minimum purchase amount is 100000000000000 wei (0.0000001 ETH)
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 `;
 
 /**

--- a/cdp-agentkit-core/typescript/src/actions/cdp/wrap_eth.ts
+++ b/cdp-agentkit-core/typescript/src/actions/cdp/wrap_eth.ts
@@ -44,7 +44,7 @@ Important notes:
 - Minimum purchase amount is 100000000000000 wei (0.0000001 WETH)
 - Only supported on the following networks:
   - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnnet')
+  - Base Mainnet (ie, 'base', 'base-mainnet')
 `;
 
 export const WrapEthInput = z


### PR DESCRIPTION
### What changed? Why?

Fix typo in network prompts
