### PR TITLE
chore: release twitter-langchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,7 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/@coinbase/coinbase-sdk/-/coinbase-sdk-0.14.1.tgz",
       "integrity": "sha512-3goViecQEPvUBndle4nTF8Sv4lIEOe6lad05yG3ZRIhj0tgfn2hI9i6V+eZ3np+sAQQO1J+6uL2j9PH/AMWtiw==",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.4.0",
@@ -8392,27 +8393,15 @@
     },
     "twitter-langchain/typescript": {
       "name": "@coinbase/twitter-langchain",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
-        "@coinbase/cdp-agentkit-core": "^0.0.13",
+        "@coinbase/cdp-agentkit-core": "^0.0.14",
         "@langchain/core": "^0.3.19",
         "twitter-api-v2": "^1.18.2",
         "zod": "^3.22.4"
       },
       "peerDependencies": {
         "@coinbase/coinbase-sdk": "^0.15.0"
-      }
-    },
-    "twitter-langchain/typescript/node_modules/@coinbase/cdp-agentkit-core": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-agentkit-core/-/cdp-agentkit-core-0.0.13.tgz",
-      "integrity": "sha512-4hRRnRMvX0lB6a2r8Nllhlxrhcy2lC6mMfg5jnLKGfMmJXvZ3hqjMH7eziy4Vm+msihu0OBqEVIA24qtGOxJtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@coinbase/coinbase-sdk": "^0.14.1",
-        "twitter-api-v2": "^1.18.2",
-        "viem": "^2.21.51",
-        "zod": "^3.23.8"
       }
     },
     "twitter-langchain/typescript/node_modules/@coinbase/cdp-agentkit-core/node_modules/@coinbase/coinbase-sdk": {

--- a/twitter-langchain/python/CHANGELOG.md
+++ b/twitter-langchain/python/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.0.11] - 2025-01-24
+
+### Added
+
+- Bump dependency `cdp-agentkit-core` to version `0.0.11`.
+
 ## [0.0.10] - 2025-01-22
 
 ### Added

--- a/twitter-langchain/python/docs/conf.py
+++ b/twitter-langchain/python/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = 'CDP Agentkit - Twitter LangChain'
 author = 'Coinbase Developer Platform'
-release = '0.0.10'
+release = '0.0.11'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/twitter-langchain/python/poetry.lock
+++ b/twitter-langchain/python/poetry.lock
@@ -488,7 +488,7 @@ test = ["coverage (>=7)", "hypothesis", "pytest"]
 
 [[package]]
 name = "cdp-agentkit-core"
-version = "0.0.10"
+version = "0.0.11"
 description = "CDP Agentkit core primitives"
 optional = false
 python-versions = "^3.10"
@@ -496,7 +496,7 @@ files = []
 develop = true
 
 [package.dependencies]
-cdp-sdk = "^0.14.1"
+cdp-sdk = "^0.15.0"
 pydantic = "^2.0"
 web3 = "^7.6.0"
 
@@ -506,13 +506,13 @@ url = "../../cdp-agentkit-core/python"
 
 [[package]]
 name = "cdp-sdk"
-version = "0.14.1"
+version = "0.15.0"
 description = "CDP Python SDK"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "cdp_sdk-0.14.1-py3-none-any.whl", hash = "sha256:a39712a0d608c20018012c765aec68520b632d2e511c4503408cf9eb32890aaf"},
-    {file = "cdp_sdk-0.14.1.tar.gz", hash = "sha256:8acffd3dc5bc77789064fd69d9850a3ade6ac105fde0fadec487c04c7d8b8bfe"},
+    {file = "cdp_sdk-0.15.0-py3-none-any.whl", hash = "sha256:f640c1cad0aee829ad24ee1b41dc3f40f74472a1da4d53e257ba996527a64f95"},
+    {file = "cdp_sdk-0.15.0.tar.gz", hash = "sha256:f7b015b2d3811d69db4ea5cb29cefc33fb47e7d2ce587f70222742ab602f610c"},
 ]
 
 [package.dependencies]
@@ -2727,13 +2727,13 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.10.5"
+version = "2.10.6"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.10.5-py3-none-any.whl", hash = "sha256:4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53"},
-    {file = "pydantic-2.10.5.tar.gz", hash = "sha256:278b38dbbaec562011d659ee05f63346951b3a248a6f3642e1bc68894ea2b4ff"},
+    {file = "pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584"},
+    {file = "pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236"},
 ]
 
 [package.dependencies]
@@ -3685,13 +3685,13 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.45.2"
+version = "0.45.3"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "starlette-0.45.2-py3-none-any.whl", hash = "sha256:4daec3356fb0cb1e723a5235e5beaf375d2259af27532958e2d79df549dad9da"},
-    {file = "starlette-0.45.2.tar.gz", hash = "sha256:bba1831d15ae5212b22feab2f218bab6ed3cd0fc2dc1d4442443bb1ee52260e0"},
+    {file = "starlette-0.45.3-py3-none-any.whl", hash = "sha256:dfb6d332576f136ec740296c7e8bb8c8a7125044e7c6da30744718880cdd059d"},
+    {file = "starlette-0.45.3.tar.gz", hash = "sha256:2cbcba2a75806f8a41c722141486f37c28e30a0921c5f6fe4346cb0dcee1302f"},
 ]
 
 [package.dependencies]
@@ -4360,4 +4360,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5793474f84327e631d958f8577540b7782a54c91565b1ec8e637a31602c6432c"
+content-hash = "7f377fe36df17a75ea0ee324d9b75cb3eca5d07423c2c296bc6191a5c1e54144"

--- a/twitter-langchain/python/pyproject.toml
+++ b/twitter-langchain/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "twitter-langchain"
-version = "0.0.10"
+version = "0.0.11"
 description = "Twitter Langchain Toolkit"
 authors = ["John Peterson <john.peterson@coinbase.com>"]
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ python = "^3.10"
 pydantic = "^2.9.2"
 langchain = "^0.3.7"
 tweepy = "^4.14.0"
-cdp-agentkit-core = "^0.0.10"
+cdp-agentkit-core = "^0.0.11"
 standard-imghdr = "^3.13.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/twitter-langchain/typescript/CHANGELOG.md
+++ b/twitter-langchain/typescript/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.0.12] - 2025-01-24
+
+### Added
+
+- Bump `@coinbase/cdp-agentkit-core` dependency to `0.0.14`
+
 ## [0.0.11] - 2025-01-22
 
 ### Added

--- a/twitter-langchain/typescript/package.json
+++ b/twitter-langchain/typescript/package.json
@@ -1,13 +1,11 @@
 {
   "name": "@coinbase/twitter-langchain",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Twitter (X) langchain Toolkit extension of CDP Agentkit",
   "repository": "https://github.com/coinbase/agentkit",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsc",
     "lint": "npx --yes eslint -c .eslintrc.json src/**/*.ts",
@@ -37,7 +35,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@coinbase/cdp-agentkit-core": "^0.0.13",
+    "@coinbase/cdp-agentkit-core": "^0.0.14",
     "@langchain/core": "^0.3.19",
     "twitter-api-v2": "^1.18.2",
     "zod": "^3.22.4"


### PR DESCRIPTION
### What changed? Why?
* bumped cdp-agentkit-core  to 0.0.11 for python
* bumped cdp-agentkit-core  to 0.0.14 for typescript
* release python twitter-langchain 0.0.11
* release typescript twitter-langchain 0.0.12

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
