### PR TITLE
chore: add github action to publish farcaster-langchain

### DIFF
--- a/.github/workflows/publish_npm_farcaster_langchain.yml
+++ b/.github/workflows/publish_npm_farcaster_langchain.yml
@@ -1,0 +1,24 @@
+name: Publish Farcaster LangChain to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-npm-farcaster-langchain:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm i && npm run build
+      - name: Install, build and publish @coinbase/farcaster-langchain
+        working-directory: ./farcaster-langchain/typescript
+        run: |
+          npm publish --ignore-scripts --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What changed? Why?
Adds action to publish farcaster-langchain
