### PR TITLE
chore: add more detail to contributing action guides

### DIFF
--- a/.github/CONTRIBUTING-PYTHON.md
+++ b/.github/CONTRIBUTING-PYTHON.md
@@ -30,32 +30,52 @@ If the versions are not correct or you don't have Python or Poetry installed, do
 
 ## Adding an Agentic Action
 
-One of the most common ways to contribute to AgentKit is by adding a new agentic action. Here are the high level steps:
+An Action is an interface for an AI Agent to interact with the real world: any Python function that you can think of can be used by an Agent via an Action! There are a few components to an Action:
 
-1. Create a new file in `cdp-agentkit-core/python/cdp_agentkit_core/actions`
-2. Implement your new action inside your newly created file
-    - For an example of an action, see [mint_nft.py](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/python/cdp_agentkit_core/actions/mint_nft.py)
-3. Add your action to [`cdp_agentkit_core/actions/__init__.py`](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py)
-4. Add a test for your action in `cdp-agentkit-core/python/tests/actions`
-    - For an example, see [test_mint_nft.py](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/python/tests/actions/test_mint_nft.py)
+1. **Prompt**: A description that helps the AI understand when and how to use the action. It's important to describe the inputs and outputs of the action and include examples. Additionally, think about what inputs can be removed entirely and fetched or inferred by the LLM, so that users don't have to manually provide them.
+2. **Input Schema**: Define the input parameters using [Pydantic](https://docs.pydantic.dev/latest/) schemas. Pydantic is used to validate the inputs to the action and to generate a JSON schema that can be used by the LLM to understand the inputs.
+3. **Implementation Function**: The actual logic that executes the action. This function receives as input the wallet that the Agent has access to, and as you'll see in the walkthrough below, we can use this wallet to invoke an onchain contract! For more information on contract invocations using a CDP wallet, see [here](https://docs.cdp.coinbase.com/cdp-sdk/docs/onchain-interactions#smart-contract-interactions).
 
-Actions are created by implementing the `CdpAction` interface:
+In practice, Actions are housed in `cdp-agentkit-core/python/cdp_agentkit_core/actions` and generally grouped by the type of action they are. For example, actions related to interacting with social platforms such as X (Twitter) are housed in `cdp-agentkit-core/python/cdp_agentkit_core/actions/social/twitter`. When adding a new action, check if there is an existing folder for the type of action you are adding and add your new action to the appropriate folder.
+
+Here's the structure of the actions directory:
+
+```
+./cdp-agentkit-core/python
+└── cdp_agentkit_core
+    └── actions
+       ├── defi
+       ├── morpho
+       ├── pyth
+       ├── social
+       ├── superfluid
+       └── wow
+```
+
+Once you decide which folder to add your action to, go ahead and create a new file there to house your action, then read through the following sections to learn how to implement your action. For a complete example of an action, see [mint_nft.py](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/python/cdp_agentkit_core/actions/mint_nft.py).
+
+### Crafting a good prompt
+
+The prompt is used by the LLM to understand when and how to use the action. It's important to be as specific as possible in describing the inputs and outputs of the action and include examples. Take the Mint NFT prompt for example:
 
 ```python
-from collections.abc import Callable
-
-from cdp import Wallet
-from pydantic import BaseModel, Field
-
-from cdp_agentkit_core.actions import CdpAction
-
 MINT_NFT_PROMPT = """
 This tool will mint an NFT (ERC-721) to a specified destination address onchain via a contract invocation.
 It takes the contract address of the NFT onchain and the destination address onchain that will receive the NFT as inputs.
 Do not use the contract address as the destination address. If you are unsure of the destination address, please ask the user before proceeding.
 """
+```
 
+* The prompt disambuguates the type of NFT by specifying "ERC-721"
+* The prompt specifies that the destination address should not be the contract address
+* The prompt specifies that the LLM should ask the user for the destination address if it is unsure
+* Think about the best UX: if a contract address from a known list of addresses is required, you can instruct the LLM to use another action to get the list of addresses and prompt the user to choose an address from that list. For example, consider a DeFi action that allows a user to withdraw funds from a liquidity provider position. This action would take a contract address, so it would be valuable to have another action that can pull a list of addresses representing the user's positions. You can then instruct the LLM via the prompt to use that action in the case that no contract address is provided.
 
+### Defining the input schema
+
+The input schema is used to validate the inputs to the action and to generate a JSON schema that can be used by the LLM to understand the inputs. For Python, we use [Pydantic](https://docs.pydantic.dev/latest/) to define the input schema. For example, the Mint NFT input schema is defined as follows:
+
+```python
 class MintNftInput(BaseModel):
     """Input argument schema for mint NFT action."""
 
@@ -67,8 +87,15 @@ class MintNftInput(BaseModel):
         ...,
         description="The destination address that will receive the NFT onchain, e.g. `0x036CbD53842c5426634e7929541eC2318f3dCF7e`",
     )
+```
 
+This says that the input schema has two fields: `contract_address` and `destination`. The `contract_address` field is required and must be a string. The `destination` field is required and must be a string. For more information on Pydantic, see the [Pydantic documentation](https://docs.pydantic.dev/latest/).
 
+### Implementing the action
+
+Now we need to implement the actual function that the AI will call when using your action. The function receives as input the wallet that the Agent has access to, along with the inputs defined in the input schema, and it must return a string. This return value is used by the LLM to understand the result of the action, which in turn will generate a user-facing response. Here's an example of the Mint NFT implementation function:
+
+```python
 def mint_nft(wallet: Wallet, contract_address: str, destination: str) -> str:
     """Mint an NFT (ERC-721) to a specified destination address onchain via a contract invocation.
 
@@ -92,7 +119,13 @@ def mint_nft(wallet: Wallet, contract_address: str, destination: str) -> str:
 
     return f"Minted NFT from contract {contract_address} to address {destination} on network {wallet.network_id}.\nTransaction hash for the mint: {mint_invocation.transaction.transaction_hash}\nTransaction link for the mint: {mint_invocation.transaction.transaction_link}"
 
+```
 
+Notice the return value contains useful information for the user, such as the transaction hash and link. It's important to include this information in the return value so that the user can easily see the result of the action.
+
+Finally, we need to create a class that implements the `CdpAction` interface and export it. This class contains the name, description, input schema, and implementation function of the action. Here's an example of the Mint NFT action class:
+
+```python
 class MintNftAction(CdpAction):
     """Mint NFT action."""
 
@@ -102,18 +135,21 @@ class MintNftAction(CdpAction):
     func: Callable[..., str] = mint_nft
 ```
 
-#### Components of an Agentic Action
+This class is then exported out of [`cdp_agentkit_core/actions/__init__.py`](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/python/cdp_agentkit_core/actions/__init__.py) so that is is consumable by users of the `cdp-agentkit-core` package.
 
-1. **Input Schema**: Define the input parameters using Pydantic schemas
-2. **Prompt**: A description that helps the AI understand when and how to use the action. It's important to describe the inputs and outputs of the action and include examples. Additionally, think about what inputs can be removed entirely and fetched or inferred by the LLM, so that users don't have to manually provide them.
-3. **Action Class**: Implements the `CdpAction` interface with:
-   - `name`: Unique identifier for the action
-   - `description`: The prompt text
-   - `args_schema`: The Pydantic schema for validating inputs
-   - `func`: The implementation function
-4. **Implementation Function**: The actual logic that executes the action
+### Testing the action
 
-Check out the [Testing](#testing) section to learn how to manually test your new action.
+There are two forms of testing you should do: unit testing and manual end-to-end testing.
+
+To add a unit test for your action, add a file to the folder in `cdp-agentkit-core/python/tests/actions` that corresponds to the same folder that you are adding your action to. For an example, see [test_mint_nft.py](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/python/tests/actions/test_mint_nft.py).
+
+You can then run the unit tests with the following command:
+```bash
+cd cdp-agentkit-core/python
+make test
+```
+
+For instructions on manual end-to-end testing, see the [Testing](#testing) section.
 
 ## Adding an Agentic Action to Langchain Toolkit
 

--- a/.github/CONTRIBUTING-PYTHON.md
+++ b/.github/CONTRIBUTING-PYTHON.md
@@ -8,6 +8,7 @@ This guide covers Python-specific setup and development for AgentKit.
 - [Adding an Agentic Action](#adding-an-agentic-action)
 - [Adding an Agentic Action to Langchain Toolkit](#adding-an-agentic-action-to-langchain-toolkit)
 - [Adding an Agentic Action to the Twitter Toolkit](#adding-an-agentic-action-to-the-twitter-toolkit)
+- [Integrating into an AI Agent Framework](#integrating-into-an-ai-agent-framework)
 - [Testing](#testing)
 - [Code Style](#code-style)
 
@@ -197,6 +198,14 @@ The action will be included automatically, all you need to do is add the action 
 5. Update `TwitterToolkit` documentation
     - Add the action to the list of tools
     - Add any additional ENV requirements
+
+## Integrating into an AI Agent Framework
+
+Actions are necessary building blocks powering onchain AI applications, but they're just one piece of the puzzle. To make them truly useful, they must be integrated into an AI Agent framework such as [LangChain](https://www.langchain.com/) or [Eliza](https://elizaos.github.io/eliza/), among others.
+
+Integrations into AI Agent frameworks are specific to the framework itself, so we can't go into specific implementation details here, but we can offer up some examples and tips.
+- To automatically get access to new actions as they are released, make sure to import the `CDP_ACTIONS` constant from `cdp-agentkit-core`. This will make it so that all you / the framework authors have to do to get new actions is bump the version of AgentKit the framework is using.
+- Check out how [AgentKit Actions are mapped into LangChain Tools](https://github.com/coinbase/agentkit/blob/master/cdp-langchain/python/cdp_langchain/agent_toolkits/cdp_toolkit.py#L132-L141)
 
 ## Testing
 

--- a/.github/CONTRIBUTING-TYPESCRIPT.md
+++ b/.github/CONTRIBUTING-TYPESCRIPT.md
@@ -27,28 +27,46 @@ Once you have these installed, make sure you install the project dependencies by
 
 ## Adding an Agentic Action
 
-One of the most common ways to contribute to AgentKit is by adding a new agentic action. Here are the high level steps:
+An Action is an interface for an AI Agent to interact with the real world: any TypeScript function that you can think of can be used by an Agent via an Action! There are a few components to an Action:
 
-1. Create a new file in `cdp-agentkit-core/typescript/src/actions/cdp`
-2. Implement your new action inside your newly created file
-    - For an example of an action, see [mint_nft.ts](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/typescript/src/actions/cdp/mint_nft.ts)
-3. Add your action to [cdp-agentkit-core/typescript/src/actions/cdp/index.ts`](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/typescript/src/actions/cdp/index.ts)
-4. Add a test for your action in `cdp-agentkit-core/typescript/src/tests`
-    - For an example, see [mint_nft_test.ts](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/typescript/src/tests/mint_nft_test.ts)
+1. **Prompt**: A description that helps the AI understand when and how to use the action. It's important to describe the inputs and outputs of the action and include examples. Additionally, think about what inputs can be removed entirely and fetched or inferred by the LLM, so that users don't have to manually provide them.
+2. **Input Schema**: Define the input parameters using [Zod](https://zod.dev/) schemas. Zod is used to validate the inputs to the action and to generate a JSON schema that can be used by the LLM to understand the inputs.
+3. **Implementation Function**: The actual logic that executes the action. This function receives as input the wallet that the Agent has access to, and as you'll see in the walkthrough below, we can use this wallet to invoke an onchain contract! For more information on contract invocations using a CDP wallet, see [here](https://docs.cdp.coinbase.com/cdp-sdk/docs/onchain-interactions#smart-contract-interactions).
 
-Actions are created by implementing the `CdpAction` interface:
+In practice, Actions are housed in `cdp-agentkit-core/typescript/src/actions/cdp` and generally grouped by the type of action they are. For example, actions related to interacting with social platforms such as X (Twitter) are housed in `cdp-agentkit-core/typescript/src/actions/cdp/social/twitter`. When adding a new action, check if there is an existing folder for the type of action you are adding and add your new action to the appropriate folder.
+
+Here's the structure of the actions directory:
+
+```
+./cdp-agentkit-core/typescript/src
+└── actions
+    └── cdp
+       ├── data
+       ├── defi
+       └── social
+```
+
+Once you decide which folder to add your action to, go ahead and create a new file there to house your action, then read through the following sections to learn how to implement your action. For a complete example of an action, see  [mint_nft.ts](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/typescript/src/actions/cdp/mint_nft.ts).
+
+### Crafting a good prompt
+
+The prompt is used by the LLM to understand when and how to use the action. It's important to be as specific as possible in describing the inputs and outputs of the action and include examples. Take the Mint NFT prompt for example:
 
 ```typescript
-import { CdpAction } from "./cdp_action";
-import { Wallet } from "@coinbase/coinbase-sdk";
-import { z } from "zod";
-
 const MINT_NFT_PROMPT = `
 This tool will mint an NFT (ERC-721) to a specified destination address onchain via a contract invocation. It takes the contract address of the NFT onchain and the destination address onchain that will receive the NFT as inputs. Do not use the contract address as the destination address. If you are unsure of the destination address, please ask the user before proceeding.`;
+```
 
-/**
- * Input schema for mint NFT action.
- */
+* The prompt disambuguates the type of NFT by specifying "ERC-721"
+* The prompt specifies that the destination address should not be the contract address
+* The prompt specifies that the LLM should ask the user for the destination address if it is unsure
+* Think about the best UX: if a contract address from a known list of addresses is required, you can instruct the LLM to use another action to get the list of addresses and prompt the user to choose an address from that list. For example, consider a DeFi action that allows a user to withdraw funds from a liquidity provider position. This action would take a contract address, so it would be valuable to have another action that can pull a list of addresses representing the user's positions. You can then instruct the LLM via the prompt to use that action in the case that no contract address is provided.
+
+### Defining the input schema
+
+The input schema is used to validate the inputs to the action and to generate a JSON schema that can be used by the LLM to understand the inputs. For TypeScript, we use [Zod](https://zod.dev/) to define the input schema. For example, the Mint NFT input schema is defined as follows:
+
+```typescript
 const MintNftInput = z
   .object({
     contractAddress: z.string().describe("The contract address of the NFT to mint"),
@@ -56,14 +74,15 @@ const MintNftInput = z
   })
   .strip()
   .describe("Instructions for minting an NFT");
+```
 
-/**
- * Mints an NFT (ERC-721) to a specified destination address onchain.
- *
- * @param wallet - The wallet to mint the NFT from.
- * @param args - The input arguments for the action.
- * @returns A message containing the NFT mint details.
- */
+This says that the input schema has two fields: `contractAddress` and `destination`. The `contractAddress` field is required and must be a string. The `destination` field is required and must be a string. For more information on Zod, see the [Zod documentation](https://zod.dev/).
+
+### Implementing the action
+
+Now we need to implement the actual function that the AI will call when using your action. The function receives as input the wallet that the Agent has access to, along with the inputs defined in the input schema, and it must return a string. This return value is used by the LLM to understand the result of the action, which in turn will generate a user-facing response. Here's an example of the Mint NFT implementation function:
+
+```typescript
 async function mintNft(wallet: Wallet, args: z.infer<typeof MintNftInput>): Promise<string> {
   const mintArgs = {
     to: args.destination,
@@ -84,10 +103,13 @@ async function mintNft(wallet: Wallet, args: z.infer<typeof MintNftInput>): Prom
     return `Error minting NFT: ${error}`;
   }
 }
+```
 
-/**
- * Mint NFT action.
- */
+Notice the return value contains useful information for the user, such as the transaction hash and link. It's important to include this information in the return value so that the user can easily see the result of the action.
+
+Finally, we need to create a class that implements the `CdpAction` interface and export it. This class contains the name, description, input schema, and implementation function of the action. Here's an example of the Mint NFT action class:
+
+```typescript
 export class MintNftAction implements CdpAction<typeof MintNftInput> {
   public name = "mint_nft";
   public description = MINT_NFT_PROMPT;
@@ -96,16 +118,21 @@ export class MintNftAction implements CdpAction<typeof MintNftInput> {
 }
 ```
 
-#### Components of an Agentic Action
+This class is then exported out of [cdp-agentkit-core/typescript/src/actions/cdp/index.ts](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/typescript/src/actions/cdp/index.ts) so that is is consumable by users of the `@coinbase/cdp-agentkit-core` package.
 
-1. **Input Schema**: Define the input parameters using Zod schemas
-2. **Prompt**: A description that helps the AI understand when and how to use the action. It's important to describe the inputs and outputs of the action and include examples. Additionally, think about what inputs can be removed entirely and fetched or inferred by the LLM, so that users don't have to manually provide them.
-3. **Action Class**: Implements the `CdpAction` interface with:
-   - `name`: Unique identifier for the action
-   - `description`: The prompt text
-   - `argsSchema`: The Zod schema for validating inputs
-   - `func`: The implementation function
-4. **Implementation Function**: The actual logic that executes the action
+### Testing the action
+
+There are two forms of testing you should do: unit testing and manual end-to-end testing.
+
+To add a unit test for your action, add a file to the folder in `cdp-agentkit-core/typescript/src/tests/actions` that corresponds to the same folder that you are adding your action to, or to the top-level if there is no folder. For an example, see [test_mint_nft.ts](https://github.com/coinbase/agentkit/blob/master/cdp-agentkit-core/typescript/tests/actions/test_mint_nft.ts).
+
+You can then run the unit tests with the following command:
+```bash
+cd cdp-agentkit-core/typescript
+npm test
+```
+
+For instructions on manual end-to-end testing, see the [Testing](#testing) section.
 
 Check out the [Testing](#testing) section to learn how to manually test your new action.
 

--- a/.github/CONTRIBUTING-TYPESCRIPT.md
+++ b/.github/CONTRIBUTING-TYPESCRIPT.md
@@ -7,6 +7,7 @@ This guide covers TypeScript-specific setup and development for AgentKit.
 - [Development Setup](#development-setup)
 - [Adding an Agentic Action](#adding-an-agentic-action)
 - [Adding an Agentic Action to Langchain Toolkit](#adding-an-agentic-action-to-langchain-toolkit)
+- [Integrating into an AI Agent Framework](#integrating-into-an-ai-agent-framework)
 - [Testing](#testing)
 - [Code Style](#code-style)
 
@@ -139,6 +140,15 @@ Check out the [Testing](#testing) section to learn how to manually test your new
 ## Adding an Agentic Action to Langchain Toolkit
 
 The action will be included automatically, all you need to do is add the action to the list of tools in the `CdpToolkit` class documentation in `cdp-langchain/typescript/src/toolkits/cdp_toolkit.ts`.
+
+## Integrating into an AI Agent Framework
+
+Actions are necessary building blocks powering onchain AI applications, but they're just one piece of the puzzle. To make them truly useful, they must be integrated into an AI Agent framework such as [LangChain](https://www.langchain.com/) or [Eliza](https://elizaos.github.io/eliza/), among others.
+
+Integrations into AI Agent frameworks are specific to the framework itself, so we can't go into specific implementation details here, but we can offer up some examples and tips.
+- To automatically get access to new actions as they are released, make sure to import the `CDP_ACTIONS` constant from `@coinbase/cdp-agentkit-core`. This will make it so that all you / the framework authors have to do to get new actions is bump the version of AgentKit the framework is using.
+- Check out how [AgentKit actions are mapped into LangChain Tools](https://github.com/coinbase/agentkit/blob/master/cdp-langchain/typescript/src/toolkits/cdp_toolkit.ts#L59)
+- Check out how [AgentKit Actions are mapped into Eliza Actions](https://github.com/elizaOS/eliza/blob/develop/packages/plugin-agentkit/src/actions.ts#L31)
 
 ## Testing
 


### PR DESCRIPTION
### What changed? Why?
Closes the action items:
* Articulate subfolder structure – If action falls under one of the predefined categories, it should go under one of the subfolders (e.g. pyth, defi, social)
* Link out to Zod & Pydantic docs
* Add guidance on contributing to new AI frameworks

