### PR TITLE
chore: map chainId to networkId

### DIFF
--- a/cdp-agentkit-core/typescript/src/action_providers/action_provider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/action_provider.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { WalletProvider } from "../wallet_providers/wallet_provider";
-import { Network } from "../wallet_providers/wallet_provider";
+import { Network } from "../network";
 import { StoredActionMetadata, ACTION_DECORATOR_KEY } from "./action_decorator";
 
 /**

--- a/cdp-agentkit-core/typescript/src/action_providers/basename/basenameActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/basename/basenameActionProvider.ts
@@ -1,7 +1,7 @@
 import { encodeFunctionData, Hex, namehash, parseEther } from "viem";
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network } from "../../wallet_providers/wallet_provider";
+import { Network } from "../../network";
 import { CreateAction } from "../action_decorator";
 import {
   L2_RESOLVER_ADDRESS_MAINNET,

--- a/cdp-agentkit-core/typescript/src/action_providers/cdp/cdpActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/cdp/cdpActionProvider.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network, EvmWalletProvider } from "../../wallet_providers";
+import { EvmWalletProvider } from "../../wallet_providers";
 import { CreateAction } from "../action_decorator";
 import { Coinbase, ExternalAddress } from "@coinbase/coinbase-sdk";
 import { AddressReputationSchema, RequestFaucetFundsSchema } from "./schemas";
+import { Network } from "../../network";
 
 /**
  * Configuration options for the CdpActionProvider.

--- a/cdp-agentkit-core/typescript/src/action_providers/erc20/erc20ActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/erc20/erc20ActionProvider.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network } from "../../wallet_providers/wallet_provider";
+import { Network } from "../../network";
 import { CreateAction } from "../action_decorator";
 import { GetBalanceSchema, TransferSchema } from "./schemas";
 import { abi } from "./constants";

--- a/cdp-agentkit-core/typescript/src/action_providers/erc721/erc721ActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/erc721/erc721ActionProvider.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network, EvmWalletProvider } from "../../wallet_providers";
+import { EvmWalletProvider } from "../../wallet_providers";
 import { CreateAction } from "../action_decorator";
 import { GetBalanceSchema, MintSchema, TransferSchema } from "./schemas";
 import { ERC721_ABI } from "./constants";
 import { encodeFunctionData, Hex } from "viem";
+import { Network } from "../../network";
 
 /**
  * Erc721ActionProvider is an action provider for Erc721 contract interactions.

--- a/cdp-agentkit-core/typescript/src/action_providers/farcaster/farcasterActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/farcaster/farcasterActionProvider.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network } from "../../wallet_providers";
+import { Network } from "../../network";
 import { CreateAction } from "../action_decorator";
 import { FarcasterAccountDetailsSchema, FarcasterPostCastSchema } from "./schemas";
 

--- a/cdp-agentkit-core/typescript/src/action_providers/morpho/morphoActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/morpho/morphoActionProvider.ts
@@ -3,11 +3,12 @@ import { Decimal } from "decimal.js";
 import { encodeFunctionData, parseEther } from "viem";
 
 import { ActionProvider } from "../action_provider";
-import { Network, EvmWalletProvider } from "../../wallet_providers";
+import { EvmWalletProvider } from "../../wallet_providers";
 import { CreateAction } from "../action_decorator";
 import { approve } from "../../utils";
 import { METAMORPHO_ABI } from "./constants";
 import { DepositSchema, WithdrawSchema } from "./schemas";
+import { Network } from "../../network";
 
 export const SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"];
 

--- a/cdp-agentkit-core/typescript/src/action_providers/twitter/twitterActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/twitter/twitterActionProvider.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { ActionProvider } from "../action_provider";
 import { CreateAction } from "../action_decorator";
 import { TwitterApi, TwitterApiTokens } from "twitter-api-v2";
-import { Network } from "../../wallet_providers/wallet_provider";
+import { Network } from "../../network";
 import {
   TwitterAccountDetailsSchema,
   TwitterAccountMentionsSchema,

--- a/cdp-agentkit-core/typescript/src/action_providers/wallet/walletActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/wallet/walletActionProvider.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network, WalletProvider } from "../../wallet_providers/wallet_provider";
+import { WalletProvider } from "../../wallet_providers/wallet_provider";
 import { CreateAction } from "../action_decorator";
+import { Network } from "../../network";
 
 /**
  * Schema for the get_wallet_details action.

--- a/cdp-agentkit-core/typescript/src/action_providers/weth/wethActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/weth/wethActionProvider.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network } from "../../wallet_providers/wallet_provider";
+import { Network } from "../../network";
 import { CreateAction } from "../action_decorator";
 import { WrapEthSchema } from "./schemas";
 import { WETH_ABI, WETH_ADDRESS } from "./constants";

--- a/cdp-agentkit-core/typescript/src/action_providers/wow/wowActionProvider.ts
+++ b/cdp-agentkit-core/typescript/src/action_providers/wow/wowActionProvider.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { ActionProvider } from "../action_provider";
-import { Network, EvmWalletProvider } from "../../wallet_providers";
+import { EvmWalletProvider } from "../../wallet_providers";
 import { CreateAction } from "../action_decorator";
+import { Network } from "../../network";
 import {
   SUPPORTED_NETWORKS,
   WOW_ABI,

--- a/cdp-agentkit-core/typescript/src/network/index.ts
+++ b/cdp-agentkit-core/typescript/src/network/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/cdp-agentkit-core/typescript/src/network/network.ts
+++ b/cdp-agentkit-core/typescript/src/network/network.ts
@@ -1,0 +1,15 @@
+/**
+ * Maps EVM chain IDs to Coinbase network IDs
+ */
+export const CHAIN_ID_TO_NETWORK_ID: Record<number, string> = {
+  1: "ethereum-mainnet",
+  11155111: "ethereum-sepolia",
+  137: "polygon-mainnet",
+  80001: "polygon-mumbai",
+  8453: "base-mainnet",
+  84532: "base-sepolia",
+  42161: "arbitrum-mainnet",
+  421614: "arbitrum-sepolia",
+  10: "optimism-mainnet",
+  11155420: "optimism-sepolia",
+};

--- a/cdp-agentkit-core/typescript/src/network/types.ts
+++ b/cdp-agentkit-core/typescript/src/network/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Network is the network that the wallet provider is connected to.
+ */
+export interface Network {
+  /**
+   * The protocol family of the network.
+   */
+  protocolFamily: string;
+
+  /**
+   * The network ID of the network.
+   */
+  networkId?: string;
+
+  /**
+   * The chain ID of the network.
+   */
+  chainId?: string;
+}

--- a/cdp-agentkit-core/typescript/src/wallet_providers/cdp_wallet_provider.ts
+++ b/cdp-agentkit-core/typescript/src/wallet_providers/cdp_wallet_provider.ts
@@ -3,7 +3,7 @@
 
 import { ReadContractParameters, ReadContractReturnType, TransactionRequest } from "viem";
 import { EvmWalletProvider } from "./evm_wallet_provider";
-import { Network } from "./wallet_provider";
+import { Network } from "../network";
 
 /**
  * A wallet provider that uses the Coinbase SDK.

--- a/cdp-agentkit-core/typescript/src/wallet_providers/viem_wallet_provider.ts
+++ b/cdp-agentkit-core/typescript/src/wallet_providers/viem_wallet_provider.ts
@@ -11,7 +11,8 @@ import {
   ReadContractReturnType,
 } from "viem";
 import { EvmWalletProvider } from "./evm_wallet_provider";
-import { Network } from "./wallet_provider";
+import { Network } from "../network";
+import { CHAIN_ID_TO_NETWORK_ID } from "../network/network";
 
 /**
  * A wallet provider that uses the Viem library.
@@ -119,6 +120,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
     return {
       protocolFamily: "evm" as const,
       chainId: this.#walletClient.chain!.id! as any as string,
+      networkId: CHAIN_ID_TO_NETWORK_ID[this.#walletClient.chain!.id!],
     };
   }
 

--- a/cdp-agentkit-core/typescript/src/wallet_providers/wallet_provider.ts
+++ b/cdp-agentkit-core/typescript/src/wallet_providers/wallet_provider.ts
@@ -1,22 +1,4 @@
-/**
- * Network is the network that the wallet provider is connected to.
- */
-export interface Network {
-  /**
-   * The protocol family of the network.
-   */
-  protocolFamily: string;
-
-  /**
-   * The network ID of the network.
-   */
-  networkId?: string;
-
-  /**
-   * The chain ID of the network.
-   */
-  chainId?: string;
-}
+import { Network } from "../network";
 
 /**
  * WalletProvider is the abstract base class for all wallet providers.


### PR DESCRIPTION
### What changed? Why?
Map chainId to networkId so CDP actions can work, specifically testing faucet

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
