### PR TITLE
fix: use prefix notation that plays nicely with langchain

### DIFF
--- a/cdp-agentkit-core/typescript/src/action-providers/actionDecorator.ts
+++ b/cdp-agentkit-core/typescript/src/action-providers/actionDecorator.ts
@@ -83,7 +83,7 @@ export type StoredActionMetadata = Map<string, ActionMetadata>;
  */
 export function CreateAction(params: CreateActionDecoratorParams) {
   return (target: object, propertyKey: string, descriptor: PropertyDescriptor) => {
-    const prefixedActionName = `${target.constructor.name}.${params.name}`;
+    const prefixedActionName = `${target.constructor.name}_${params.name}`;
 
     const originalMethod = descriptor.value;
 


### PR DESCRIPTION
### What changed? Why?
Fixes this error:
```
Error: 400 Invalid 'tools[0].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
