### PR TITLE
Add Moonwell Capabilities

### DIFF
--- a/typescript/agentkit/src/action-providers/moonwell/constants.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/constants.ts
@@ -1,81 +1,114 @@
 export const MOONWELL_BASE_ADDRESSES = {
-    "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22": "MOONWELL_USDC",
-    "0x73b06D8d18De422E269645eaCe15400DE7462417": "MOONWELL_DAI",
-    "0x628ff693426583D9a7FB391E54366292F509D457": "MOONWELL_WETH",
-    "0x3bf93770f2d4a794c3d9EBEfBAeBAE2a8f09A5E5": "MOONWELL_cbETH",
-    "0x627Fe393Bc6EdDA28e99AE648fD6fF362514304b": "MOONWELL_wstETH",
-    "0x73902f619CEB9B31FD8EFecf435CbDf89E369Ba6": "MOONWELL_AERO",
-    "0xb8051464C8c92209C92F3a4CD9C73746C4c3CFb3": "MOONWELL_weETH",
-    "0xF877ACaFA28c19b96727966690b2f44d35aD5976": "MOONWELL_cbBTC",
-    "0xb682c840B5F4FC58B20769E691A6fa1305A501a2": "MOONWELL_EURC",
-    "0xfC41B49d064Ac646015b459C522820DB9472F4B5": "MOONWELL_wrsETH",
-    "0xdC7810B47eAAb250De623F0eE07764afa5F71ED1": "MOONWELL_WELL",
-    "0xb6419c6C2e60c4025D6D06eE4F913ce89425a357": "MOONWELL_USDS",
-    "0x9A858ebfF1bEb0D3495BB0e2897c1528eD84A218": "MOONWELL_TBTC",
-    "0x70778cfcFC475c7eA0f24cC625Baf6EaE475D0c9": "WETH_ROUTER"
+  "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22": "MOONWELL_USDC",
+  "0x73b06D8d18De422E269645eaCe15400DE7462417": "MOONWELL_DAI",
+  "0x628ff693426583D9a7FB391E54366292F509D457": "MOONWELL_WETH",
+  "0x3bf93770f2d4a794c3d9EBEfBAeBAE2a8f09A5E5": "MOONWELL_cbETH",
+  "0x627Fe393Bc6EdDA28e99AE648fD6fF362514304b": "MOONWELL_wstETH",
+  "0x73902f619CEB9B31FD8EFecf435CbDf89E369Ba6": "MOONWELL_AERO",
+  "0xb8051464C8c92209C92F3a4CD9C73746C4c3CFb3": "MOONWELL_weETH",
+  "0xF877ACaFA28c19b96727966690b2f44d35aD5976": "MOONWELL_cbBTC",
+  "0xb682c840B5F4FC58B20769E691A6fa1305A501a2": "MOONWELL_EURC",
+  "0xfC41B49d064Ac646015b459C522820DB9472F4B5": "MOONWELL_wrsETH",
+  "0xdC7810B47eAAb250De623F0eE07764afa5F71ED1": "MOONWELL_WELL",
+  "0xb6419c6C2e60c4025D6D06eE4F913ce89425a357": "MOONWELL_USDS",
+  "0x9A858ebfF1bEb0D3495BB0e2897c1528eD84A218": "MOONWELL_TBTC",
+  "0x70778cfcFC475c7eA0f24cC625Baf6EaE475D0c9": "WETH_ROUTER",
 };
 
 export const MOONWELL_BASE_SEPOLIA_ADDRESSES = {
-    "0x876852425331a113d8E432eFFB3aC5BEf38f033a": "MOONWELL_USDBC",
-    "0x5302EbD8BC32435C823c2e22B04Cd6c45f593e89": "MOONWELL_cbETH",
-    "0x2F39a349A79492a70E152760ce7123A1933eCf28": "MOONWELL_WETH",
+  "0x876852425331a113d8E432eFFB3aC5BEf38f033a": "MOONWELL_USDBC",
+  "0x5302EbD8BC32435C823c2e22B04Cd6c45f593e89": "MOONWELL_cbETH",
+  "0x2F39a349A79492a70E152760ce7123A1933eCf28": "MOONWELL_WETH",
 };
 
 export const WETH_ROUTER_ADDRESS = "0x70778cfcFC475c7eA0f24cC625Baf6EaE475D0c9";
 
+// Token decimals mapping
+export const TOKEN_DECIMALS = {
+  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913": 6, // USDC
+  "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42": 6, // EURC
+  "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A": 18, // weETH
+  "0xEDfa23602D0EC14714057867A78d01e94176BEA0": 18, // wrsETH
+  "0x236aa50979D5f3De3Bd1Eeb40E81137F22ab794b": 18, // tBTC
+  "0xA88594D404727625A9437C3f886C7643872296AE": 18, // WELL
+  "0x820C137fa70C8691f0e44Dc420a5e53c168921Dc": 18, // USDS
+  "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb": 18, // DAI
+  "0x4200000000000000000000000000000000000006": 18, // WETH
+  "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22": 18, // cbETH
+  "0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452": 18, // wstETH
+  "0x940181a94a35a4569e4529a3cdfb74e38fd98631": 18, // AERO
+  "0x0000000000000000000000000000000000000000": 18, // ETH (native)
+};
+
+export const MTOKENS_UNDERLYING_DECIMALS = {
+  MOONWELL_USDC: 6,
+  MOONWELL_DAI: 18,
+  MOONWELL_WETH: 18,
+  MOONWELL_cbETH: 18,
+  MOONWELL_wstETH: 18,
+  MOONWELL_AERO: 18,
+  MOONWELL_weETH: 18,
+  MOONWELL_cbBTC: 18,
+  MOONWELL_EURC: 6,
+  MOONWELL_wrsETH: 18,
+  MOONWELL_WELL: 18,
+  MOONWELL_USDS: 18,
+  MOONWELL_TBTC: 18,
+};
+
 export const ETH_ROUTER_ABI = [
-    {
-        name: "mint",
-        inputs: [
-            {
-                internalType: "address",
-                name: "receiver",
-                type: "address"
-            }
-        ],
-        outputs: [],
-        stateMutability: "payable",
-        type: "function"
-    }
+  {
+    name: "mint",
+    inputs: [
+      {
+        internalType: "address",
+        name: "receiver",
+        type: "address",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
 ];
 
 export const MTOKEN_ABI = [
-    {
-        type: "function",
-        name: "mint",
-        inputs: [
-            {
-                name: "mintAmount",
-                type: "uint256",
-                internalType: "uint256"
-            }
-        ],
-        outputs: [
-            {
-                name: "",
-                type: "uint256",
-                internalType: "uint256"
-            }
-        ],
-        stateMutability: "nonpayable"
-    },
-    {
-        type: "function",
-        name: "redeemUnderlying",
-        inputs: [
-            {
-                name: "redeemAmount",
-                type: "uint256",
-                internalType: "uint256"
-            }
-        ],
-        outputs: [
-            {
-                name: "",
-                type: "uint256",
-                internalType: "uint256"
-            }
-        ],
-        stateMutability: "nonpayable"
-    },
-]; 
+  {
+    type: "function",
+    name: "mint",
+    inputs: [
+      {
+        name: "mintAmount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "redeemUnderlying",
+    inputs: [
+      {
+        name: "redeemAmount",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "uint256",
+        internalType: "uint256",
+      },
+    ],
+    stateMutability: "nonpayable",
+  },
+];

--- a/typescript/agentkit/src/action-providers/moonwell/constants.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/constants.ts
@@ -1,0 +1,81 @@
+export const MOONWELL_BASE_ADDRESSES = {
+    "0xEdc817A28E8B93B03976FBd4a3dDBc9f7D176c22": "MOONWELL_USDC",
+    "0x73b06D8d18De422E269645eaCe15400DE7462417": "MOONWELL_DAI",
+    "0x628ff693426583D9a7FB391E54366292F509D457": "MOONWELL_WETH",
+    "0x3bf93770f2d4a794c3d9EBEfBAeBAE2a8f09A5E5": "MOONWELL_cbETH",
+    "0x627Fe393Bc6EdDA28e99AE648fD6fF362514304b": "MOONWELL_wstETH",
+    "0x73902f619CEB9B31FD8EFecf435CbDf89E369Ba6": "MOONWELL_AERO",
+    "0xb8051464C8c92209C92F3a4CD9C73746C4c3CFb3": "MOONWELL_weETH",
+    "0xF877ACaFA28c19b96727966690b2f44d35aD5976": "MOONWELL_cbBTC",
+    "0xb682c840B5F4FC58B20769E691A6fa1305A501a2": "MOONWELL_EURC",
+    "0xfC41B49d064Ac646015b459C522820DB9472F4B5": "MOONWELL_wrsETH",
+    "0xdC7810B47eAAb250De623F0eE07764afa5F71ED1": "MOONWELL_WELL",
+    "0xb6419c6C2e60c4025D6D06eE4F913ce89425a357": "MOONWELL_USDS",
+    "0x9A858ebfF1bEb0D3495BB0e2897c1528eD84A218": "MOONWELL_TBTC",
+    "0x70778cfcFC475c7eA0f24cC625Baf6EaE475D0c9": "WETH_ROUTER"
+};
+
+export const MOONWELL_BASE_SEPOLIA_ADDRESSES = {
+    "0x876852425331a113d8E432eFFB3aC5BEf38f033a": "MOONWELL_USDBC",
+    "0x5302EbD8BC32435C823c2e22B04Cd6c45f593e89": "MOONWELL_cbETH",
+    "0x2F39a349A79492a70E152760ce7123A1933eCf28": "MOONWELL_WETH",
+};
+
+export const WETH_ROUTER_ADDRESS = "0x70778cfcFC475c7eA0f24cC625Baf6EaE475D0c9";
+
+export const ETH_ROUTER_ABI = [
+    {
+        name: "mint",
+        inputs: [
+            {
+                internalType: "address",
+                name: "receiver",
+                type: "address"
+            }
+        ],
+        outputs: [],
+        stateMutability: "payable",
+        type: "function"
+    }
+];
+
+export const MTOKEN_ABI = [
+    {
+        type: "function",
+        name: "mint",
+        inputs: [
+            {
+                name: "mintAmount",
+                type: "uint256",
+                internalType: "uint256"
+            }
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256"
+            }
+        ],
+        stateMutability: "nonpayable"
+    },
+    {
+        type: "function",
+        name: "redeemUnderlying",
+        inputs: [
+            {
+                name: "redeemAmount",
+                type: "uint256",
+                internalType: "uint256"
+            }
+        ],
+        outputs: [
+            {
+                name: "",
+                type: "uint256",
+                internalType: "uint256"
+            }
+        ],
+        stateMutability: "nonpayable"
+    },
+]; 

--- a/typescript/agentkit/src/action-providers/moonwell/index.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/index.ts
@@ -1,0 +1,1 @@
+export { moonwellActionProvider } from "./moonwellActionProvider"; 

--- a/typescript/agentkit/src/action-providers/moonwell/index.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/index.ts
@@ -1,1 +1,1 @@
-export { moonwellActionProvider } from "./moonwellActionProvider"; 
+export { moonwellActionProvider } from "./moonwellActionProvider";

--- a/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.test.ts
@@ -1,0 +1,551 @@
+import { encodeFunctionData, parseEther } from "viem";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { approve } from "../../utils";
+import { MoonwellActionProvider } from "./moonwellActionProvider";
+import { MTOKEN_ABI, ETH_ROUTER_ABI, WETH_ROUTER_ADDRESS, MOONWELL_BASE_ADDRESSES } from "./constants";
+import { DepositSchema, WithdrawSchema } from "./schemas";
+import { Network } from "../../network";
+
+const MOCK_MTOKEN_ADDRESS = "0x73902f619CEB9B31FD8EFecf435CbDf89E369Ba6";
+const MOCK_ATOMIC_ASSETS = "1000000000000000000";
+const MOCK_WHOLE_ASSETS = "1.0";
+const MOCK_TOKEN_ADDRESS = "0x4200000000000000000000000000000000000006";
+const MOCK_TX_HASH = "0xabcdef1234567890";
+const MOCK_RECEIPT = { status: 1, blockNumber: 1234567 };
+const WETH_MTOKEN = "0x628ff693426583D9a7FB391E54366292F509D457";
+
+jest.mock("../../utils");
+const mockApprove = approve as jest.MockedFunction<typeof approve>;
+
+describe("Moonwell Action Provider", () => {
+    const actionProvider = new MoonwellActionProvider();
+    let mockWallet: jest.Mocked<EvmWalletProvider>;
+
+    beforeEach(() => {
+        mockWallet = {
+            getAddress: jest.fn().mockReturnValue(MOCK_TOKEN_ADDRESS),
+            getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" } as Network),
+            sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+            waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
+        } as unknown as jest.Mocked<EvmWalletProvider>;
+
+        mockApprove.mockResolvedValue("Approval successful");
+    });
+
+    describe("Deposit Schema", () => {
+        it("should successfully parse valid input", () => {
+            const validInput = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            const result = DepositSchema.safeParse(validInput);
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual(validInput);
+            }
+        });
+
+        it("should fail parsing empty input", () => {
+            const emptyInput = {};
+            const result = DepositSchema.safeParse(emptyInput);
+
+            expect(result.success).toBe(false);
+        });
+
+        it("should fail with invalid mToken address", () => {
+            const invalidInput = {
+                mTokenAddress: "not_an_address",
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+            const result = DepositSchema.safeParse(invalidInput);
+
+            expect(result.success).toBe(false);
+        });
+
+        it("should handle valid asset string formats", () => {
+            const validInput = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            const validInputs = [
+                { ...validInput, assets: "1.5" },
+                { ...validInput, assets: "0.00001" },
+                { ...validInput, assets: "1000" },
+            ];
+
+            validInputs.forEach(input => {
+                const result = DepositSchema.safeParse(input);
+                expect(result.success).toBe(true);
+            });
+        });
+
+        it("should reject invalid asset strings", () => {
+            const validInput = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            const invalidInputs = [
+                { ...validInput, assets: "" },
+                { ...validInput, assets: "1,000" },
+                { ...validInput, assets: "1.2.3" },
+                { ...validInput, assets: "abc" },
+            ];
+
+            invalidInputs.forEach(input => {
+                const result = DepositSchema.safeParse(input);
+                expect(result.success).toBe(false);
+            });
+        });
+    });
+
+    describe("Withdraw Schema", () => {
+        it("should successfully parse valid input", () => {
+            const validInput = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_ATOMIC_ASSETS,
+            };
+
+            const result = WithdrawSchema.safeParse(validInput);
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data).toEqual(validInput);
+            }
+        });
+
+        it("should fail parsing empty input", () => {
+            const emptyInput = {};
+            const result = WithdrawSchema.safeParse(emptyInput);
+
+            expect(result.success).toBe(false);
+        });
+
+        it("should fail with invalid mToken address", () => {
+            const invalidInput = {
+                mTokenAddress: "not_an_address",
+                assets: MOCK_ATOMIC_ASSETS,
+            };
+            const result = WithdrawSchema.safeParse(invalidInput);
+
+            expect(result.success).toBe(false);
+        });
+
+        it("should handle valid asset string formats", () => {
+            const validInput = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_ATOMIC_ASSETS,
+            };
+
+            const validInputs = [
+                { ...validInput, assets: "1000000000000000000" },
+                { ...validInput, assets: "1" },
+                { ...validInput, assets: "999999999999999999999" },
+            ];
+
+            validInputs.forEach(input => {
+                const result = WithdrawSchema.safeParse(input);
+                expect(result.success).toBe(true);
+            });
+        });
+
+        it("should reject invalid asset strings", () => {
+            const validInput = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_ATOMIC_ASSETS,
+            };
+
+            const invalidInputs = [
+                { ...validInput, assets: "" },
+                { ...validInput, assets: "1.5" },
+                { ...validInput, assets: "1,000" },
+                { ...validInput, assets: "abc" },
+            ];
+
+            invalidInputs.forEach(input => {
+                const result = WithdrawSchema.safeParse(input);
+                expect(result.success).toBe(false);
+            });
+        });
+    });
+
+    describe("deposit", () => {
+        it("should successfully deposit to Moonwell MToken", async () => {
+            const args = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            mockWallet.getNetwork.mockReturnValue({
+                protocolFamily: "evm",
+                networkId: "base-mainnet",
+            } as Network);
+
+            const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+            const response = await actionProvider.deposit(mockWallet, args);
+
+            expect(mockApprove).toHaveBeenCalledWith(
+                mockWallet,
+                MOCK_TOKEN_ADDRESS,
+                MOCK_MTOKEN_ADDRESS,
+                atomicAssets,
+            );
+
+            expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+                to: MOCK_MTOKEN_ADDRESS as `0x${string}`,
+                data: encodeFunctionData({
+                    abi: MTOKEN_ABI,
+                    functionName: "mint",
+                    args: [atomicAssets],
+                }),
+            });
+
+            expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+            expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
+            expect(response).toContain(MOCK_TX_HASH);
+            expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+        });
+
+        it("should successfully deposit to Moonwell MToken on sepolia", async () => {
+            const args = {
+                mTokenAddress: "0x2F39a349A79492a70E152760ce7123A1933eCf28", // Sepolia WETH mToken
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            mockWallet.getNetwork.mockReturnValue({
+                protocolFamily: "evm",
+                networkId: "base-sepolia",
+            } as Network);
+
+            const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+            const response = await actionProvider.deposit(mockWallet, args);
+
+            expect(mockApprove).toHaveBeenCalledWith(
+                mockWallet,
+                MOCK_TOKEN_ADDRESS,
+                args.mTokenAddress,
+                atomicAssets,
+            );
+
+            expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+                to: args.mTokenAddress as `0x${string}`,
+                data: encodeFunctionData({
+                    abi: MTOKEN_ABI,
+                    functionName: "mint",
+                    args: [atomicAssets],
+                }),
+            });
+
+            expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+            expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
+            expect(response).toContain(MOCK_TX_HASH);
+            expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+        });
+
+        it("should reject deposit with zero assets amount", async () => {
+            const args = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: "0.0",
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            const response = await actionProvider.deposit(mockWallet, args);
+
+            expect(response).toBe("Error: Assets amount must be greater than 0");
+            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should reject deposit with invalid MToken address not in MOONWELL_BASE_ADDRESSES", async () => {
+            const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_ADDRESSES
+            const args = {
+                mTokenAddress: invalidMTokenAddress,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            mockWallet.getNetwork.mockReturnValue({
+                protocolFamily: "evm",
+                networkId: "base-mainnet",
+            } as Network);
+
+            const response = await actionProvider.deposit(mockWallet, args);
+
+            expect(response).toBe("Error: Invalid MToken address");
+            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should reject deposit with invalid MToken address not in MOONWELL_BASE_SEPOLIA_ADDRESSES", async () => {
+            const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_SEPOLIA_ADDRESSES
+            const args = {
+                mTokenAddress: invalidMTokenAddress,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            mockWallet.getNetwork.mockReturnValue({
+                protocolFamily: "evm",
+                networkId: "base-sepolia",
+            } as Network);
+
+            const response = await actionProvider.deposit(mockWallet, args);
+
+            expect(response).toBe("Error: Invalid MToken address");
+            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should handle approval failure", async () => {
+            const args = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            mockApprove.mockResolvedValue("Error: Approval failed");
+
+            const response = await actionProvider.deposit(mockWallet, args);
+
+            expect(mockApprove).toHaveBeenCalled();
+            expect(response).toContain("Error approving Moonwell MToken as spender: Error: Approval failed");
+            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should handle deposit errors", async () => {
+            const args = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_WHOLE_ASSETS,
+                tokenAddress: MOCK_TOKEN_ADDRESS,
+            };
+
+            mockWallet.sendTransaction.mockRejectedValue(new Error("Failed to deposit"));
+
+            const response = await actionProvider.deposit(mockWallet, args);
+
+            expect(mockApprove).toHaveBeenCalled();
+            expect(mockWallet.sendTransaction).toHaveBeenCalled();
+            expect(response).toContain("Error depositing to Moonwell MToken: Error: Failed to deposit");
+        });
+
+        describe("ETH deposits via router", () => {
+            beforeEach(() => {
+                // Clear all mocks before each test
+                jest.clearAllMocks();
+                mockWallet = {
+                    getAddress: jest.fn().mockReturnValue(MOCK_TOKEN_ADDRESS),
+                    getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" } as Network),
+                    sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+                    waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
+                } as unknown as jest.Mocked<EvmWalletProvider>;
+            });
+
+            it("should use router for ETH deposits on mainnet", async () => {
+                const args = {
+                    mTokenAddress: WETH_MTOKEN,
+                    assets: MOCK_WHOLE_ASSETS,
+                    tokenAddress: MOCK_TOKEN_ADDRESS,
+                };
+
+                mockWallet.getNetwork.mockReturnValue({
+                    protocolFamily: "evm",
+                    networkId: "base-mainnet",
+                } as Network);
+
+                const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+                const response = await actionProvider.deposit(mockWallet, args);
+
+                // Should not call approve for ETH deposits
+                expect(mockApprove).not.toHaveBeenCalled();
+
+                expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+                    to: WETH_ROUTER_ADDRESS as `0x${string}`,
+                    data: encodeFunctionData({
+                        abi: ETH_ROUTER_ABI,
+                        functionName: "mint",
+                        args: [MOCK_TOKEN_ADDRESS],
+                    }),
+                    value: atomicAssets,
+                });
+
+                expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+                expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS} ETH to Moonwell WETH via router`);
+                expect(response).toContain(MOCK_TX_HASH);
+                expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+            });
+
+            it("should not use router for ETH deposits on sepolia", async () => {
+                // Clear mocks before test
+                jest.clearAllMocks();
+                mockApprove.mockResolvedValue("Approval successful");
+
+                const args = {
+                    mTokenAddress: "0x2F39a349A79492a70E152760ce7123A1933eCf28", // Sepolia WETH mToken
+                    assets: MOCK_WHOLE_ASSETS,
+                    tokenAddress: MOCK_TOKEN_ADDRESS,
+                };
+
+                mockWallet.getNetwork.mockReturnValue({
+                    protocolFamily: "evm",
+                    networkId: "base-sepolia",
+                } as Network);
+
+                const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+                const response = await actionProvider.deposit(mockWallet, args);
+
+                // Should call approve for token deposits on non-mainnet
+                expect(mockApprove).toHaveBeenCalledWith(
+                    mockWallet,
+                    MOCK_TOKEN_ADDRESS,
+                    args.mTokenAddress,
+                    atomicAssets,
+                );
+
+                expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+                    to: args.mTokenAddress as `0x${string}`,
+                    data: encodeFunctionData({
+                        abi: MTOKEN_ABI,
+                        functionName: "mint",
+                        args: [atomicAssets],
+                    }),
+                });
+
+                expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+                expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
+                expect(response).toContain(MOCK_TX_HASH);
+                expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+            });
+
+            it("should handle errors in ETH deposit via router", async () => {
+                const args = {
+                    mTokenAddress: WETH_MTOKEN,
+                    assets: MOCK_WHOLE_ASSETS,
+                    tokenAddress: MOCK_TOKEN_ADDRESS,
+                };
+
+                mockWallet.getNetwork.mockReturnValue({
+                    protocolFamily: "evm",
+                    networkId: "base-mainnet",
+                } as Network);
+
+                mockWallet.sendTransaction.mockImplementation(() => {
+                    throw new Error("Failed to deposit ETH");
+                });
+
+                const response = await actionProvider.deposit(mockWallet, args);
+
+                // Should not call approve for ETH deposits on mainnet
+                expect(mockApprove).not.toHaveBeenCalled();
+                expect(response).toContain("Error depositing to Moonwell MToken: Error: Failed to deposit ETH");
+            });
+        });
+    });
+
+    describe("withdraw", () => {
+        it("should successfully withdraw from Moonwell MToken", async () => {
+            const args = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_ATOMIC_ASSETS,
+            };
+
+            const response = await actionProvider.withdraw(mockWallet, args);
+
+            expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+                to: MOCK_MTOKEN_ADDRESS as `0x${string}`,
+                data: encodeFunctionData({
+                    abi: MTOKEN_ABI,
+                    functionName: "redeemUnderlying",
+                    args: [BigInt(MOCK_ATOMIC_ASSETS)],
+                }),
+            });
+
+            expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+            expect(response).toContain(`Withdrawn ${MOCK_ATOMIC_ASSETS}`);
+            expect(response).toContain(MOCK_TX_HASH);
+            expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+        });
+
+        it("should reject withdrawal with zero assets amount", async () => {
+            const args = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: "0",
+            };
+
+            const response = await actionProvider.withdraw(mockWallet, args);
+
+            expect(response).toBe("Error: Assets amount must be greater than 0");
+            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should reject withdrawal with invalid MToken address not in MOONWELL_BASE_ADDRESSES", async () => {
+            const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_ADDRESSES
+            const args = {
+                mTokenAddress: invalidMTokenAddress,
+                assets: MOCK_ATOMIC_ASSETS,
+            };
+
+            const response = await actionProvider.withdraw(mockWallet, args);
+
+            expect(response).toBe("Error: Invalid MToken address");
+            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should handle errors when withdrawing", async () => {
+            const args = {
+                mTokenAddress: MOCK_MTOKEN_ADDRESS,
+                assets: MOCK_ATOMIC_ASSETS,
+            };
+
+            mockWallet.sendTransaction.mockRejectedValue(new Error("Failed to withdraw"));
+
+            const response = await actionProvider.withdraw(mockWallet, args);
+
+            expect(mockWallet.sendTransaction).toHaveBeenCalled();
+            expect(response).toContain("Error withdrawing from Moonwell MToken: Error: Failed to withdraw");
+        });
+    });
+
+    describe("supportsNetwork", () => {
+        it("should return true for Base Mainnet", () => {
+            const result = actionProvider.supportsNetwork({
+                protocolFamily: "evm",
+                networkId: "base-mainnet",
+            });
+            expect(result).toBe(true);
+        });
+
+        it("should return true for Base Sepolia", () => {
+            const result = actionProvider.supportsNetwork({
+                protocolFamily: "evm",
+                networkId: "base-sepolia",
+            });
+            expect(result).toBe(true);
+        });
+
+        it("should return false for other EVM networks", () => {
+            const result = actionProvider.supportsNetwork({
+                protocolFamily: "evm",
+                networkId: "ethereum",
+            });
+            expect(result).toBe(false);
+        });
+
+        it("should return false for non-EVM networks", () => {
+            const result = actionProvider.supportsNetwork({
+                protocolFamily: "bitcoin",
+                networkId: "base-mainnet",
+            });
+            expect(result).toBe(false);
+        });
+    });
+});

--- a/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.test.ts
@@ -1,9 +1,15 @@
-import { encodeFunctionData, parseEther } from "viem";
+import { encodeFunctionData, parseEther, parseUnits } from "viem";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { approve } from "../../utils";
 import { MoonwellActionProvider } from "./moonwellActionProvider";
-import { MTOKEN_ABI, ETH_ROUTER_ABI, WETH_ROUTER_ADDRESS, MOONWELL_BASE_ADDRESSES } from "./constants";
-import { DepositSchema, WithdrawSchema } from "./schemas";
+import {
+  MTOKEN_ABI,
+  ETH_ROUTER_ABI,
+  WETH_ROUTER_ADDRESS,
+  MOONWELL_BASE_ADDRESSES,
+  MTOKENS_UNDERLYING_DECIMALS,
+} from "./constants";
+import { MintSchema, RedeemSchema } from "./schemas";
 import { Network } from "../../network";
 
 const MOCK_MTOKEN_ADDRESS = "0x73902f619CEB9B31FD8EFecf435CbDf89E369Ba6";
@@ -11,541 +17,571 @@ const MOCK_ATOMIC_ASSETS = "1000000000000000000";
 const MOCK_WHOLE_ASSETS = "1.0";
 const MOCK_TOKEN_ADDRESS = "0x4200000000000000000000000000000000000006";
 const MOCK_TX_HASH = "0xabcdef1234567890";
-const MOCK_RECEIPT = { status: 1, blockNumber: 1234567 };
+const MOCK_RECEIPT = { status: "success", blockNumber: 1234567 };
 const WETH_MTOKEN = "0x628ff693426583D9a7FB391E54366292F509D457";
 
 jest.mock("../../utils");
 const mockApprove = approve as jest.MockedFunction<typeof approve>;
 
 describe("Moonwell Action Provider", () => {
-    const actionProvider = new MoonwellActionProvider();
-    let mockWallet: jest.Mocked<EvmWalletProvider>;
+  const actionProvider = new MoonwellActionProvider();
+  let mockWallet: jest.Mocked<EvmWalletProvider>;
+  let consoleErrorSpy: jest.SpyInstance;
 
-    beforeEach(() => {
+  beforeEach(() => {
+    // Mock console.error to suppress debug logs
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mockWallet = {
+      getAddress: jest.fn().mockReturnValue(MOCK_TOKEN_ADDRESS),
+      getNetwork: jest
+        .fn()
+        .mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" } as Network),
+      sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+      waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
+    } as unknown as jest.Mocked<EvmWalletProvider>;
+
+    mockApprove.mockResolvedValue("Approval successful");
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("Mint Schema", () => {
+    it("should successfully parse valid input", () => {
+      const validInput = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      const result = MintSchema.safeParse(validInput);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validInput);
+      }
+    });
+
+    it("should fail parsing empty input", () => {
+      const emptyInput = {};
+      const result = MintSchema.safeParse(emptyInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail with invalid mToken address", () => {
+      const invalidInput = {
+        mTokenAddress: "not_an_address",
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+      const result = MintSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should handle valid asset string formats", () => {
+      const validInput = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      const validInputs = [
+        { ...validInput, assets: "1.5" },
+        { ...validInput, assets: "0.00001" },
+        { ...validInput, assets: "1000" },
+      ];
+
+      validInputs.forEach(input => {
+        const result = MintSchema.safeParse(input);
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it("should reject invalid asset strings", () => {
+      const validInput = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      const invalidInputs = [
+        { ...validInput, assets: "" },
+        { ...validInput, assets: "1,000" },
+        { ...validInput, assets: "1.2.3" },
+        { ...validInput, assets: "abc" },
+      ];
+
+      invalidInputs.forEach(input => {
+        const result = MintSchema.safeParse(input);
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe("Redeem Schema", () => {
+    it("should successfully parse valid input", () => {
+      const validInput = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_ATOMIC_ASSETS,
+      };
+
+      const result = RedeemSchema.safeParse(validInput);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(validInput);
+      }
+    });
+
+    it("should fail parsing empty input", () => {
+      const emptyInput = {};
+      const result = RedeemSchema.safeParse(emptyInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail with invalid mToken address", () => {
+      const invalidInput = {
+        mTokenAddress: "not_an_address",
+        assets: MOCK_ATOMIC_ASSETS,
+      };
+      const result = RedeemSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should handle valid asset string formats", () => {
+      const validInput = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_ATOMIC_ASSETS,
+      };
+
+      const validInputs = [
+        { ...validInput, assets: "1000000000000000000" },
+        { ...validInput, assets: "1" },
+        { ...validInput, assets: "999999999999999999999" },
+      ];
+
+      validInputs.forEach(input => {
+        const result = RedeemSchema.safeParse(input);
+        expect(result.success).toBe(true);
+      });
+    });
+
+    it("should reject invalid asset strings", () => {
+      const validInput = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_ATOMIC_ASSETS,
+      };
+
+      const invalidInputs = [
+        { ...validInput, assets: "" },
+        { ...validInput, assets: "1,000" },
+        { ...validInput, assets: "1.2.3" },
+        { ...validInput, assets: "abc" },
+        { ...validInput, assets: "-1.5" },
+      ];
+
+      invalidInputs.forEach(input => {
+        const result = RedeemSchema.safeParse(input);
+        expect(result.success).toBe(false);
+      });
+    });
+  });
+
+  describe("mint", () => {
+    it("should successfully deposit to Moonwell MToken", async () => {
+      const args = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      mockWallet.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-mainnet",
+      } as Network);
+
+      const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+      const response = await actionProvider.mint(mockWallet, args);
+
+      expect(mockApprove).toHaveBeenCalledWith(
+        mockWallet,
+        MOCK_TOKEN_ADDRESS,
+        MOCK_MTOKEN_ADDRESS,
+        atomicAssets,
+      );
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+        to: MOCK_MTOKEN_ADDRESS as `0x${string}`,
+        data: encodeFunctionData({
+          abi: MTOKEN_ABI,
+          functionName: "mint",
+          args: [atomicAssets],
+        }),
+        value: 0n,
+      });
+
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+      expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
+      expect(response).toContain(MOCK_TX_HASH);
+      expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+    });
+
+    it("should successfully deposit to Moonwell MToken on sepolia", async () => {
+      const args = {
+        mTokenAddress: "0x2F39a349A79492a70E152760ce7123A1933eCf28", // Sepolia WETH mToken
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      mockWallet.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      } as Network);
+
+      const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+      const response = await actionProvider.mint(mockWallet, args);
+
+      expect(mockApprove).toHaveBeenCalledWith(
+        mockWallet,
+        MOCK_TOKEN_ADDRESS,
+        args.mTokenAddress,
+        atomicAssets,
+      );
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+        to: args.mTokenAddress as `0x${string}`,
+        data: encodeFunctionData({
+          abi: MTOKEN_ABI,
+          functionName: "mint",
+          args: [atomicAssets],
+        }),
+        value: 0n,
+      });
+
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+      expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
+      expect(response).toContain(MOCK_TX_HASH);
+      expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+    });
+
+    it("should reject deposit with zero assets amount", async () => {
+      const args = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: "0.0",
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      const response = await actionProvider.mint(mockWallet, args);
+
+      expect(response).toBe("Error: Assets amount must be greater than 0");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should reject deposit with invalid MToken address not in MOONWELL_BASE_ADDRESSES", async () => {
+      const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_ADDRESSES
+      const args = {
+        mTokenAddress: invalidMTokenAddress,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      mockWallet.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-mainnet",
+      } as Network);
+
+      const response = await actionProvider.mint(mockWallet, args);
+
+      expect(response).toBe("Error: Invalid MToken address");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should reject deposit with invalid MToken address not in MOONWELL_BASE_SEPOLIA_ADDRESSES", async () => {
+      const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_SEPOLIA_ADDRESSES
+      const args = {
+        mTokenAddress: invalidMTokenAddress,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      mockWallet.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      } as Network);
+
+      const response = await actionProvider.mint(mockWallet, args);
+
+      expect(response).toBe("Error: Invalid MToken address");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should handle approval failure", async () => {
+      const args = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      mockApprove.mockResolvedValue("Error: Approval failed");
+
+      const response = await actionProvider.mint(mockWallet, args);
+
+      expect(mockApprove).toHaveBeenCalled();
+      expect(response).toContain(
+        "Error approving Moonwell MToken as spender: Error: Approval failed",
+      );
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should handle deposit errors", async () => {
+      const args = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+      };
+
+      const error = new Error("Failed to deposit");
+      mockWallet.sendTransaction.mockRejectedValue(error);
+
+      const response = await actionProvider.mint(mockWallet, args);
+
+      expect(mockApprove).toHaveBeenCalled();
+      expect(mockWallet.sendTransaction).toHaveBeenCalled();
+      expect(response).toBe("Error minting Moonwell MToken: Failed to deposit");
+      expect(consoleErrorSpy).toHaveBeenCalledWith("DEBUG - Mint error:", error);
+    });
+
+    describe("ETH deposits via router", () => {
+      beforeEach(() => {
+        // Clear all mocks before each test
+        jest.clearAllMocks();
         mockWallet = {
-            getAddress: jest.fn().mockReturnValue(MOCK_TOKEN_ADDRESS),
-            getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" } as Network),
-            sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
-            waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
+          getAddress: jest.fn().mockReturnValue(MOCK_TOKEN_ADDRESS),
+          getNetwork: jest
+            .fn()
+            .mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" } as Network),
+          sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+          waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
         } as unknown as jest.Mocked<EvmWalletProvider>;
+      });
 
+      it("should use router for ETH deposits on mainnet", async () => {
+        const args = {
+          mTokenAddress: WETH_MTOKEN,
+          assets: MOCK_WHOLE_ASSETS,
+          tokenAddress: MOCK_TOKEN_ADDRESS,
+        };
+
+        mockWallet.getNetwork.mockReturnValue({
+          protocolFamily: "evm",
+          networkId: "base-mainnet",
+        } as Network);
+
+        const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+        const response = await actionProvider.mint(mockWallet, args);
+
+        // Should not call approve for ETH deposits
+        expect(mockApprove).not.toHaveBeenCalled();
+
+        expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+          to: WETH_ROUTER_ADDRESS as `0x${string}`,
+          data: encodeFunctionData({
+            abi: ETH_ROUTER_ABI,
+            functionName: "mint",
+            args: [MOCK_TOKEN_ADDRESS],
+          }),
+          value: atomicAssets,
+        });
+
+        expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+        expect(response).toContain(
+          `Deposited ${MOCK_WHOLE_ASSETS} ETH to Moonwell WETH via router`,
+        );
+        expect(response).toContain(MOCK_TX_HASH);
+        expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+      });
+
+      it("should not use router for ETH deposits on sepolia", async () => {
+        // Clear mocks before test
+        jest.clearAllMocks();
         mockApprove.mockResolvedValue("Approval successful");
+
+        const args = {
+          mTokenAddress: "0x2F39a349A79492a70E152760ce7123A1933eCf28", // Sepolia WETH mToken
+          assets: MOCK_WHOLE_ASSETS,
+          tokenAddress: MOCK_TOKEN_ADDRESS,
+        };
+
+        mockWallet.getNetwork.mockReturnValue({
+          protocolFamily: "evm",
+          networkId: "base-sepolia",
+        } as Network);
+
+        const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+
+        const response = await actionProvider.mint(mockWallet, args);
+
+        // Should call approve for token deposits on non-mainnet
+        expect(mockApprove).toHaveBeenCalledWith(
+          mockWallet,
+          MOCK_TOKEN_ADDRESS,
+          args.mTokenAddress,
+          atomicAssets,
+        );
+
+        expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+          to: args.mTokenAddress as `0x${string}`,
+          data: encodeFunctionData({
+            abi: MTOKEN_ABI,
+            functionName: "mint",
+            args: [atomicAssets],
+          }),
+          value: 0n,
+        });
+
+        expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+        expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
+        expect(response).toContain(MOCK_TX_HASH);
+        expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+      });
+
+      it("should handle errors in ETH deposit via router", async () => {
+        const args = {
+          mTokenAddress: WETH_MTOKEN,
+          assets: MOCK_WHOLE_ASSETS,
+          tokenAddress: MOCK_TOKEN_ADDRESS,
+        };
+
+        mockWallet.getNetwork.mockReturnValue({
+          protocolFamily: "evm",
+          networkId: "base-mainnet",
+        } as Network);
+
+        const error = new Error("Failed to deposit ETH");
+        mockWallet.sendTransaction.mockRejectedValue(error);
+
+        const response = await actionProvider.mint(mockWallet, args);
+
+        // Should not call approve for ETH deposits on mainnet
+        expect(mockApprove).not.toHaveBeenCalled();
+        expect(response).toBe("Error minting Moonwell MToken: Failed to deposit ETH");
+        expect(consoleErrorSpy).toHaveBeenCalledWith("DEBUG - Mint error:", error);
+      });
+    });
+  });
+
+  describe("redeem", () => {
+    it("should successfully redeem from Moonwell MToken", async () => {
+      const args = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: "1.0",
+      };
+
+      const decimals = MTOKENS_UNDERLYING_DECIMALS[MOONWELL_BASE_ADDRESSES[args.mTokenAddress]];
+      const atomicAssets = parseUnits(args.assets, decimals);
+
+      const response = await actionProvider.redeem(mockWallet, args);
+
+      const expectedData = encodeFunctionData({
+        abi: MTOKEN_ABI,
+        functionName: "redeemUnderlying",
+        args: [atomicAssets],
+      });
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+        to: MOCK_MTOKEN_ADDRESS as `0x${string}`,
+        data: expectedData,
+        value: 0n,
+      });
+
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+      expect(response).toContain(`Redeemed ${args.assets}`);
+      expect(response).toContain(MOCK_TX_HASH);
+      expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
     });
 
-    describe("Deposit Schema", () => {
-        it("should successfully parse valid input", () => {
-            const validInput = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
+    it("should reject redeem with zero assets amount", async () => {
+      const args = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: "0",
+      };
 
-            const result = DepositSchema.safeParse(validInput);
+      const response = await actionProvider.redeem(mockWallet, args);
 
-            expect(result.success).toBe(true);
-            if (result.success) {
-                expect(result.data).toEqual(validInput);
-            }
-        });
-
-        it("should fail parsing empty input", () => {
-            const emptyInput = {};
-            const result = DepositSchema.safeParse(emptyInput);
-
-            expect(result.success).toBe(false);
-        });
-
-        it("should fail with invalid mToken address", () => {
-            const invalidInput = {
-                mTokenAddress: "not_an_address",
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-            const result = DepositSchema.safeParse(invalidInput);
-
-            expect(result.success).toBe(false);
-        });
-
-        it("should handle valid asset string formats", () => {
-            const validInput = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            const validInputs = [
-                { ...validInput, assets: "1.5" },
-                { ...validInput, assets: "0.00001" },
-                { ...validInput, assets: "1000" },
-            ];
-
-            validInputs.forEach(input => {
-                const result = DepositSchema.safeParse(input);
-                expect(result.success).toBe(true);
-            });
-        });
-
-        it("should reject invalid asset strings", () => {
-            const validInput = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            const invalidInputs = [
-                { ...validInput, assets: "" },
-                { ...validInput, assets: "1,000" },
-                { ...validInput, assets: "1.2.3" },
-                { ...validInput, assets: "abc" },
-            ];
-
-            invalidInputs.forEach(input => {
-                const result = DepositSchema.safeParse(input);
-                expect(result.success).toBe(false);
-            });
-        });
+      expect(response).toBe("Error: Assets amount must be greater than 0");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
     });
 
-    describe("Withdraw Schema", () => {
-        it("should successfully parse valid input", () => {
-            const validInput = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_ATOMIC_ASSETS,
-            };
+    it("should reject redeem with invalid MToken address not in MOONWELL_BASE_ADDRESSES", async () => {
+      const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_ADDRESSES
+      const args = {
+        mTokenAddress: invalidMTokenAddress,
+        assets: MOCK_ATOMIC_ASSETS,
+      };
 
-            const result = WithdrawSchema.safeParse(validInput);
+      const response = await actionProvider.redeem(mockWallet, args);
 
-            expect(result.success).toBe(true);
-            if (result.success) {
-                expect(result.data).toEqual(validInput);
-            }
-        });
-
-        it("should fail parsing empty input", () => {
-            const emptyInput = {};
-            const result = WithdrawSchema.safeParse(emptyInput);
-
-            expect(result.success).toBe(false);
-        });
-
-        it("should fail with invalid mToken address", () => {
-            const invalidInput = {
-                mTokenAddress: "not_an_address",
-                assets: MOCK_ATOMIC_ASSETS,
-            };
-            const result = WithdrawSchema.safeParse(invalidInput);
-
-            expect(result.success).toBe(false);
-        });
-
-        it("should handle valid asset string formats", () => {
-            const validInput = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_ATOMIC_ASSETS,
-            };
-
-            const validInputs = [
-                { ...validInput, assets: "1000000000000000000" },
-                { ...validInput, assets: "1" },
-                { ...validInput, assets: "999999999999999999999" },
-            ];
-
-            validInputs.forEach(input => {
-                const result = WithdrawSchema.safeParse(input);
-                expect(result.success).toBe(true);
-            });
-        });
-
-        it("should reject invalid asset strings", () => {
-            const validInput = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_ATOMIC_ASSETS,
-            };
-
-            const invalidInputs = [
-                { ...validInput, assets: "" },
-                { ...validInput, assets: "1.5" },
-                { ...validInput, assets: "1,000" },
-                { ...validInput, assets: "abc" },
-            ];
-
-            invalidInputs.forEach(input => {
-                const result = WithdrawSchema.safeParse(input);
-                expect(result.success).toBe(false);
-            });
-        });
+      expect(response).toBe("Error: Invalid MToken address");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
     });
 
-    describe("deposit", () => {
-        it("should successfully deposit to Moonwell MToken", async () => {
-            const args = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
+    it("should handle errors when redeeming", async () => {
+      const args = {
+        mTokenAddress: MOCK_MTOKEN_ADDRESS,
+        assets: MOCK_ATOMIC_ASSETS,
+      };
 
-            mockWallet.getNetwork.mockReturnValue({
-                protocolFamily: "evm",
-                networkId: "base-mainnet",
-            } as Network);
+      const error = new Error("Failed to redeem");
+      mockWallet.sendTransaction.mockRejectedValue(error);
 
-            const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
+      const response = await actionProvider.redeem(mockWallet, args);
 
-            const response = await actionProvider.deposit(mockWallet, args);
+      expect(mockWallet.sendTransaction).toHaveBeenCalled();
+      expect(response).toBe("Error redeeming from Moonwell MToken: Failed to redeem");
+      expect(consoleErrorSpy).toHaveBeenCalledWith("DEBUG - Redeem error:", error);
+    });
+  });
 
-            expect(mockApprove).toHaveBeenCalledWith(
-                mockWallet,
-                MOCK_TOKEN_ADDRESS,
-                MOCK_MTOKEN_ADDRESS,
-                atomicAssets,
-            );
-
-            expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-                to: MOCK_MTOKEN_ADDRESS as `0x${string}`,
-                data: encodeFunctionData({
-                    abi: MTOKEN_ABI,
-                    functionName: "mint",
-                    args: [atomicAssets],
-                }),
-            });
-
-            expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
-            expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
-            expect(response).toContain(MOCK_TX_HASH);
-            expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
-        });
-
-        it("should successfully deposit to Moonwell MToken on sepolia", async () => {
-            const args = {
-                mTokenAddress: "0x2F39a349A79492a70E152760ce7123A1933eCf28", // Sepolia WETH mToken
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            mockWallet.getNetwork.mockReturnValue({
-                protocolFamily: "evm",
-                networkId: "base-sepolia",
-            } as Network);
-
-            const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
-
-            const response = await actionProvider.deposit(mockWallet, args);
-
-            expect(mockApprove).toHaveBeenCalledWith(
-                mockWallet,
-                MOCK_TOKEN_ADDRESS,
-                args.mTokenAddress,
-                atomicAssets,
-            );
-
-            expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-                to: args.mTokenAddress as `0x${string}`,
-                data: encodeFunctionData({
-                    abi: MTOKEN_ABI,
-                    functionName: "mint",
-                    args: [atomicAssets],
-                }),
-            });
-
-            expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
-            expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
-            expect(response).toContain(MOCK_TX_HASH);
-            expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
-        });
-
-        it("should reject deposit with zero assets amount", async () => {
-            const args = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: "0.0",
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            const response = await actionProvider.deposit(mockWallet, args);
-
-            expect(response).toBe("Error: Assets amount must be greater than 0");
-            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
-        });
-
-        it("should reject deposit with invalid MToken address not in MOONWELL_BASE_ADDRESSES", async () => {
-            const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_ADDRESSES
-            const args = {
-                mTokenAddress: invalidMTokenAddress,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            mockWallet.getNetwork.mockReturnValue({
-                protocolFamily: "evm",
-                networkId: "base-mainnet",
-            } as Network);
-
-            const response = await actionProvider.deposit(mockWallet, args);
-
-            expect(response).toBe("Error: Invalid MToken address");
-            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
-        });
-
-        it("should reject deposit with invalid MToken address not in MOONWELL_BASE_SEPOLIA_ADDRESSES", async () => {
-            const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_SEPOLIA_ADDRESSES
-            const args = {
-                mTokenAddress: invalidMTokenAddress,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            mockWallet.getNetwork.mockReturnValue({
-                protocolFamily: "evm",
-                networkId: "base-sepolia",
-            } as Network);
-
-            const response = await actionProvider.deposit(mockWallet, args);
-
-            expect(response).toBe("Error: Invalid MToken address");
-            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
-        });
-
-        it("should handle approval failure", async () => {
-            const args = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            mockApprove.mockResolvedValue("Error: Approval failed");
-
-            const response = await actionProvider.deposit(mockWallet, args);
-
-            expect(mockApprove).toHaveBeenCalled();
-            expect(response).toContain("Error approving Moonwell MToken as spender: Error: Approval failed");
-            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
-        });
-
-        it("should handle deposit errors", async () => {
-            const args = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_WHOLE_ASSETS,
-                tokenAddress: MOCK_TOKEN_ADDRESS,
-            };
-
-            mockWallet.sendTransaction.mockRejectedValue(new Error("Failed to deposit"));
-
-            const response = await actionProvider.deposit(mockWallet, args);
-
-            expect(mockApprove).toHaveBeenCalled();
-            expect(mockWallet.sendTransaction).toHaveBeenCalled();
-            expect(response).toContain("Error depositing to Moonwell MToken: Error: Failed to deposit");
-        });
-
-        describe("ETH deposits via router", () => {
-            beforeEach(() => {
-                // Clear all mocks before each test
-                jest.clearAllMocks();
-                mockWallet = {
-                    getAddress: jest.fn().mockReturnValue(MOCK_TOKEN_ADDRESS),
-                    getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" } as Network),
-                    sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
-                    waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
-                } as unknown as jest.Mocked<EvmWalletProvider>;
-            });
-
-            it("should use router for ETH deposits on mainnet", async () => {
-                const args = {
-                    mTokenAddress: WETH_MTOKEN,
-                    assets: MOCK_WHOLE_ASSETS,
-                    tokenAddress: MOCK_TOKEN_ADDRESS,
-                };
-
-                mockWallet.getNetwork.mockReturnValue({
-                    protocolFamily: "evm",
-                    networkId: "base-mainnet",
-                } as Network);
-
-                const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
-
-                const response = await actionProvider.deposit(mockWallet, args);
-
-                // Should not call approve for ETH deposits
-                expect(mockApprove).not.toHaveBeenCalled();
-
-                expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-                    to: WETH_ROUTER_ADDRESS as `0x${string}`,
-                    data: encodeFunctionData({
-                        abi: ETH_ROUTER_ABI,
-                        functionName: "mint",
-                        args: [MOCK_TOKEN_ADDRESS],
-                    }),
-                    value: atomicAssets,
-                });
-
-                expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
-                expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS} ETH to Moonwell WETH via router`);
-                expect(response).toContain(MOCK_TX_HASH);
-                expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
-            });
-
-            it("should not use router for ETH deposits on sepolia", async () => {
-                // Clear mocks before test
-                jest.clearAllMocks();
-                mockApprove.mockResolvedValue("Approval successful");
-
-                const args = {
-                    mTokenAddress: "0x2F39a349A79492a70E152760ce7123A1933eCf28", // Sepolia WETH mToken
-                    assets: MOCK_WHOLE_ASSETS,
-                    tokenAddress: MOCK_TOKEN_ADDRESS,
-                };
-
-                mockWallet.getNetwork.mockReturnValue({
-                    protocolFamily: "evm",
-                    networkId: "base-sepolia",
-                } as Network);
-
-                const atomicAssets = parseEther(MOCK_WHOLE_ASSETS);
-
-                const response = await actionProvider.deposit(mockWallet, args);
-
-                // Should call approve for token deposits on non-mainnet
-                expect(mockApprove).toHaveBeenCalledWith(
-                    mockWallet,
-                    MOCK_TOKEN_ADDRESS,
-                    args.mTokenAddress,
-                    atomicAssets,
-                );
-
-                expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-                    to: args.mTokenAddress as `0x${string}`,
-                    data: encodeFunctionData({
-                        abi: MTOKEN_ABI,
-                        functionName: "mint",
-                        args: [atomicAssets],
-                    }),
-                });
-
-                expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
-                expect(response).toContain(`Deposited ${MOCK_WHOLE_ASSETS}`);
-                expect(response).toContain(MOCK_TX_HASH);
-                expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
-            });
-
-            it("should handle errors in ETH deposit via router", async () => {
-                const args = {
-                    mTokenAddress: WETH_MTOKEN,
-                    assets: MOCK_WHOLE_ASSETS,
-                    tokenAddress: MOCK_TOKEN_ADDRESS,
-                };
-
-                mockWallet.getNetwork.mockReturnValue({
-                    protocolFamily: "evm",
-                    networkId: "base-mainnet",
-                } as Network);
-
-                mockWallet.sendTransaction.mockImplementation(() => {
-                    throw new Error("Failed to deposit ETH");
-                });
-
-                const response = await actionProvider.deposit(mockWallet, args);
-
-                // Should not call approve for ETH deposits on mainnet
-                expect(mockApprove).not.toHaveBeenCalled();
-                expect(response).toContain("Error depositing to Moonwell MToken: Error: Failed to deposit ETH");
-            });
-        });
+  describe("supportsNetwork", () => {
+    it("should return true for Base Mainnet", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "evm",
+        networkId: "base-mainnet",
+      });
+      expect(result).toBe(true);
     });
 
-    describe("withdraw", () => {
-        it("should successfully withdraw from Moonwell MToken", async () => {
-            const args = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_ATOMIC_ASSETS,
-            };
-
-            const response = await actionProvider.withdraw(mockWallet, args);
-
-            expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-                to: MOCK_MTOKEN_ADDRESS as `0x${string}`,
-                data: encodeFunctionData({
-                    abi: MTOKEN_ABI,
-                    functionName: "redeemUnderlying",
-                    args: [BigInt(MOCK_ATOMIC_ASSETS)],
-                }),
-            });
-
-            expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
-            expect(response).toContain(`Withdrawn ${MOCK_ATOMIC_ASSETS}`);
-            expect(response).toContain(MOCK_TX_HASH);
-            expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
-        });
-
-        it("should reject withdrawal with zero assets amount", async () => {
-            const args = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: "0",
-            };
-
-            const response = await actionProvider.withdraw(mockWallet, args);
-
-            expect(response).toBe("Error: Assets amount must be greater than 0");
-            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
-        });
-
-        it("should reject withdrawal with invalid MToken address not in MOONWELL_BASE_ADDRESSES", async () => {
-            const invalidMTokenAddress = "0x1234567890123456789012345678901234567890"; // Valid address format but not in MOONWELL_BASE_ADDRESSES
-            const args = {
-                mTokenAddress: invalidMTokenAddress,
-                assets: MOCK_ATOMIC_ASSETS,
-            };
-
-            const response = await actionProvider.withdraw(mockWallet, args);
-
-            expect(response).toBe("Error: Invalid MToken address");
-            expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
-        });
-
-        it("should handle errors when withdrawing", async () => {
-            const args = {
-                mTokenAddress: MOCK_MTOKEN_ADDRESS,
-                assets: MOCK_ATOMIC_ASSETS,
-            };
-
-            mockWallet.sendTransaction.mockRejectedValue(new Error("Failed to withdraw"));
-
-            const response = await actionProvider.withdraw(mockWallet, args);
-
-            expect(mockWallet.sendTransaction).toHaveBeenCalled();
-            expect(response).toContain("Error withdrawing from Moonwell MToken: Error: Failed to withdraw");
-        });
+    it("should return true for Base Sepolia", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      });
+      expect(result).toBe(true);
     });
 
-    describe("supportsNetwork", () => {
-        it("should return true for Base Mainnet", () => {
-            const result = actionProvider.supportsNetwork({
-                protocolFamily: "evm",
-                networkId: "base-mainnet",
-            });
-            expect(result).toBe(true);
-        });
-
-        it("should return true for Base Sepolia", () => {
-            const result = actionProvider.supportsNetwork({
-                protocolFamily: "evm",
-                networkId: "base-sepolia",
-            });
-            expect(result).toBe(true);
-        });
-
-        it("should return false for other EVM networks", () => {
-            const result = actionProvider.supportsNetwork({
-                protocolFamily: "evm",
-                networkId: "ethereum",
-            });
-            expect(result).toBe(false);
-        });
-
-        it("should return false for non-EVM networks", () => {
-            const result = actionProvider.supportsNetwork({
-                protocolFamily: "bitcoin",
-                networkId: "base-mainnet",
-            });
-            expect(result).toBe(false);
-        });
+    it("should return false for other EVM networks", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "evm",
+        networkId: "ethereum",
+      });
+      expect(result).toBe(false);
     });
+
+    it("should return false for non-EVM networks", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "bitcoin",
+        networkId: "base-mainnet",
+      });
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+import { Decimal } from "decimal.js";
+import { encodeFunctionData, parseEther } from "viem";
+
+import { ActionProvider } from "../actionProvider";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { CreateAction } from "../actionDecorator";
+import { approve } from "../../utils";
+import { MTOKEN_ABI, MOONWELL_BASE_ADDRESSES, ETH_ROUTER_ABI, WETH_ROUTER_ADDRESS, MOONWELL_BASE_SEPOLIA_ADDRESSES } from "./constants";
+import { DepositSchema, WithdrawSchema } from "./schemas";
+import { Network } from "../../network";
+
+export const SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"];
+
+/**
+ * MoonwellActionProvider is an action provider for Moonwell MToken interactions.
+ */
+export class MoonwellActionProvider extends ActionProvider {
+    /**
+     * Constructor for the MoonwellActionProvider class.
+     */
+    constructor() {
+        super("moonwell", []);
+    }
+
+    /**
+     * Deposits assets into a Moonwell MToken
+     *
+     * @param wallet - The wallet instance to execute the transaction
+     * @param args - The input arguments for the action
+     * @returns A success message with transaction details or an error message
+     */
+    @CreateAction({
+        name: "deposit",
+        description: `
+This tool allows depositing assets into a Moonwell MToken. 
+
+It takes:
+- mTokenAddress: The address of the Moonwell MToken to deposit to
+- assets: The amount of assets to deposit in whole units
+  Examples for WETH:
+  - 1 WETH
+  - 0.1 WETH
+  - 0.01 WETH
+- tokenAddress: The address of the token to approve
+
+Important notes:
+- Make sure to use the exact amount provided. Do not convert units for assets for this action.
+- Please use a token address (example 0x4200000000000000000000000000000000000006) for the tokenAddress field.
+`,
+        schema: DepositSchema,
+    })
+    async deposit(wallet: EvmWalletProvider, args: z.infer<typeof DepositSchema>): Promise<string> {
+        const assets = new Decimal(args.assets);
+
+        if (assets.comparedTo(new Decimal(0.0)) != 1) {
+            return "Error: Assets amount must be greater than 0";
+        }
+
+        const network = await wallet.getNetwork();
+        const networkObject = network.networkId === "base-mainnet" ? MOONWELL_BASE_ADDRESSES : MOONWELL_BASE_SEPOLIA_ADDRESSES;
+
+        if (!networkObject[args.mTokenAddress]) {
+            return "Error: Invalid MToken address";
+        }
+
+        try {
+            const atomicAssets = parseEther(args.assets);
+            const userAddress = await wallet.getAddress();
+
+            // Check if this is a WETH deposit on mainnet
+            if (network.networkId === "base-mainnet" && "MOONWELL_WETH" === networkObject[args.mTokenAddress]) {
+                // Use the router for ETH deposits - no approval needed since we're sending native ETH
+                const data = encodeFunctionData({
+                    abi: ETH_ROUTER_ABI,
+                    functionName: "mint",
+                    args: [userAddress],
+                });
+
+                const txHash = await wallet.sendTransaction({
+                    to: WETH_ROUTER_ADDRESS as `0x${string}`,
+                    data,
+                    value: atomicAssets,
+                });
+
+                const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+                return `Deposited ${args.assets} ETH to Moonwell WETH via router with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(receipt)}`;
+            } else {
+                // For all other tokens, we need approval first
+                const approvalResult = await approve(
+                    wallet,
+                    args.tokenAddress,
+                    args.mTokenAddress,
+                    atomicAssets,
+                );
+                if (approvalResult.startsWith("Error")) {
+                    return `Error approving Moonwell MToken as spender: ${approvalResult}`;
+                }
+
+                const data = encodeFunctionData({
+                    abi: MTOKEN_ABI,
+                    functionName: "mint",
+                    args: [atomicAssets],
+                });
+
+                const txHash = await wallet.sendTransaction({
+                    to: args.mTokenAddress as `0x${string}`,
+                    data,
+                });
+
+                const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+                return `Deposited ${args.assets} to Moonwell MToken ${args.mTokenAddress} with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(receipt)}`;
+            }
+        } catch (error) {
+            return `Error depositing to Moonwell MToken: ${error}`;
+        }
+    }
+
+    /**
+     * Withdraws assets from a Moonwell MToken
+     *
+     * @param wallet - The wallet instance to execute the transaction
+     * @param args - The input arguments for the action
+     * @returns A success message with transaction details or an error message
+     */
+    @CreateAction({
+        name: "withdraw",
+        description: `
+This tool allows withdrawing assets from a Moonwell MToken. It takes:
+
+- mTokenAddress: The address of the Moonwell MToken to withdraw from
+- assets: The amount of assets to withdraw in atomic units (wei)
+`,
+        schema: WithdrawSchema,
+    })
+    async withdraw(wallet: EvmWalletProvider, args: z.infer<typeof WithdrawSchema>): Promise<string> {
+        if (BigInt(args.assets) <= 0) {
+            return "Error: Assets amount must be greater than 0";
+        }
+
+        const network = await wallet.getNetwork();
+        const networkObject = network.networkId === "base-mainnet" ? MOONWELL_BASE_ADDRESSES : MOONWELL_BASE_SEPOLIA_ADDRESSES;
+
+        if (!networkObject[args.mTokenAddress]) {
+            return "Error: Invalid MToken address";
+        }
+
+        try {
+            const data = encodeFunctionData({
+                abi: MTOKEN_ABI,
+                functionName: "redeemUnderlying",
+                args: [BigInt(args.assets)],
+            });
+
+            const txHash = await wallet.sendTransaction({
+                to: args.mTokenAddress as `0x${string}`,
+                data,
+            });
+
+            const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+            return `Withdrawn ${args.assets} from Moonwell MToken ${args.mTokenAddress} with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(receipt)}`;
+        } catch (error) {
+            return `Error withdrawing from Moonwell MToken: ${error}`;
+        }
+    }
+
+    /**
+     * Checks if the Moonwell action provider supports the given network.
+     *
+     * @param network - The network to check.
+     * @returns True if the Moonwell action provider supports the network, false otherwise.
+     */
+    supportsNetwork = (network: Network) =>
+        network.protocolFamily === "evm" && SUPPORTED_NETWORKS.includes(network.networkId!);
+}
+
+export const moonwellActionProvider = () => new MoonwellActionProvider(); 

--- a/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/moonwellActionProvider.ts
@@ -1,13 +1,21 @@
 import { z } from "zod";
 import { Decimal } from "decimal.js";
-import { encodeFunctionData, parseEther } from "viem";
+import { encodeFunctionData, parseEther, parseUnits } from "viem";
 
 import { ActionProvider } from "../actionProvider";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { CreateAction } from "../actionDecorator";
 import { approve } from "../../utils";
-import { MTOKEN_ABI, MOONWELL_BASE_ADDRESSES, ETH_ROUTER_ABI, WETH_ROUTER_ADDRESS, MOONWELL_BASE_SEPOLIA_ADDRESSES } from "./constants";
-import { DepositSchema, WithdrawSchema } from "./schemas";
+import {
+  MTOKEN_ABI,
+  MOONWELL_BASE_ADDRESSES,
+  ETH_ROUTER_ABI,
+  WETH_ROUTER_ADDRESS,
+  MOONWELL_BASE_SEPOLIA_ADDRESSES,
+  MTOKENS_UNDERLYING_DECIMALS,
+  TOKEN_DECIMALS,
+} from "./constants";
+import { MintSchema, RedeemSchema } from "./schemas";
 import { Network } from "../../network";
 
 export const SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"];
@@ -16,165 +24,262 @@ export const SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"];
  * MoonwellActionProvider is an action provider for Moonwell MToken interactions.
  */
 export class MoonwellActionProvider extends ActionProvider {
-    /**
-     * Constructor for the MoonwellActionProvider class.
-     */
-    constructor() {
-        super("moonwell", []);
-    }
+  /**
+   * Constructor for the MoonwellActionProvider class.
+   */
+  constructor() {
+    super("moonwell", []);
+  }
 
-    /**
-     * Deposits assets into a Moonwell MToken
-     *
-     * @param wallet - The wallet instance to execute the transaction
-     * @param args - The input arguments for the action
-     * @returns A success message with transaction details or an error message
-     */
-    @CreateAction({
-        name: "deposit",
-        description: `
-This tool allows depositing assets into a Moonwell MToken. 
+  /**
+   * Deposits assets into a Moonwell MToken
+   *
+   * @param wallet - The wallet instance to execute the transaction
+   * @param args - The input arguments for the action
+   * @returns A success message with transaction details or an error message
+   */
+  @CreateAction({
+    name: "mint",
+    description: `
+This tool allows minting assets into a Moonwell MToken. 
 
 It takes:
-- mTokenAddress: The address of the Moonwell MToken to deposit to
-- assets: The amount of assets to deposit in whole units
+- mTokenAddress: The address of the Moonwell MToken to mint to
+- assets: The amount of assets that will be approved to spend by the mToken in whole units
   Examples for WETH:
   - 1 WETH
   - 0.1 WETH
   - 0.01 WETH
+  Examples for cbETH:
+  - 1 cbETH
+  - 0.1 cbETH
+  - 0.01 cbETH
+  Examples for USDC:
+  - 1 USDC
+  - 0.1 USDC
+  - 0.01 USDC
 - tokenAddress: The address of the token to approve
 
 Important notes:
 - Make sure to use the exact amount provided. Do not convert units for assets for this action.
 - Please use a token address (example 0x4200000000000000000000000000000000000006) for the tokenAddress field.
 `,
-        schema: DepositSchema,
-    })
-    async deposit(wallet: EvmWalletProvider, args: z.infer<typeof DepositSchema>): Promise<string> {
-        const assets = new Decimal(args.assets);
+    schema: MintSchema,
+  })
+  async mint(wallet: EvmWalletProvider, args: z.infer<typeof MintSchema>): Promise<string> {
+    const assets = new Decimal(args.assets);
 
-        if (assets.comparedTo(new Decimal(0.0)) != 1) {
-            return "Error: Assets amount must be greater than 0";
-        }
-
-        const network = await wallet.getNetwork();
-        const networkObject = network.networkId === "base-mainnet" ? MOONWELL_BASE_ADDRESSES : MOONWELL_BASE_SEPOLIA_ADDRESSES;
-
-        if (!networkObject[args.mTokenAddress]) {
-            return "Error: Invalid MToken address";
-        }
-
-        try {
-            const atomicAssets = parseEther(args.assets);
-            const userAddress = await wallet.getAddress();
-
-            // Check if this is a WETH deposit on mainnet
-            if (network.networkId === "base-mainnet" && "MOONWELL_WETH" === networkObject[args.mTokenAddress]) {
-                // Use the router for ETH deposits - no approval needed since we're sending native ETH
-                const data = encodeFunctionData({
-                    abi: ETH_ROUTER_ABI,
-                    functionName: "mint",
-                    args: [userAddress],
-                });
-
-                const txHash = await wallet.sendTransaction({
-                    to: WETH_ROUTER_ADDRESS as `0x${string}`,
-                    data,
-                    value: atomicAssets,
-                });
-
-                const receipt = await wallet.waitForTransactionReceipt(txHash);
-
-                return `Deposited ${args.assets} ETH to Moonwell WETH via router with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(receipt)}`;
-            } else {
-                // For all other tokens, we need approval first
-                const approvalResult = await approve(
-                    wallet,
-                    args.tokenAddress,
-                    args.mTokenAddress,
-                    atomicAssets,
-                );
-                if (approvalResult.startsWith("Error")) {
-                    return `Error approving Moonwell MToken as spender: ${approvalResult}`;
-                }
-
-                const data = encodeFunctionData({
-                    abi: MTOKEN_ABI,
-                    functionName: "mint",
-                    args: [atomicAssets],
-                });
-
-                const txHash = await wallet.sendTransaction({
-                    to: args.mTokenAddress as `0x${string}`,
-                    data,
-                });
-
-                const receipt = await wallet.waitForTransactionReceipt(txHash);
-
-                return `Deposited ${args.assets} to Moonwell MToken ${args.mTokenAddress} with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(receipt)}`;
-            }
-        } catch (error) {
-            return `Error depositing to Moonwell MToken: ${error}`;
-        }
+    if (assets.comparedTo(new Decimal(0.0)) != 1) {
+      return "Error: Assets amount must be greater than 0";
     }
 
-    /**
-     * Withdraws assets from a Moonwell MToken
-     *
-     * @param wallet - The wallet instance to execute the transaction
-     * @param args - The input arguments for the action
-     * @returns A success message with transaction details or an error message
-     */
-    @CreateAction({
-        name: "withdraw",
-        description: `
-This tool allows withdrawing assets from a Moonwell MToken. It takes:
+    const network = await wallet.getNetwork();
+    const networkObject =
+      network.networkId === "base-mainnet"
+        ? MOONWELL_BASE_ADDRESSES
+        : MOONWELL_BASE_SEPOLIA_ADDRESSES;
 
-- mTokenAddress: The address of the Moonwell MToken to withdraw from
-- assets: The amount of assets to withdraw in atomic units (wei)
+    if (!networkObject[args.mTokenAddress]) {
+      return "Error: Invalid MToken address";
+    }
+
+    try {
+      // Handle different token decimals
+      let atomicAssets;
+      const userAddress = await wallet.getAddress();
+
+      if (
+        network.networkId === "base-mainnet" &&
+        "MOONWELL_WETH" === networkObject[args.mTokenAddress]
+      ) {
+        // For ETH minting, use parseEther (18 decimals)
+        atomicAssets = parseEther(args.assets);
+      } else {
+        // For other tokens, use the correct decimals
+        const decimals = TOKEN_DECIMALS[args.tokenAddress];
+        if (!decimals) {
+          return `Error: Unsupported token address ${args.tokenAddress}. Please verify the token address is correct.`;
+        }
+        atomicAssets = parseUnits(args.assets, decimals);
+      }
+
+      // Check if this is a WETH mint on mainnet
+      if (
+        network.networkId === "base-mainnet" &&
+        "MOONWELL_WETH" === networkObject[args.mTokenAddress]
+      ) {
+        // Use the router for ETH mints - no approval needed since we're sending native ETH
+        const data = encodeFunctionData({
+          abi: ETH_ROUTER_ABI,
+          functionName: "mint",
+          args: [userAddress],
+        });
+
+        const txHash = await wallet.sendTransaction({
+          to: WETH_ROUTER_ADDRESS as `0x${string}`,
+          data,
+          value: atomicAssets,
+        });
+
+        const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+        return `Deposited ${args.assets} ETH to Moonwell WETH via router with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(
+          receipt,
+          (_, value) => (typeof value === "bigint" ? value.toString() : value),
+        )}`;
+      } else {
+        // For all other tokens, we need approval first
+        const approvalResult = await approve(
+          wallet,
+          args.tokenAddress,
+          args.mTokenAddress,
+          atomicAssets,
+        );
+
+        if (approvalResult.startsWith("Error")) {
+          return `Error approving Moonwell MToken as spender: ${approvalResult}`;
+        }
+
+        const data = encodeFunctionData({
+          abi: MTOKEN_ABI,
+          functionName: "mint",
+          args: [atomicAssets],
+        });
+
+        const txHash = await wallet.sendTransaction({
+          to: args.mTokenAddress as `0x${string}`,
+          data,
+          value: 0n,
+        });
+
+        const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+        if (!receipt) {
+          throw new Error("No receipt received for mint transaction");
+        }
+
+        if (receipt.status !== "success") {
+          throw new Error(`Mint transaction failed with status ${receipt.status}`);
+        }
+
+        return `Deposited ${args.assets} to Moonwell MToken ${args.mTokenAddress} with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(
+          receipt,
+          (_, value) => (typeof value === "bigint" ? value.toString() : value),
+        )}`;
+      }
+    } catch (error) {
+      console.error("DEBUG - Mint error:", error);
+      if (error instanceof Error) {
+        return `Error minting Moonwell MToken: ${error.message}`;
+      }
+      return `Error minting Moonwell MToken: ${error}`;
+    }
+  }
+
+  /**
+   * Redeems assets from a Moonwell MToken
+   *
+   * @param wallet - The wallet instance to execute the transaction
+   * @param args - The input arguments for the action
+   * @returns A success message with transaction details or an error message
+   */
+  @CreateAction({
+    name: "redeem",
+    description: `
+This tool allows redeeming assets from a Moonwell MToken. 
+
+It takes:
+- mTokenAddress: The address of the Moonwell MToken to redeem from
+- assets: The amount of assets to redeem in whole units
+  Examples for WETH:
+  - 1 WETH
+  - 0.1 WETH
+  - 0.01 WETH
+  Examples for cbETH:
+  - 1 cbETH
+  - 0.1 cbETH
+  - 0.01 cbETH
+  Examples for USDC:
+  - 1 USDC
+  - 0.1 USDC
+  - 0.01 USDC
+
+Important notes:
+- Make sure to use the exact amount provided. Do not convert units for assets for this action.
+- Please use a token address (example 0x4200000000000000000000000000000000000006) for the tokenAddress field.
 `,
-        schema: WithdrawSchema,
-    })
-    async withdraw(wallet: EvmWalletProvider, args: z.infer<typeof WithdrawSchema>): Promise<string> {
-        if (BigInt(args.assets) <= 0) {
-            return "Error: Assets amount must be greater than 0";
-        }
+    schema: RedeemSchema,
+  })
+  async redeem(wallet: EvmWalletProvider, args: z.infer<typeof RedeemSchema>): Promise<string> {
+    const assets = new Decimal(args.assets);
 
-        const network = await wallet.getNetwork();
-        const networkObject = network.networkId === "base-mainnet" ? MOONWELL_BASE_ADDRESSES : MOONWELL_BASE_SEPOLIA_ADDRESSES;
-
-        if (!networkObject[args.mTokenAddress]) {
-            return "Error: Invalid MToken address";
-        }
-
-        try {
-            const data = encodeFunctionData({
-                abi: MTOKEN_ABI,
-                functionName: "redeemUnderlying",
-                args: [BigInt(args.assets)],
-            });
-
-            const txHash = await wallet.sendTransaction({
-                to: args.mTokenAddress as `0x${string}`,
-                data,
-            });
-
-            const receipt = await wallet.waitForTransactionReceipt(txHash);
-
-            return `Withdrawn ${args.assets} from Moonwell MToken ${args.mTokenAddress} with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(receipt)}`;
-        } catch (error) {
-            return `Error withdrawing from Moonwell MToken: ${error}`;
-        }
+    if (assets.comparedTo(new Decimal(0.0)) != 1) {
+      return "Error: Assets amount must be greater than 0";
     }
 
-    /**
-     * Checks if the Moonwell action provider supports the given network.
-     *
-     * @param network - The network to check.
-     * @returns True if the Moonwell action provider supports the network, false otherwise.
-     */
-    supportsNetwork = (network: Network) =>
-        network.protocolFamily === "evm" && SUPPORTED_NETWORKS.includes(network.networkId!);
+    const network = await wallet.getNetwork();
+    const networkObject =
+      network.networkId === "base-mainnet"
+        ? MOONWELL_BASE_ADDRESSES
+        : MOONWELL_BASE_SEPOLIA_ADDRESSES;
+
+    if (!networkObject[args.mTokenAddress]) {
+      return "Error: Invalid MToken address";
+    }
+
+    try {
+      // Handle different token decimals
+      const decimals = MTOKENS_UNDERLYING_DECIMALS[MOONWELL_BASE_ADDRESSES[args.mTokenAddress]];
+
+      if (!decimals) {
+        return `Error: Unsupported token address ${args.mTokenAddress}. Please verify the token address is correct.`;
+      }
+
+      const atomicAssets = parseUnits(args.assets, decimals);
+
+      const data = encodeFunctionData({
+        abi: MTOKEN_ABI,
+        functionName: "redeemUnderlying",
+        args: [atomicAssets],
+      });
+
+      const txHash = await wallet.sendTransaction({
+        to: args.mTokenAddress as `0x${string}`,
+        data,
+        value: 0n,
+      });
+
+      const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+      if (!receipt) {
+        throw new Error("No receipt received for redeem transaction");
+      }
+
+      if (receipt.status !== "success") {
+        throw new Error(`Redeem transaction failed with status ${receipt.status}`);
+      }
+
+      return `Redeemed ${args.assets} from Moonwell MToken ${args.mTokenAddress} with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(
+        receipt,
+        (_, value) => (typeof value === "bigint" ? value.toString() : value),
+      )}`;
+    } catch (error) {
+      console.error("DEBUG - Redeem error:", error);
+      if (error instanceof Error) {
+        return `Error redeeming from Moonwell MToken: ${error.message}`;
+      }
+      return `Error redeeming from Moonwell MToken: ${error}`;
+    }
+  }
+
+  /**
+   * Checks if the Moonwell action provider supports the given network.
+   *
+   * @param network - The network to check.
+   * @returns True if the Moonwell action provider supports the network, false otherwise.
+   */
+  supportsNetwork = (network: Network) =>
+    network.protocolFamily === "evm" && SUPPORTED_NETWORKS.includes(network.networkId!);
 }
 
-export const moonwellActionProvider = () => new MoonwellActionProvider(); 
+export const moonwellActionProvider = () => new MoonwellActionProvider();

--- a/typescript/agentkit/src/action-providers/moonwell/schemas.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/schemas.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * Input schema for Moonwell MToken deposit action.
+ */
+export const DepositSchema = z
+    .object({
+        assets: z
+            .string()
+            .regex(/^\d+(\.\d+)?$/, "Must be a valid integer or decimal value")
+            .describe("The quantity of assets to deposit, in whole units"),
+        tokenAddress: z
+            .string()
+            .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+            .describe("The address of the assets token to approve for deposit"),
+        mTokenAddress: z
+            .string()
+            .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+            .describe("The address of the Moonwell MToken to deposit to"),
+    })
+    .describe("Input schema for Moonwell MToken deposit action");
+
+/**
+ * Input schema for Moonwell MToken withdraw action.
+ */
+export const WithdrawSchema = z
+    .object({
+        mTokenAddress: z
+            .string()
+            .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+            .describe("The address of the Moonwell MToken to withdraw from"),
+        assets: z
+            .string()
+            .regex(/^\d+$/, "Must be a valid whole number")
+            .describe("The amount of assets to withdraw in atomic units e.g. 1"),
+    })
+    .strip()
+    .describe("Input schema for Moonwell MToken withdraw action"); 

--- a/typescript/agentkit/src/action-providers/moonwell/schemas.ts
+++ b/typescript/agentkit/src/action-providers/moonwell/schemas.ts
@@ -1,38 +1,38 @@
 import { z } from "zod";
 
 /**
- * Input schema for Moonwell MToken deposit action.
+ * Input schema for Moonwell MToken mint action.
  */
-export const DepositSchema = z
-    .object({
-        assets: z
-            .string()
-            .regex(/^\d+(\.\d+)?$/, "Must be a valid integer or decimal value")
-            .describe("The quantity of assets to deposit, in whole units"),
-        tokenAddress: z
-            .string()
-            .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
-            .describe("The address of the assets token to approve for deposit"),
-        mTokenAddress: z
-            .string()
-            .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
-            .describe("The address of the Moonwell MToken to deposit to"),
-    })
-    .describe("Input schema for Moonwell MToken deposit action");
+export const MintSchema = z
+  .object({
+    assets: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/, "Must be a valid integer or decimal value")
+      .describe("The quantity of assets to use to mint, in whole units"),
+    tokenAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The address of the assets token to approve for minting"),
+    mTokenAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The address of the Moonwell MToken to mint from"),
+  })
+  .describe("Input schema for Moonwell MToken mint action");
 
 /**
- * Input schema for Moonwell MToken withdraw action.
+ * Input schema for Moonwell MToken redeem action.
  */
-export const WithdrawSchema = z
-    .object({
-        mTokenAddress: z
-            .string()
-            .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
-            .describe("The address of the Moonwell MToken to withdraw from"),
-        assets: z
-            .string()
-            .regex(/^\d+$/, "Must be a valid whole number")
-            .describe("The amount of assets to withdraw in atomic units e.g. 1"),
-    })
-    .strip()
-    .describe("Input schema for Moonwell MToken withdraw action"); 
+export const RedeemSchema = z
+  .object({
+    mTokenAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The address of the Moonwell MToken to redeem from"),
+    assets: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/, "Must be a valid integer or decimal value")
+      .describe("The quantity of assets to redeem, in whole units"),
+  })
+  .strip()
+  .describe("Input schema for Moonwell MToken redeem action");


### PR DESCRIPTION
### Moonwell Capabilities

This PR adds adapters to allow users to mint and redeem on Moonwell mToken markets on Base and Base Sepolia.

#### Qualified Impact
There are no downstream effects of these changes as this is an isolated change. If there are failures, these changes can be backed out by deleting the `typescript/agentkit/src/action-providers/moonwell` directory.