### PR TITLE
Fix python example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Your wallet has been successfully funded with testnet ETH. You can view the tran
 git clone https://github.com/coinbase/agentkit.git
 
 # Navigate to the chatbot-python example
-cd agentkit/python/cdp-langchain/examples/chatbot-python
+cd agentkit/python/examples/cdp-langchain-chatbot 
 
 # At this point, fill in your CDP API key name, private key, and OpenAI API key in the
 # .env.example file.


### PR DESCRIPTION
### What changed? Why?

The pervious `agentkit/python/cdp-langchain/examples/chatbot-python` directory is no longer there and the folder location is updated

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
