### PR TITLE
feat: add action to list nfts on opensea (ts)

### DIFF
--- a/typescript/.changeset/breezy-parks-buy.md
+++ b/typescript/.changeset/breezy-parks-buy.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Added a new action provider to interact with OpenSea

--- a/typescript/agentkit/CHANGELOG.md
+++ b/typescript/agentkit/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### Added
 
+- Added `openseaActionProvider` to list NFTs on OpenSea.
 - Added `alchemyTokenPricesActionProvider` to fetch token prices from Alchemy.
 - Added `token_prices_by_symbol` action to fetch token prices by symbol.
 - Added `token_prices_by_address` action to fetch token prices by network and address pairs.
@@ -62,6 +63,7 @@
 
 ### Fixed
 
+- Fixed mint function definition in ERC721_ABI.
 - Added account argument in call to estimateGas in CdpWalletProvider
 - Added explicit template type arguments for `ActionProvider` extensions
 

--- a/typescript/agentkit/CHANGELOG.md
+++ b/typescript/agentkit/CHANGELOG.md
@@ -54,7 +54,6 @@
 
 ### Added
 
-- Added `openseaActionProvider` to list NFTs on OpenSea.
 - Added `alchemyTokenPricesActionProvider` to fetch token prices from Alchemy.
 - Added `token_prices_by_symbol` action to fetch token prices by symbol.
 - Added `token_prices_by_address` action to fetch token prices by network and address pairs.
@@ -63,7 +62,6 @@
 
 ### Fixed
 
-- Fixed mint function definition in ERC721_ABI.
 - Added account argument in call to estimateGas in CdpWalletProvider
 - Added explicit template type arguments for `ActionProvider` extensions
 

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -46,6 +46,7 @@
     "@solana/spl-token": "^0.4.12",
     "@solana/web3.js": "^1.98.0",
     "md5": "^2.3.0",
+    "opensea-js": "^7.1.15",
     "reflect-metadata": "^0.2.2",
     "twitter-api-v2": "^1.18.2",
     "viem": "^2.22.16",

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -46,7 +46,7 @@
     "@solana/spl-token": "^0.4.12",
     "@solana/web3.js": "^1.98.0",
     "md5": "^2.3.0",
-    "opensea-js": "^7.1.16",
+    "opensea-js": "^7.1.18",
     "reflect-metadata": "^0.2.2",
     "twitter-api-v2": "^1.18.2",
     "viem": "^2.22.16",
@@ -54,21 +54,21 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/secp256k1": "^4.0.6",
     "@types/nunjucks": "^3.2.6",
     "@types/ora": "^3.2.0",
     "@types/prompts": "^2.4.9",
+    "@types/secp256k1": "^4.0.6",
     "http-server": "^14.1.1",
     "jest": "^29.7.0",
     "mock-fs": "^5.2.0",
-    "ts-jest": "^29.2.5",
-    "tsd": "^0.31.2",
-    "typescript": "^5.7.2",
     "nunjucks": "^3.2.4",
     "ora": "^7.0.1",
-    "prompts": "^2.4.2",
     "picocolors": "^1.0.0",
-    "tsx": "^4.7.1"
+    "prompts": "^2.4.2",
+    "ts-jest": "^29.2.5",
+    "tsd": "^0.31.2",
+    "tsx": "^4.7.1",
+    "typescript": "^5.7.2"
   },
   "exports": {
     ".": {

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -46,7 +46,7 @@
     "@solana/spl-token": "^0.4.12",
     "@solana/web3.js": "^1.98.0",
     "md5": "^2.3.0",
-    "opensea-js": "^7.1.15",
+    "opensea-js": "^7.1.16",
     "reflect-metadata": "^0.2.2",
     "twitter-api-v2": "^1.18.2",
     "viem": "^2.22.16",

--- a/typescript/agentkit/src/action-providers/erc721/constants.ts
+++ b/typescript/agentkit/src/action-providers/erc721/constants.ts
@@ -1,9 +1,6 @@
 export const ERC721_ABI = [
   {
-    inputs: [
-      { internalType: "address", name: "to", type: "address" },
-      { internalType: "uint256", name: "tokenId", type: "uint256" },
-    ],
+    inputs: [{ internalType: "address", name: "to", type: "address" }],
     name: "mint",
     outputs: [],
     payable: false,

--- a/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.test.ts
@@ -40,7 +40,7 @@ describe("ERC721 Action Provider", () => {
         data: encodeFunctionData({
           abi: ERC721_ABI,
           functionName: "mint",
-          args: [MOCK_DESTINATION, 1n],
+          args: [MOCK_DESTINATION],
         }),
       });
 

--- a/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.ts
@@ -39,7 +39,7 @@ Do not use the contract address as the destination address. If you are unsure of
       const data = encodeFunctionData({
         abi: ERC721_ABI,
         functionName: "mint",
-        args: [args.destination as Hex, 1n],
+        args: [args.destination as Hex],
       });
 
       const hash = await walletProvider.sendTransaction({

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -14,6 +14,7 @@ export * from "./jupiter";
 export * from "./pyth";
 export * from "./moonwell";
 export * from "./morpho";
+export * from "./opensea";
 export * from "./spl";
 export * from "./twitter";
 export * from "./wallet";

--- a/typescript/agentkit/src/action-providers/opensea/README.md
+++ b/typescript/agentkit/src/action-providers/opensea/README.md
@@ -1,1 +1,47 @@
 # Opensea Action Provider
+
+This directory contains the **OpenseaActionProvider** implementation, which provides actions to interact with the **OpenSea NFT marketplace** for listing and viewing NFTs.
+
+## Directory Structure
+
+```
+opensea/
+├── openseaActionProvider.ts         # Main provider with OpenSea functionality
+├── openseaActionProvider.test.ts    # Test file for OpenSea provider
+├── schemas.ts                       # NFT listing and query schemas
+├── utils.ts                         # Utility functions for OpenSea integration
+├── index.ts                         # Main exports
+└── README.md                        # This file
+```
+
+## Actions
+
+- `list_nft`: List an NFT for sale on OpenSea
+- `get_nfts_by_account`: Fetch NFTs owned by a specific wallet address
+
+## Adding New Actions
+
+To add new OpenSea actions:
+
+1. Define your action schema in `schemas.ts`
+2. Implement the action in `openseaActionProvider.ts`
+3. Add tests in `openseaActionProvider.test.ts`
+
+## Network Support
+
+The OpenSea provider supports the following networks:
+- Ethereum Mainnet
+- Ethereum Sepolia
+- Base
+- Arbitrum
+- Optimism
+
+## Configuration
+
+The provider requires an OpenSea API key to function. This can be provided via:
+- Environment variable: `OPENSEA_API_KEY`
+- Provider configuration: `apiKey` parameter
+
+## Notes
+
+For more information on the **OpenSea API**, visit [OpenSea Developer Documentation](https://docs.opensea.io/).

--- a/typescript/agentkit/src/action-providers/opensea/README.md
+++ b/typescript/agentkit/src/action-providers/opensea/README.md
@@ -1,0 +1,1 @@
+# Opensea Action Provider

--- a/typescript/agentkit/src/action-providers/opensea/index.ts
+++ b/typescript/agentkit/src/action-providers/opensea/index.ts
@@ -1,0 +1,1 @@
+export * from "./openseaActionProvider";

--- a/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.test.ts
@@ -11,11 +11,21 @@ describe("OpenSea Action Provider", () => {
   const MOCK_TOKEN_ID = "1";
   const MOCK_PRICE = 0.1;
   const MOCK_EXPIRATION_DAYS = 90;
+  const MOCK_OPENSEA_BASE_URL = "https://testnets.opensea.io";
+  const MOCK_OPENSEA_CHAIN = "base_sepolia";
 
   let actionProvider: ReturnType<typeof openseaActionProvider>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Mock OpenSeaSDK constructor
+    (OpenSeaSDK as jest.Mock).mockImplementation(() => ({
+      createListing: jest.fn(),
+      api: {
+        apiBaseUrl: MOCK_OPENSEA_BASE_URL,
+      },
+      chain: MOCK_OPENSEA_CHAIN,
+    }));
     actionProvider = openseaActionProvider({
       apiKey: MOCK_API_KEY,
       privateKey: MOCK_PRIVATE_KEY,
@@ -25,10 +35,24 @@ describe("OpenSea Action Provider", () => {
 
   describe("listNft", () => {
     it("should successfully list an NFT", async () => {
-      const mockListing = {
-        /* mock listing response */
-      };
-      (OpenSeaSDK.prototype.createListing as jest.Mock).mockResolvedValue(mockListing);
+      const mockListing = {};
+      const mockCreateListing = jest.fn().mockResolvedValue(mockListing);
+
+      // Update the mock implementation with the mock function
+      (OpenSeaSDK as jest.Mock).mockImplementation(() => ({
+        createListing: mockCreateListing,
+        api: {
+          apiBaseUrl: MOCK_OPENSEA_BASE_URL,
+        },
+        chain: MOCK_OPENSEA_CHAIN,
+      }));
+
+      // Re-create provider with new mock
+      actionProvider = openseaActionProvider({
+        apiKey: MOCK_API_KEY,
+        privateKey: MOCK_PRIVATE_KEY,
+        networkId: "base-sepolia",
+      });
 
       const args = {
         contractAddress: MOCK_CONTRACT,
@@ -39,7 +63,7 @@ describe("OpenSea Action Provider", () => {
 
       const response = await actionProvider.listNft(args);
 
-      expect(OpenSeaSDK.prototype.createListing).toHaveBeenCalledWith(
+      expect(mockCreateListing).toHaveBeenCalledWith(
         expect.objectContaining({
           asset: {
             tokenId: MOCK_TOKEN_ID,
@@ -51,13 +75,29 @@ describe("OpenSea Action Provider", () => {
       );
 
       expect(response).toBe(
-        `Successfully listed NFT ${MOCK_CONTRACT} token ${MOCK_TOKEN_ID} for ${MOCK_PRICE} ETH, expiring in ${MOCK_EXPIRATION_DAYS} days. Listing on OpenSea: https://testnets.opensea.io/assets/base_sepolia/${MOCK_CONTRACT}/${MOCK_TOKEN_ID}.`,
+        `Successfully listed NFT ${MOCK_CONTRACT} token ${MOCK_TOKEN_ID} for ${MOCK_PRICE} ETH, expiring in ${MOCK_EXPIRATION_DAYS} days. Listing on OpenSea: ${MOCK_OPENSEA_BASE_URL}/assets/${MOCK_OPENSEA_CHAIN}/${MOCK_CONTRACT}/${MOCK_TOKEN_ID}.`,
       );
     });
 
     it("should handle listing errors", async () => {
       const error = new Error("Listing failed");
-      (OpenSeaSDK.prototype.createListing as jest.Mock).mockRejectedValue(error);
+      const mockCreateListing = jest.fn().mockRejectedValue(error);
+
+      // Update the mock implementation with the mock function
+      (OpenSeaSDK as jest.Mock).mockImplementation(() => ({
+        createListing: mockCreateListing,
+        api: {
+          apiBaseUrl: MOCK_OPENSEA_BASE_URL,
+        },
+        chain: MOCK_OPENSEA_CHAIN,
+      }));
+
+      // Re-create provider with new mock
+      actionProvider = openseaActionProvider({
+        apiKey: MOCK_API_KEY,
+        privateKey: MOCK_PRIVATE_KEY,
+        networkId: "base-sepolia",
+      });
 
       const args = {
         contractAddress: MOCK_CONTRACT,
@@ -79,23 +119,15 @@ describe("OpenSea Action Provider", () => {
         networkId: "base-sepolia",
         chainId: "84532",
       };
-      const baseMainnetNetwork: Network = {
-        protocolFamily: "evm",
-        networkId: "base-mainnet",
-        chainId: "8453",
-      };
-
       expect(actionProvider.supportsNetwork(baseSepoliaNetwork)).toBe(true);
-      expect(actionProvider.supportsNetwork(baseMainnetNetwork)).toBe(true);
     });
 
     it("should return false for unsupported networks", () => {
-      const ethereumNetwork: Network = {
-        protocolFamily: "evm",
-        networkId: "ethereum",
-        chainId: "1",
+      const fantomNetwork: Network = {
+        protocolFamily: "bitcoin",
+        networkId: "any",
       };
-      expect(actionProvider.supportsNetwork(ethereumNetwork)).toBe(false);
+      expect(actionProvider.supportsNetwork(fantomNetwork)).toBe(false);
     });
   });
 });

--- a/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.test.ts
@@ -51,7 +51,7 @@ describe("OpenSea Action Provider", () => {
       );
 
       expect(response).toBe(
-        `Successfully listed NFT ${MOCK_CONTRACT} token ${MOCK_TOKEN_ID} for ${MOCK_PRICE} ETH, expiring in ${MOCK_EXPIRATION_DAYS} days`,
+        `Successfully listed NFT ${MOCK_CONTRACT} token ${MOCK_TOKEN_ID} for ${MOCK_PRICE} ETH, expiring in ${MOCK_EXPIRATION_DAYS} days. Listing on OpenSea: https://testnets.opensea.io/assets/base_sepolia/${MOCK_CONTRACT}/${MOCK_TOKEN_ID}.`,
       );
     });
 

--- a/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.test.ts
@@ -1,0 +1,101 @@
+import { OpenSeaSDK } from "opensea-js";
+import { openseaActionProvider } from "./openseaActionProvider";
+import { Network } from "../../network";
+
+jest.mock("opensea-js");
+
+describe("OpenSea Action Provider", () => {
+  const MOCK_API_KEY = "test-api-key";
+  const MOCK_PRIVATE_KEY = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+  const MOCK_CONTRACT = "0x1234567890123456789012345678901234567890";
+  const MOCK_TOKEN_ID = "1";
+  const MOCK_PRICE = 0.1;
+  const MOCK_EXPIRATION_DAYS = 90;
+
+  let actionProvider: ReturnType<typeof openseaActionProvider>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    actionProvider = openseaActionProvider({
+      apiKey: MOCK_API_KEY,
+      privateKey: MOCK_PRIVATE_KEY,
+      networkId: "base-sepolia",
+    });
+  });
+
+  describe("listNft", () => {
+    it("should successfully list an NFT", async () => {
+      const mockListing = {
+        /* mock listing response */
+      };
+      (OpenSeaSDK.prototype.createListing as jest.Mock).mockResolvedValue(mockListing);
+
+      const args = {
+        contractAddress: MOCK_CONTRACT,
+        tokenId: MOCK_TOKEN_ID,
+        price: MOCK_PRICE,
+        expirationDays: MOCK_EXPIRATION_DAYS,
+      };
+
+      const response = await actionProvider.listNft(args);
+
+      expect(OpenSeaSDK.prototype.createListing).toHaveBeenCalledWith(
+        expect.objectContaining({
+          asset: {
+            tokenId: MOCK_TOKEN_ID,
+            tokenAddress: MOCK_CONTRACT,
+          },
+          startAmount: MOCK_PRICE,
+          quantity: 1,
+        }),
+      );
+
+      expect(response).toBe(
+        `Successfully listed NFT ${MOCK_CONTRACT} token ${MOCK_TOKEN_ID} for ${MOCK_PRICE} ETH, expiring in ${MOCK_EXPIRATION_DAYS} days`,
+      );
+    });
+
+    it("should handle listing errors", async () => {
+      const error = new Error("Listing failed");
+      (OpenSeaSDK.prototype.createListing as jest.Mock).mockRejectedValue(error);
+
+      const args = {
+        contractAddress: MOCK_CONTRACT,
+        tokenId: MOCK_TOKEN_ID,
+        price: MOCK_PRICE,
+        expirationDays: MOCK_EXPIRATION_DAYS,
+      };
+
+      const response = await actionProvider.listNft(args);
+      expect(response).toContain(`Error listing NFT ${MOCK_CONTRACT} token ${MOCK_TOKEN_ID}`);
+      expect(response).toContain(error.message);
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should return true for supported networks", () => {
+      const baseSepoliaNetwork: Network = {
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+        chainId: "84532",
+      };
+      const baseMainnetNetwork: Network = {
+        protocolFamily: "evm",
+        networkId: "base-mainnet",
+        chainId: "8453",
+      };
+
+      expect(actionProvider.supportsNetwork(baseSepoliaNetwork)).toBe(true);
+      expect(actionProvider.supportsNetwork(baseMainnetNetwork)).toBe(true);
+    });
+
+    it("should return false for unsupported networks", () => {
+      const ethereumNetwork: Network = {
+        protocolFamily: "evm",
+        networkId: "ethereum",
+        chainId: "1",
+      };
+      expect(actionProvider.supportsNetwork(ethereumNetwork)).toBe(false);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.ts
@@ -96,7 +96,7 @@ export class OpenseaActionProvider extends ActionProvider {
   @CreateAction({
     name: "list_nft",
     description: `
-This tool will list an NFT for sale on OpenSea. 
+This tool will list an NFT for sale on the OpenSea marketplace. 
 Currently only base-sepolia and base-mainnet are supported.
 
 It takes the following inputs:
@@ -106,13 +106,14 @@ It takes the following inputs:
 - expirationDays: (Optional) Number of days the listing should be active for (default: 90)
 
 Important notes:
-- The wallet must own the NFT to list it
-- Price is in ETH (e.g. 1.5 for 1.5 ETH) - this is what you will receive if the NFT is sold, it is not required to have this amount in your wallet
-- This is a gasless action - no ETH balance is required for listing the NFT
-- This will approve the whole NFT collection to be managed by OpenSea
-- Only supported on the following networks:
-  - Base Sepolia (ie, 'base-sepolia')
-  - Base Mainnet (ie, 'base', 'base-mainnet')
+- The wallet must own the NFT
+- Price is in ETH (e.g., 1.5 for 1.5 ETH). This is the amount the seller will receive if the NFT is sold. It is not required to have this amount in the wallet.
+- Listing the NFT requires approval for OpenSea to manage the entire NFT collection:  
+  - If the collection is not already approved, an onchain transaction is required, which will incur gas fees.  
+  - If already approved, listing is gasless and does not require any onchain transaction.  
+- Only the following networks are supported:
+  - Base Sepolia (base-sepolia)
+  - Base Mainnet (base, base-mainnet)
   `,
     schema: ListNftSchema,
   })

--- a/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/opensea/openseaActionProvider.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { ListNftSchema } from "./schemas";
+import { OpenSeaSDK, Chain } from "opensea-js";
+import { Network } from "../../network";
+import { Wallet, JsonRpcProvider } from "ethers";
+
+/**
+ * Configuration options for the OpenseaActionProvider.
+ */
+export interface OpenseaActionProviderConfig {
+  /**
+   * OpenSea API Key.
+   */
+  apiKey?: string;
+
+  /**
+   * The network ID to use for the OpenseaActionProvider.
+   */
+  networkId?: string;
+
+  /**
+   * The private key to use for the OpenseaActionProvider.
+   */
+  privateKey?: string;
+}
+
+/**
+ * OpenseaActionProvider is an action provider for OpenSea marketplace interactions.
+ */
+export class OpenseaActionProvider extends ActionProvider {
+  private readonly apiKey: string;
+  private openseaSDK: OpenSeaSDK;
+  private walletWithProvider: Wallet;
+  /**
+   * Constructor for the OpenseaActionProvider class.
+   *
+   * @param config - The configuration options for the OpenseaActionProvider.
+   */
+  constructor(config: OpenseaActionProviderConfig = {}) {
+    super("opensea", []);
+
+    const apiKey = config.apiKey || process.env.OPENSEA_API_KEY;
+    if (!apiKey) {
+      throw new Error("OPENSEA_API_KEY is not configured.");
+    }
+    this.apiKey = apiKey;
+
+    const rpcUrl =
+      config.networkId === "base-sepolia"
+        ? "https://sepolia.base.org"
+        : config.networkId === "base-mainnet"
+          ? "https://main.base.org"
+          : null;
+
+    if (!rpcUrl) {
+      throw new Error("Unsupported network. Only base-sepolia and base-mainnet are supported.");
+    }
+
+    const provider = new JsonRpcProvider(rpcUrl);
+    const walletWithProvider = new Wallet(config.privateKey!, provider);
+    this.walletWithProvider = walletWithProvider;
+
+    const openseaSDK = new OpenSeaSDK(walletWithProvider, {
+      chain: config.networkId === "base-mainnet" ? Chain.Mainnet : Chain.BaseSepolia,
+      apiKey: this.apiKey,
+    });
+    this.openseaSDK = openseaSDK;
+  }
+
+  /**
+   * Lists an NFT for sale on OpenSea.
+   *
+   * @param args - The input arguments for the action.
+   * @returns A message containing the listing details.
+   */
+  @CreateAction({
+    name: "list_nft",
+    description: `
+This tool will list an NFT for sale on OpenSea marketplace. Currently only base-sepolia and base-mainnet are supported.
+
+It takes the following inputs:
+- contractAddress: The NFT contract address to list
+- tokenId: The ID of the NFT to list
+- price: The price in ETH to list the NFT for
+- expirationDays: (Optional) Number of days the listing should be active for (default: 90)
+
+Important notes:
+- Ensure you have approved OpenSea to manage this NFT before listing
+- The wallet must own the NFT to list it
+- Price is in ETH (e.g. 1.5 for 1.5 ETH)
+`,
+    schema: ListNftSchema,
+  })
+  async listNft(args: z.infer<typeof ListNftSchema>): Promise<string> {
+    try {
+      const expirationTime = Math.round(Date.now() / 1000 + args.expirationDays * 24 * 60 * 60);
+      const listing = await this.openseaSDK.createListing({
+        asset: {
+          tokenId: args.tokenId,
+          tokenAddress: args.contractAddress,
+        },
+        startAmount: args.price,
+        quantity: 1,
+        paymentTokenAddress: "0x0000000000000000000000000000000000000000",
+        expirationTime: expirationTime,
+        accountAddress: this.walletWithProvider.address,
+      });
+
+      const listingStr = JSON.stringify(
+        listing,
+        (key, value) => (typeof value === "bigint" ? value.toString() : value),
+        2,
+      );
+      console.log("Listing details:", listingStr);
+
+      return `Successfully listed NFT ${args.contractAddress} token ${args.tokenId} for ${args.price} ETH, expiring in ${args.expirationDays} days`;
+    } catch (error) {
+      return `Error listing NFT ${args.contractAddress} token ${args.tokenId} for ${args.price} ETH using account ${this.walletWithProvider.address}: ${error}`;
+    }
+  }
+
+  /**
+   * Checks if the Opensea action provider supports the given network.
+   *
+   * @param network - The network to check.
+   * @returns True if the Opensea action provider supports the network, false otherwise.
+   */
+  supportsNetwork = (network: Network) =>
+    network.networkId === "base-mainnet" || network.networkId === "base-sepolia";
+}
+
+export const openseaActionProvider = (config?: OpenseaActionProviderConfig) =>
+  new OpenseaActionProvider(config);

--- a/typescript/agentkit/src/action-providers/opensea/schemas.ts
+++ b/typescript/agentkit/src/action-providers/opensea/schemas.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
  */
 export const ListNftSchema = z
   .object({
-    contractAddress: z.string().describe("The NFT contract address to list"),
-    tokenId: z.string().describe("The tokenID of the NFT to list"),
+    contractAddress: z.string().nonempty().describe("The NFT contract address to list"),
+    tokenId: z.string().nonempty().describe("The tokenID of the NFT to list"),
     price: z.number().positive().describe("The price in ETH to list the NFT for"),
     expirationDays: z
       .number()
@@ -17,3 +17,18 @@ export const ListNftSchema = z
   })
   .strip()
   .describe("Input schema for listing an NFT on OpenSea");
+
+/**
+ * Input schema for getting NFTs from a specific wallet address.
+ */
+export const GetNftsByAccountSchema = z
+  .object({
+    accountAddress: z
+      .string()
+      .optional()
+      .describe(
+        "The wallet address to fetch NFTs for (defaults to connected wallet if not provided)",
+      ),
+  })
+  .strip()
+  .describe("Input schema for fetching NFTs by account");

--- a/typescript/agentkit/src/action-providers/opensea/schemas.ts
+++ b/typescript/agentkit/src/action-providers/opensea/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+/**
+ * Input schema for listing an NFT on OpenSea.
+ */
+export const ListNftSchema = z
+  .object({
+    contractAddress: z.string().describe("The NFT contract address to list"),
+    tokenId: z.string().describe("The tokenID of the NFT to list"),
+    price: z.number().positive().describe("The price in ETH to list the NFT for"),
+    expirationDays: z
+      .number()
+      .positive()
+      .optional()
+      .default(90)
+      .describe("Number of days the listing should be active for (default: 90)"),
+  })
+  .strip()
+  .describe("Input schema for listing an NFT on OpenSea");

--- a/typescript/agentkit/src/action-providers/opensea/utils.ts
+++ b/typescript/agentkit/src/action-providers/opensea/utils.ts
@@ -1,0 +1,45 @@
+import { Chain } from "opensea-js";
+
+/**
+ * Supported Opensea chains
+ */
+export const supportedChains: Record<string, Chain> = {
+  "1": Chain.Mainnet,
+  "137": Chain.Polygon,
+  "80002": Chain.Amoy,
+  "11155111": Chain.Sepolia,
+  "8217": Chain.Klaytn,
+  "1001": Chain.Baobab,
+  "43114": Chain.Avalanche,
+  "43113": Chain.Fuji,
+  "42161": Chain.Arbitrum,
+  "42170": Chain.ArbitrumNova,
+  "421614": Chain.ArbitrumSepolia,
+  "238": Chain.Blast,
+  "168587773": Chain.BlastSepolia,
+  "8453": Chain.Base,
+  "84532": Chain.BaseSepolia,
+  "10": Chain.Optimism,
+  "11155420": Chain.OptimismSepolia,
+  "7777777": Chain.Zora,
+  "999999999": Chain.ZoraSepolia,
+  "1329": Chain.Sei,
+  "1328": Chain.SeiTestnet,
+  "8333": Chain.B3,
+  "1993": Chain.B3Sepolia,
+  "80094": Chain.BeraChain,
+};
+
+/**
+ * Maps EVM chain IDs to Opensea chain
+ *
+ * @param chainId - The EVM chain ID to map
+ * @returns The corresponding OpenSea Chain enum value
+ */
+export const chainIdToOpenseaChain = (chainId: string): Chain => {
+  const chain = supportedChains[chainId];
+  if (!chain) {
+    throw new Error(`Unsupported chain ID on Opensea: ${chainId}`);
+  }
+  return chain;
+};

--- a/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
@@ -555,4 +555,16 @@ export class CdpWalletProvider extends EvmWalletProvider {
 
     return this.#cdpWallet.export();
   }
+
+  /**
+   * Gets the wallet.
+   *
+   * @returns The wallet.
+   */
+  getWallet(): Wallet {
+    if (!this.#cdpWallet) {
+      throw new Error("Wallet not initialized");
+    }
+    return this.#cdpWallet;
+  }
 }

--- a/typescript/examples/langchain-cdp-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-cdp-chatbot/chatbot.ts
@@ -4,9 +4,11 @@ import {
   wethActionProvider,
   walletActionProvider,
   erc20ActionProvider,
+  erc721ActionProvider,
   cdpApiActionProvider,
   cdpWalletActionProvider,
   pythActionProvider,
+  openseaActionProvider,
 } from "@coinbase/agentkit";
 import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { HumanMessage } from "@langchain/core/messages";
@@ -99,6 +101,7 @@ async function initializeAgent() {
         pythActionProvider(),
         walletActionProvider(),
         erc20ActionProvider(),
+        erc721ActionProvider(),
         cdpApiActionProvider({
           apiKeyName: process.env.CDP_API_KEY_NAME,
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
@@ -107,6 +110,14 @@ async function initializeAgent() {
           apiKeyName: process.env.CDP_API_KEY_NAME,
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),
+        // Only add OpenSea provider if API key is configured
+        ...(process.env.OPENSEA_API_KEY ? [
+          openseaActionProvider({
+            apiKey: process.env.OPENSEA_API_KEY,
+            networkId: walletProvider.getNetwork().networkId,
+            privateKey: (await (await walletProvider.getWallet().getDefaultAddress()).export()),
+          })
+        ] : []),
       ],
     });
 

--- a/typescript/examples/langchain-cdp-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-cdp-chatbot/chatbot.ts
@@ -111,13 +111,15 @@ async function initializeAgent() {
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),
         // Only add OpenSea provider if API key is configured
-        ...(process.env.OPENSEA_API_KEY ? [
-          openseaActionProvider({
-            apiKey: process.env.OPENSEA_API_KEY,
-            networkId: walletProvider.getNetwork().networkId,
-            privateKey: (await (await walletProvider.getWallet().getDefaultAddress()).export()),
-          })
-        ] : []),
+        ...(process.env.OPENSEA_API_KEY
+          ? [
+              openseaActionProvider({
+                apiKey: process.env.OPENSEA_API_KEY,
+                networkId: walletProvider.getNetwork().networkId,
+                privateKey: await (await walletProvider.getWallet().getDefaultAddress()).export(),
+              }),
+            ]
+          : []),
       ],
     });
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -4610,6 +4610,11 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/buffer-reverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+      "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg=="
+    },
     "node_modules/bufferutil": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
@@ -9726,9 +9731,9 @@
       }
     },
     "node_modules/opensea-js": {
-      "version": "7.1.15",
-      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.15.tgz",
-      "integrity": "sha512-mURaWFJN6lySwjHCjwGSBKQS9HdV8O3fr90cwM9hKJvAFLUln/s58Lh+YLfpg9y44N4mAG2ijucdxFDbw7zh3g==",
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.16.tgz",
+      "integrity": "sha512-eg042/7QJl/fZevrj6QBlNkRN63Mb7MUDwCXeqyOxLxC8itfz6+TOZMK9JCSJmCZzKAimqHeqHGRY0aPA2hQ6g==",
       "hasInstallScript": true,
       "dependencies": {
         "@opensea/seaport-js": "^4.0.0",
@@ -12860,7 +12865,7 @@
         "@solana/spl-token": "^0.4.12",
         "@solana/web3.js": "^1.98.0",
         "md5": "^2.3.0",
-        "opensea-js": "^7.1.15",
+        "opensea-js": "^7.1.16",
         "reflect-metadata": "^0.2.2",
         "twitter-api-v2": "^1.18.2",
         "viem": "^2.22.16",
@@ -16201,6 +16206,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "buffer-reverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+      "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg=="
     },
     "bufferutil": {
       "version": "4.0.9",
@@ -19775,9 +19785,9 @@
       "dev": true
     },
     "opensea-js": {
-      "version": "7.1.15",
-      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.15.tgz",
-      "integrity": "sha512-mURaWFJN6lySwjHCjwGSBKQS9HdV8O3fr90cwM9hKJvAFLUln/s58Lh+YLfpg9y44N4mAG2ijucdxFDbw7zh3g==",
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.16.tgz",
+      "integrity": "sha512-eg042/7QJl/fZevrj6QBlNkRN63Mb7MUDwCXeqyOxLxC8itfz6+TOZMK9JCSJmCZzKAimqHeqHGRY0aPA2hQ6g==",
       "requires": {
         "@opensea/seaport-js": "^4.0.0",
         "ethers": "^6.9.0"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -5047,6 +5047,11 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -9114,6 +9119,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/merkletreejs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.4.1.tgz",
+      "integrity": "sha512-W2VSHeGTdAnWtedee+pgGn7SHvncMdINnMeHAaXrfarSaMNLff/pm7RCr/QXYxN6XzJFgJZY+28ejO0lAosW4A==",
+      "dependencies": {
+        "buffer-reverse": "^1.0.1",
+        "crypto-js": "^4.2.0",
+        "treeify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -9705,6 +9723,19 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/opensea-js": {
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.15.tgz",
+      "integrity": "sha512-mURaWFJN6lySwjHCjwGSBKQS9HdV8O3fr90cwM9hKJvAFLUln/s58Lh+YLfpg9y44N4mAG2ijucdxFDbw7zh3g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@opensea/seaport-js": "^4.0.0",
+        "ethers": "^6.9.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/optionator": {
@@ -11789,6 +11820,14 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -12821,6 +12860,7 @@
         "@solana/spl-token": "^0.4.12",
         "@solana/web3.js": "^1.98.0",
         "md5": "^2.3.0",
+        "opensea-js": "^7.1.15",
         "reflect-metadata": "^0.2.2",
         "twitter-api-v2": "^1.18.2",
         "viem": "^2.22.16",
@@ -16465,6 +16505,11 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
     "data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -19341,6 +19386,16 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
+    "merkletreejs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.4.1.tgz",
+      "integrity": "sha512-W2VSHeGTdAnWtedee+pgGn7SHvncMdINnMeHAaXrfarSaMNLff/pm7RCr/QXYxN6XzJFgJZY+28ejO0lAosW4A==",
+      "requires": {
+        "buffer-reverse": "^1.0.1",
+        "crypto-js": "^4.2.0",
+        "treeify": "^1.1.0"
+      }
+    },
     "micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -19718,6 +19773,15 @@
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
+    },
+    "opensea-js": {
+      "version": "7.1.15",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.15.tgz",
+      "integrity": "sha512-mURaWFJN6lySwjHCjwGSBKQS9HdV8O3fr90cwM9hKJvAFLUln/s58Lh+YLfpg9y44N4mAG2ijucdxFDbw7zh3g==",
+      "requires": {
+        "@opensea/seaport-js": "^4.0.0",
+        "ethers": "^6.9.0"
+      }
     },
     "optionator": {
       "version": "0.9.4",
@@ -21167,6 +21231,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A=="
     },
     "trim-newlines": {
       "version": "3.0.1",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -50,6 +50,7 @@
         "@solana/spl-token": "^0.4.12",
         "@solana/web3.js": "^1.98.0",
         "md5": "^2.3.0",
+        "opensea-js": "^7.1.18",
         "reflect-metadata": "^0.2.2",
         "twitter-api-v2": "^1.18.2",
         "viem": "^2.22.16",
@@ -9731,9 +9732,9 @@
       }
     },
     "node_modules/opensea-js": {
-      "version": "7.1.16",
-      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.16.tgz",
-      "integrity": "sha512-eg042/7QJl/fZevrj6QBlNkRN63Mb7MUDwCXeqyOxLxC8itfz6+TOZMK9JCSJmCZzKAimqHeqHGRY0aPA2hQ6g==",
+      "version": "7.1.18",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.18.tgz",
+      "integrity": "sha512-cFSwroGwRkb8/FHsNjIwL2qvdve39CKMU6IUKmx+zDfsgVwKQ+7SHEj5YfKEspji5kUPpnfBlNLCAIbRS+pssA==",
       "hasInstallScript": true,
       "dependencies": {
         "@opensea/seaport-js": "^4.0.0",
@@ -13800,6 +13801,7 @@
         "md5": "^2.3.0",
         "mock-fs": "^5.2.0",
         "nunjucks": "^3.2.4",
+        "opensea-js": "^7.1.18",
         "ora": "^7.0.1",
         "picocolors": "^1.0.0",
         "prompts": "^2.4.2",
@@ -19785,9 +19787,9 @@
       "dev": true
     },
     "opensea-js": {
-      "version": "7.1.16",
-      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.16.tgz",
-      "integrity": "sha512-eg042/7QJl/fZevrj6QBlNkRN63Mb7MUDwCXeqyOxLxC8itfz6+TOZMK9JCSJmCZzKAimqHeqHGRY0aPA2hQ6g==",
+      "version": "7.1.18",
+      "resolved": "https://registry.npmjs.org/opensea-js/-/opensea-js-7.1.18.tgz",
+      "integrity": "sha512-cFSwroGwRkb8/FHsNjIwL2qvdve39CKMU6IUKmx+zDfsgVwKQ+7SHEj5YfKEspji5kUPpnfBlNLCAIbRS+pssA==",
       "requires": {
         "@opensea/seaport-js": "^4.0.0",
         "ethers": "^6.9.0"

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2884,6 +2884,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opensea/seaport-js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@opensea/seaport-js/-/seaport-js-4.0.4.tgz",
+      "integrity": "sha512-pOBgU+y1H9Bh463ZdgFshFBxnBQvEaGfoOJFDHbkvZTNLSqIOyuDmICFTQJEiPjYsS6tMQTbw2oJBtcVLFUT2g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "ethers": "^6.9.0",
+        "merkletreejs": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -14949,6 +14962,15 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@opensea/seaport-js": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@opensea/seaport-js/-/seaport-js-4.0.4.tgz",
+      "integrity": "sha512-pOBgU+y1H9Bh463ZdgFshFBxnBQvEaGfoOJFDHbkvZTNLSqIOyuDmICFTQJEiPjYsS6tMQTbw2oJBtcVLFUT2g==",
+      "requires": {
+        "ethers": "^6.9.0",
+        "merkletreejs": "^0.4.0"
       }
     },
     "@opentelemetry/api": {


### PR DESCRIPTION
### Why? What?

Adds new OpenseaActionProvider to handle interactions with opensea.
So far only one action is implemented (list_nft) that creates a listing on opensea.
Additional actions like accept/create offer may be added in the future.

This implementation uses the opensea-js sdk that is added as new dependency and requires an opensea api key (https://docs.opensea.io/reference/api-overview). The new action is added in the chatbot.ts example, only if an OPENSEA_API_KEY is set.

The OpenSea SDK requires an ethers signer which is created when initialising OpenseaActionProvider with the privateKey to the account holding the NFT. In the chatbot.ts example, I extract the privateKey from the CdpWalletProvider. This is a bit of a hack but I couldn't find a way to directly use a EvmWalletProvider to create a ethers signer. Suggestions are welcome.

### What changed?
- [x] New Action Provider: OpenseaActionProvider
- [x] New Action: list_nft
- [x] Bug fixes for mint nft action:
  - changed mint function signature in ERC721_ABI to be consistent with the contract the deploy_nft action deploys, see eg: https://sepolia.basescan.org/address/0xff145576d6266aed8bd70172210d8aca52ca236a#code
   - still got `EstimateGasExecutionError: Execution reverted for an unknown reason` for mint nft action, similar to the issue https://github.com/coinbase/agentkit/issues/238. 
   Fixed after changing:` account: this.#publicClient.account` to `account: this.#address as `0x${string}` ` 

### Network support
- Base
- Base Sepolia
- (Should be easy to extend to further evm networks)

### Checklist
- [x] Changelog updated
- [x] Rebased against master

### How has it been tested?
- [x] Unit tests
- [x] Agent tested, example prompt below (using gpt-4o-mini)

```
Prompt: deploy nft and mint to your wallet, decide all details

-------------------
Deployed NFT Collection My Unique NFT Collection:
- to address 0xFF145576D6266AEd8BD70172210d8ACa52CA236a
- on network base-sepolia.
Transaction hash: 0x70f5bf1be168238a5b70b630462fb1de6e493fa89ecb982616a9ffd774e162e0
Transaction link: https://sepolia.basescan.org/tx/0x70f5bf1be168238a5b70b630462fb1de6e493fa89ecb982616a9ffd774e162e0
-------------------
-------------------
Successfully minted NFT 0xFF145576D6266AEd8BD70172210d8ACa52CA236a to 0x51CD6e4d10F0282f48d13f4290960bF37f5eF151
-------------------
-------------------
The NFT collection "My Unique NFT Collection" has been successfully deployed with the symbol "MUNC". Here are the details:

- **NFT Contract Address**: [0xFF145576D6266AEd8BD70172210d8ACa52CA236a](https://sepolia.basescan.org/tx/0x70f5bf1be168238a5b70b630462fb1de6e493fa89ecb982616a9ffd774e162e0)  
- **Transaction Hash**: 0x70f5bf1be168238a5b70b630462fb1de6e493fa89ecb982616a9ffd774e162e0  
- **Network**: Base Sepolia  

Additionally, an NFT has been successfully minted to your wallet. If you need any further assistance, let me know!
-------------------

Prompt: list this nft with tokenid 0 for 1 eth on opensea

-------------------
Successfully listed NFT 0xFF145576D6266AEd8BD70172210d8ACa52CA236a token 0 for 1 ETH, expiring in 90 days. Listing on OpenSea: https://testnets.opensea.io/assets/base_sepolia/0xFF145576D6266AEd8BD70172210d8ACa52CA236a/0.
-------------------
The NFT with token ID `0` has been successfully listed for **1 ETH** on OpenSea. Here are the details:

- **Listing Link**: [View Listing on OpenSea](https://testnets.opensea.io/assets/base_sepolia/0xFF145576D6266AEd8BD70172210d8ACa52CA236a/0)
- **Expiration**: 90 days
```


