### PR TITLE
Improve types and make wallet providers more flexible

### DIFF
--- a/CONTRIBUTING-TYPESCRIPT.md
+++ b/CONTRIBUTING-TYPESCRIPT.md
@@ -143,7 +143,7 @@ Do not use the contract address as the destination address. If you are unsure of
       });
 
       const hash = await walletProvider.sendTransaction({
-        to: args.contractAddress as `0x${string}`,
+        to: args.contractAddress as Hex,
         data,
       });
 

--- a/typescript/agentkit/src/action-providers/basename/basenameActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/basename/basenameActionProvider.test.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, namehash, parseEther } from "viem";
+import { encodeFunctionData, namehash, parseEther, Hex } from "viem";
 
 import { basenameActionProvider } from "./basenameActionProvider";
 import {
@@ -61,7 +61,7 @@ describe("Register Basename Action", () => {
       waitForTransactionReceipt: jest.fn(),
     } as unknown as jest.Mocked<EvmWalletProvider>;
 
-    mockWallet.sendTransaction.mockResolvedValue("some-hash" as `0x${string}`);
+    mockWallet.sendTransaction.mockResolvedValue("some-hash" as Hex);
     mockWallet.waitForTransactionReceipt.mockResolvedValue({});
   });
 

--- a/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.test.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData } from "viem";
+import { encodeFunctionData, Hex } from "viem";
 import { erc721ActionProvider } from "./erc721ActionProvider";
 import { ERC721_ABI } from "./constants";
 import { EvmWalletProvider } from "../../wallet-providers";
@@ -22,7 +22,7 @@ describe("ERC721 Action Provider", () => {
       call: jest.fn(),
     } as unknown as jest.Mocked<EvmWalletProvider>;
 
-    mockWallet.sendTransaction.mockResolvedValue("0xmockhash" as `0x${string}`);
+    mockWallet.sendTransaction.mockResolvedValue("0xmockhash" as Hex);
     mockWallet.waitForTransactionReceipt.mockResolvedValue({});
   });
 

--- a/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/erc721/erc721ActionProvider.ts
@@ -43,7 +43,7 @@ Do not use the contract address as the destination address. If you are unsure of
       });
 
       const hash = await walletProvider.sendTransaction({
-        to: args.contractAddress as `0x${string}`,
+        to: args.contractAddress as Hex,
         data,
       });
 
@@ -91,7 +91,7 @@ Important notes:
       });
 
       const hash = await walletProvider.sendTransaction({
-        to: args.contractAddress as `0x${string}`,
+        to: args.contractAddress as Hex,
         data,
       });
 

--- a/typescript/agentkit/src/action-providers/morpho/morphoActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/morpho/morphoActionProvider.test.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, parseEther } from "viem";
+import { encodeFunctionData, parseEther, Hex } from "viem";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { approve } from "../../utils";
 import { MorphoActionProvider } from "./morphoActionProvider";
@@ -23,7 +23,7 @@ describe("Morpho Action Provider", () => {
     mockWallet = {
       getAddress: jest.fn().mockReturnValue(MOCK_RECEIVER_ID),
       getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "1" }),
-      sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+      sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as Hex),
       waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
     } as unknown as jest.Mocked<EvmWalletProvider>;
 
@@ -51,7 +51,7 @@ describe("Morpho Action Provider", () => {
       );
 
       expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-        to: MOCK_VAULT_ADDRESS as `0x${string}`,
+        to: MOCK_VAULT_ADDRESS as Hex,
         data: encodeFunctionData({
           abi: METAMORPHO_ABI,
           functionName: "deposit",
@@ -92,7 +92,7 @@ describe("Morpho Action Provider", () => {
       const response = await actionProvider.withdraw(mockWallet, args);
 
       expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-        to: MOCK_VAULT_ADDRESS as `0x${string}`,
+        to: MOCK_VAULT_ADDRESS as Hex,
         data: encodeFunctionData({
           abi: METAMORPHO_ABI,
           functionName: "withdraw",

--- a/typescript/agentkit/src/action-providers/morpho/morphoActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/morpho/morphoActionProvider.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { Decimal } from "decimal.js";
-import { encodeFunctionData, parseEther } from "viem";
+import { encodeFunctionData, parseEther, Hex } from "viem";
 
 import { ActionProvider } from "../actionProvider";
 import { EvmWalletProvider } from "../../wallet-providers";
@@ -78,7 +78,7 @@ Important notes:
       });
 
       const txHash = await wallet.sendTransaction({
-        to: args.vaultAddress as `0x${string}`,
+        to: args.vaultAddress as Hex,
         data,
       });
 
@@ -121,7 +121,7 @@ This tool allows withdrawing assets from a Morpho Vault. It takes:
       });
 
       const txHash = await wallet.sendTransaction({
-        to: args.vaultAddress as `0x${string}`,
+        to: args.vaultAddress as Hex,
         data,
       });
 

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
@@ -1,4 +1,5 @@
 import { Decimal } from "decimal.js";
+import { Hex } from "viem";
 import { z } from "zod";
 
 import { CreateAction } from "../actionDecorator";
@@ -92,7 +93,7 @@ Important notes:
     args: z.infer<typeof NativeTransferSchema>,
   ): Promise<string> {
     try {
-      const result = await walletProvider.nativeTransfer(args.to as `0x${string}`, args.value);
+      const result = await walletProvider.nativeTransfer(args.to as Hex, args.value);
 
       return `Transferred ${args.value} ETH to ${args.to}.\nTransaction hash: ${result}`;
     } catch (error) {

--- a/typescript/agentkit/src/action-providers/wow/schemas.ts
+++ b/typescript/agentkit/src/action-providers/wow/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import { isAddress } from "viem";
+import { isAddress, Hex } from "viem";
 
-const ethereumAddress = z.custom<`0x${string}`>(
+const ethereumAddress = z.custom<Hex>(
   val => typeof val === "string" && isAddress(val),
   "Invalid address",
 );

--- a/typescript/agentkit/src/action-providers/wow/uniswap/utils.ts
+++ b/typescript/agentkit/src/action-providers/wow/uniswap/utils.ts
@@ -1,4 +1,4 @@
-import { formatEther, getAddress } from "viem";
+import { formatEther, getAddress, Hex } from "viem";
 import { EvmWalletProvider } from "../../../wallet-providers";
 import { ADDRESSES, WOW_ABI } from "../constants";
 import { UNISWAP_QUOTER_ABI, UNISWAP_V3_ABI } from "./constants";
@@ -66,31 +66,31 @@ export async function getPoolInfo(
   try {
     const results = await Promise.all([
       wallet.readContract({
-        address: poolAddress as `0x${string}`,
+        address: poolAddress as Hex,
         functionName: "token0",
         args: [],
         abi: UNISWAP_V3_ABI,
       }),
       wallet.readContract({
-        address: poolAddress as `0x${string}`,
+        address: poolAddress as Hex,
         functionName: "token1",
         args: [],
         abi: UNISWAP_V3_ABI,
       }),
       wallet.readContract({
-        address: poolAddress as `0x${string}`,
+        address: poolAddress as Hex,
         functionName: "fee",
         args: [],
         abi: UNISWAP_V3_ABI,
       }),
       wallet.readContract({
-        address: poolAddress as `0x${string}`,
+        address: poolAddress as Hex,
         functionName: "liquidity",
         args: [],
         abi: UNISWAP_V3_ABI,
       }),
       wallet.readContract({
-        address: poolAddress as `0x${string}`,
+        address: poolAddress as Hex,
         functionName: "slot0",
         args: [],
         abi: UNISWAP_V3_ABI,
@@ -101,13 +101,13 @@ export async function getPoolInfo(
 
     const [balance0, balance1] = await Promise.all([
       wallet.readContract({
-        address: token0Result as `0x${string}`,
+        address: token0Result as Hex,
         functionName: "balanceOf",
         args: [poolAddress],
         abi: WOW_ABI,
       }),
       wallet.readContract({
-        address: token1Result as `0x${string}`,
+        address: token1Result as Hex,
         functionName: "balanceOf",
         args: [poolAddress],
         abi: WOW_ABI,
@@ -148,7 +148,7 @@ export async function exactInputSingle(
   try {
     const networkId = wallet.getNetwork().networkId!;
     const amount = await wallet.readContract({
-      address: ADDRESSES[networkId].UniswapQuoter as `0x${string}`,
+      address: ADDRESSES[networkId].UniswapQuoter as Hex,
       functionName: "quoteExactInputSingle",
       args: [
         {
@@ -262,7 +262,7 @@ export async function getHasGraduated(
   tokenAddress: string,
 ): Promise<boolean> {
   const marketType = await wallet.readContract({
-    address: tokenAddress as `0x${string}`,
+    address: tokenAddress as Hex,
     functionName: "marketType",
     args: [],
     abi: WOW_ABI,
@@ -282,7 +282,7 @@ export async function getPoolAddress(
   tokenAddress: string,
 ): Promise<string> {
   const poolAddress = await wallet.readContract({
-    address: tokenAddress as `0x${string}`,
+    address: tokenAddress as Hex,
     functionName: "poolAddress",
     args: [],
     abi: WOW_ABI,

--- a/typescript/agentkit/src/action-providers/wow/utils.ts
+++ b/typescript/agentkit/src/action-providers/wow/utils.ts
@@ -1,3 +1,5 @@
+import { Hex } from "viem";
+
 import { EvmWalletProvider } from "../../wallet-providers";
 import { WOW_ABI } from "./constants";
 import { getHasGraduated, getUniswapQuote } from "./uniswap/utils";
@@ -14,7 +16,7 @@ export async function getCurrentSupply(
   tokenAddress: string,
 ): Promise<string> {
   const supply = await wallet.readContract({
-    address: tokenAddress as `0x${string}`,
+    address: tokenAddress as Hex,
     abi: WOW_ABI,
     functionName: "totalSupply",
     args: [],
@@ -42,7 +44,7 @@ export async function getBuyQuote(
     hasGraduated
       ? (await getUniswapQuote(wallet, tokenAddress, Number(amountEthInWei), "buy")).amountOut
       : await wallet.readContract({
-          address: tokenAddress as `0x${string}`,
+          address: tokenAddress as Hex,
           abi: WOW_ABI,
           functionName: "getEthBuyQuote",
           args: [amountEthInWei],
@@ -71,7 +73,7 @@ export async function getSellQuote(
     hasGraduated
       ? (await getUniswapQuote(wallet, tokenAddress, Number(amountTokensInWei), "sell")).amountOut
       : await wallet.readContract({
-          address: tokenAddress as `0x${string}`,
+          address: tokenAddress as Hex,
           abi: WOW_ABI,
           functionName: "getTokenSellQuote",
           args: [amountTokensInWei],

--- a/typescript/agentkit/src/action-providers/wow/wowActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/wow/wowActionProvider.test.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData } from "viem";
+import { encodeFunctionData, Hex } from "viem";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { WowActionProvider } from "./wowActionProvider";
 import { WOW_ABI, WOW_FACTORY_ABI, GENERIC_TOKEN_METADATA_URI } from "./constants";
@@ -16,8 +16,8 @@ jest.mock("./uniswap/utils", () => ({
 }));
 
 describe("WowActionProvider", () => {
-  const MOCK_CONTRACT_ADDRESS = "0x1234567890123456789012345678901234567890" as `0x${string}`;
-  const INVALID_ADDRESS = "0xinvalid" as `0x${string}`;
+  const MOCK_CONTRACT_ADDRESS = "0x1234567890123456789012345678901234567890" as Hex;
+  const INVALID_ADDRESS = "0xinvalid" as Hex;
   const MOCK_AMOUNT_ETH_IN_WEI = BigInt("100000000000000000");
   const INVALID_WEI = "1.5"; // Wei amounts can't have decimals
   const MOCK_AMOUNT_TOKENS_IN_WEI = BigInt("1000000000000000000");
@@ -26,7 +26,7 @@ describe("WowActionProvider", () => {
   const MOCK_URI = "ipfs://QmY1GqprFYvojCcUEKgqHeDj9uhZD9jmYGrQTfA9vAE78J";
   const INVALID_URI = "not-a-url";
   const MOCK_TX_HASH = "0xabcdef1234567890";
-  const MOCK_ADDRESS = "0x9876543210987654321098765432109876543210" as `0x${string}`;
+  const MOCK_ADDRESS = "0x9876543210987654321098765432109876543210" as Hex;
 
   let provider: WowActionProvider;
   let mockWallet: jest.Mocked<EvmWalletProvider>;
@@ -35,7 +35,7 @@ describe("WowActionProvider", () => {
     mockWallet = {
       getAddress: jest.fn().mockReturnValue(MOCK_ADDRESS),
       getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "base-sepolia" }),
-      sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+      sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as Hex),
       waitForTransactionReceipt: jest.fn().mockResolvedValue({}),
       readContract: jest.fn(),
     } as unknown as jest.Mocked<EvmWalletProvider>;

--- a/typescript/agentkit/src/action-providers/wow/wowActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/wow/wowActionProvider.ts
@@ -12,7 +12,7 @@ import {
 } from "./constants";
 import { getBuyQuote, getSellQuote } from "./utils";
 import { getHasGraduated } from "./uniswap/utils";
-import { encodeFunctionData } from "viem";
+import { encodeFunctionData, Hex } from "viem";
 import { WowBuyTokenInput, WowCreateTokenInput, WowSellTokenInput } from "./schemas";
 
 /**
@@ -81,7 +81,7 @@ Important notes:
       });
 
       const txHash = await wallet.sendTransaction({
-        to: args.contractAddress as `0x${string}`,
+        to: args.contractAddress as Hex,
         data,
         value: BigInt(args.amountEthInWei),
       });
@@ -139,7 +139,7 @@ Important notes:
       });
 
       const txHash = await wallet.sendTransaction({
-        to: factoryAddress as `0x${string}`,
+        to: factoryAddress as Hex,
         data,
       });
 
@@ -206,7 +206,7 @@ Important notes:
       });
 
       const txHash = await wallet.sendTransaction({
-        to: args.contractAddress as `0x${string}`,
+        to: args.contractAddress as Hex,
         data,
       });
 

--- a/typescript/agentkit/src/utils.test.ts
+++ b/typescript/agentkit/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData } from "viem";
+import { encodeFunctionData, Hex } from "viem";
 import { EvmWalletProvider } from "./wallet-providers";
 import { approve } from "./utils";
 
@@ -14,7 +14,7 @@ describe("utils", () => {
 
     beforeEach(() => {
       mockWallet = {
-        sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+        sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as Hex),
         waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
       } as unknown as jest.Mocked<EvmWalletProvider>;
     });
@@ -28,7 +28,7 @@ describe("utils", () => {
       );
 
       expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-        to: MOCK_TOKEN_ADDRESS as `0x${string}`,
+        to: MOCK_TOKEN_ADDRESS as Hex,
         data: encodeFunctionData({
           abi: [
             {
@@ -43,7 +43,7 @@ describe("utils", () => {
             },
           ],
           functionName: "approve",
-          args: [MOCK_SPENDER_ADDRESS as `0x${string}`, MOCK_AMOUNT],
+          args: [MOCK_SPENDER_ADDRESS as Hex, MOCK_AMOUNT],
         }),
       });
 

--- a/typescript/agentkit/src/utils.ts
+++ b/typescript/agentkit/src/utils.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData } from "viem";
+import { encodeFunctionData, Hex } from "viem";
 import { EvmWalletProvider } from "./wallet-providers";
 
 const ERC20_ABI = [
@@ -33,11 +33,11 @@ export async function approve(
     const data = encodeFunctionData({
       abi: ERC20_ABI,
       functionName: "approve",
-      args: [spenderAddress as `0x${string}`, amount],
+      args: [spenderAddress as Hex, amount],
     });
 
     const txHash = await wallet.sendTransaction({
-      to: tokenAddress as `0x${string}`,
+      to: tokenAddress as Hex,
       data,
     });
 

--- a/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
@@ -5,11 +5,13 @@ import {
   ReadContractReturnType,
   serializeTransaction,
   TransactionRequest,
+  TransactionReceipt,
   TransactionSerializable,
   http,
   keccak256,
   Signature,
   PublicClient,
+  Hex,
 } from "viem";
 import { EvmWalletProvider } from "./evmWalletProvider";
 import { Network } from "../network";
@@ -167,7 +169,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
    * @param message - The message to sign.
    * @returns The signed message.
    */
-  async signMessage(message: string): Promise<`0x${string}`> {
+  async signMessage(message: string): Promise<Hex> {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
@@ -175,7 +177,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
     const messageHash = hashMessage(message);
     const payload = await this.#cdpWallet.createPayloadSignature(messageHash);
 
-    return payload.getSignature() as `0x${string}`;
+    return payload.getSignature() as Hex;
   }
 
   /**
@@ -185,7 +187,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
    * @returns The signed typed data object.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async signTypedData(typedData: any): Promise<`0x${string}`> {
+  async signTypedData(typedData: any): Promise<Hex> {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
@@ -198,7 +200,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
 
     const payload = await this.#cdpWallet.createPayloadSignature(messageHash);
 
-    return payload.getSignature() as `0x${string}`;
+    return payload.getSignature() as Hex;
   }
 
   /**
@@ -207,7 +209,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
    * @param transaction - The transaction to sign.
    * @returns The signed transaction.
    */
-  async signTransaction(transaction: TransactionRequest): Promise<`0x${string}`> {
+  async signTransaction(transaction: TransactionRequest): Promise<Hex> {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
@@ -217,7 +219,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
 
     const payload = await this.#cdpWallet.createPayloadSignature(transactionHash);
 
-    return payload.getSignature() as `0x${string}`;
+    return payload.getSignature() as Hex;
   }
 
   /**
@@ -226,7 +228,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
    * @param transaction - The transaction to send.
    * @returns The hash of the transaction.
    */
-  async sendTransaction(transaction: TransactionRequest): Promise<`0x${string}`> {
+  async sendTransaction(transaction: TransactionRequest): Promise<Hex> {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
@@ -247,7 +249,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
 
     const tx = await externalAddress.broadcastExternalTransaction(signedPayload.slice(2));
 
-    return tx.transactionHash as `0x${string}`;
+    return tx.transactionHash as Hex;
   }
 
   /**
@@ -258,17 +260,13 @@ export class CdpWalletProvider extends EvmWalletProvider {
    * @param data - The data of the transaction.
    * @returns The prepared transaction.
    */
-  async prepareTransaction(
-    to: `0x${string}`,
-    value: bigint,
-    data: `0x${string}`,
-  ): Promise<TransactionSerializable> {
+  async prepareTransaction(to: Hex, value: bigint, data: Hex): Promise<TransactionSerializable> {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
 
     const nonce = await this.#publicClient!.getTransactionCount({
-      address: this.#address! as `0x${string}`,
+      address: this.#address! as Hex,
     });
 
     const feeData = await this.#publicClient!.estimateFeesPerGas();
@@ -306,7 +304,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
    */
   async addSignatureAndSerialize(
     transaction: TransactionSerializable,
-    signature: `0x${string}`,
+    signature: Hex,
   ): Promise<string> {
     // Decode the signature into its components
     const r = `0x${signature.slice(2, 66)}`; // First 32 bytes
@@ -371,8 +369,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
    * @param txHash - The hash of the transaction to wait for.
    * @returns The transaction receipt.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async waitForTransactionReceipt(txHash: `0x${string}`): Promise<any> {
+  async waitForTransactionReceipt(txHash: Hex): Promise<TransactionReceipt> {
     return await this.#publicClient!.waitForTransactionReceipt({ hash: txHash });
   }
 
@@ -470,7 +467,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
    * @param value - The amount to transfer in Wei.
    * @returns The transaction hash.
    */
-  async nativeTransfer(to: `0x${string}`, value: string): Promise<`0x${string}`> {
+  async nativeTransfer(to: Hex, value: string): Promise<Hex> {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
@@ -488,7 +485,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
       throw new Error("Transaction hash not found");
     }
 
-    return result.getTransactionHash() as `0x${string}`;
+    return result.getTransactionHash() as Hex;
   }
 
   /**

--- a/typescript/agentkit/src/wallet-providers/evmWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/evmWalletProvider.ts
@@ -2,7 +2,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { WalletProvider } from "./walletProvider";
-import { TransactionRequest, ReadContractParameters, ReadContractReturnType } from "viem";
+import {
+  TransactionRequest,
+  ReadContractParameters,
+  ReadContractReturnType,
+  TransactionReceipt,
+  Hex,
+} from "viem";
 
 /**
  * EvmWalletProvider is the abstract base class for all EVM wallet providers.
@@ -16,7 +22,7 @@ export abstract class EvmWalletProvider extends WalletProvider {
    * @param message - The message to sign.
    * @returns The signed message.
    */
-  abstract signMessage(message: string | Uint8Array): Promise<`0x${string}`>;
+  abstract signMessage(message: string | Uint8Array): Promise<Hex>;
 
   /**
    * Sign a typed data.
@@ -24,7 +30,7 @@ export abstract class EvmWalletProvider extends WalletProvider {
    * @param typedData - The typed data to sign.
    * @returns The signed typed data.
    */
-  abstract signTypedData(typedData: any): Promise<`0x${string}`>;
+  abstract signTypedData(typedData: any): Promise<Hex>;
 
   /**
    * Sign a transaction.
@@ -32,7 +38,7 @@ export abstract class EvmWalletProvider extends WalletProvider {
    * @param transaction - The transaction to sign.
    * @returns The signed transaction.
    */
-  abstract signTransaction(transaction: TransactionRequest): Promise<`0x${string}`>;
+  abstract signTransaction(transaction: TransactionRequest): Promise<Hex>;
 
   /**
    * Send a transaction.
@@ -40,7 +46,7 @@ export abstract class EvmWalletProvider extends WalletProvider {
    * @param transaction - The transaction to send.
    * @returns The transaction hash.
    */
-  abstract sendTransaction(transaction: TransactionRequest): Promise<`0x${string}`>;
+  abstract sendTransaction(transaction: TransactionRequest): Promise<Hex>;
 
   /**
    * Wait for a transaction receipt.
@@ -48,7 +54,7 @@ export abstract class EvmWalletProvider extends WalletProvider {
    * @param txHash - The transaction hash.
    * @returns The transaction receipt.
    */
-  abstract waitForTransactionReceipt(txHash: `0x${string}`): Promise<any>;
+  abstract waitForTransactionReceipt(txHash: Hex): Promise<TransactionReceipt>;
 
   /**
    * Read a contract.

--- a/typescript/agentkit/src/wallet-providers/evmWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/evmWalletProvider.ts
@@ -1,6 +1,3 @@
-// TODO: Improve type safety
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { WalletProvider } from "./walletProvider";
 import {
   TransactionRequest,
@@ -8,6 +5,7 @@ import {
   ReadContractReturnType,
   TransactionReceipt,
   Hex,
+  HashTypedDataParameters,
 } from "viem";
 
 /**
@@ -30,7 +28,7 @@ export abstract class EvmWalletProvider extends WalletProvider {
    * @param typedData - The typed data to sign.
    * @returns The signed typed data.
    */
-  abstract signTypedData(typedData: any): Promise<Hex>;
+  abstract signTypedData(typedData: HashTypedDataParameters): Promise<Hex>;
 
   /**
    * Sign a transaction.

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
@@ -10,6 +10,8 @@ import {
   ReadContractParameters,
   ReadContractReturnType,
   parseEther,
+  Hex,
+  TransactionReceipt,
 } from "viem";
 import { EvmWalletProvider } from "./evmWalletProvider";
 import { Network } from "../network";
@@ -42,7 +44,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * @param message - The message to sign.
    * @returns The signed message.
    */
-  async signMessage(message: string): Promise<`0x${string}`> {
+  async signMessage(message: string): Promise<Hex> {
     const account = this.#walletClient.account;
     if (!account) {
       throw new Error("Account not found");
@@ -57,7 +59,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * @param typedData - The typed data object to sign.
    * @returns The signed typed data object.
    */
-  async signTypedData(typedData: any): Promise<`0x${string}`> {
+  async signTypedData(typedData: any): Promise<Hex> {
     return this.#walletClient.signTypedData({
       account: this.#walletClient.account!,
       domain: typedData.domain!,
@@ -73,7 +75,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * @param transaction - The transaction to sign.
    * @returns The signed transaction.
    */
-  async signTransaction(transaction: TransactionRequest): Promise<`0x${string}`> {
+  async signTransaction(transaction: TransactionRequest): Promise<Hex> {
     const txParams = {
       account: this.#walletClient.account!,
       to: transaction.to,
@@ -91,7 +93,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * @param transaction - The transaction to send.
    * @returns The hash of the transaction.
    */
-  async sendTransaction(transaction: TransactionRequest): Promise<`0x${string}`> {
+  async sendTransaction(transaction: TransactionRequest): Promise<Hex> {
     const account = this.#walletClient.account;
     if (!account) {
       throw new Error("Account not found");
@@ -164,7 +166,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * @param txHash - The hash of the transaction to wait for.
    * @returns The transaction receipt.
    */
-  async waitForTransactionReceipt(txHash: `0x${string}`): Promise<any> {
+  async waitForTransactionReceipt(txHash: Hex): Promise<TransactionReceipt> {
     return await this.#publicClient.waitForTransactionReceipt({ hash: txHash });
   }
 
@@ -185,7 +187,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * @param value - The amount to transfer in whole units (e.g. ETH)
    * @returns The transaction hash.
    */
-  async nativeTransfer(to: `0x${string}`, value: string): Promise<`0x${string}`> {
+  async nativeTransfer(to: Hex, value: string): Promise<Hex> {
     const atomicAmount = parseEther(value);
 
     const tx = await this.sendTransaction({

--- a/typescript/agentkit/src/wallet-providers/walletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/walletProvider.ts
@@ -1,3 +1,5 @@
+import { Hex } from "viem";
+
 import { Network } from "../network";
 import { sendAnalyticsEvent } from "../analytics";
 
@@ -72,5 +74,5 @@ export abstract class WalletProvider {
    * @param value - The amount to transfer in whole units (e.g. ETH)
    * @returns The transaction hash.
    */
-  abstract nativeTransfer(to: `0x${string}`, value: string): Promise<`0x${string}`>;
+  abstract nativeTransfer(to: Hex, value: string): Promise<Hex>;
 }


### PR DESCRIPTION
### What changed? Why?

Replaced all cases of ``0x${string}`` with `Hex` from Viem for cleanliness.

Also fixed the response type of `waitForTransactionReceipt()` in a few wallet providers.

#### Qualified Impact

Exposes `publicClient` and `walletClient` from `VieimWalletProvider` to allow more custom provider flexibility, since not all viem methods are explicitly included in the class.

Closes #272