### PR TITLE
Add CdpTool.from_cdp_action utility function

### DIFF
--- a/python/cdp-langchain/cdp_langchain/agent_toolkits/cdp_toolkit.py
+++ b/python/cdp-langchain/cdp_langchain/agent_toolkits/cdp_toolkit.py
@@ -130,12 +130,9 @@ class CdpToolkit(BaseToolkit):
         actions = CDP_ACTIONS
 
         tools = [
-            CdpTool(
-                name=action.name,
-                description=action.description,
+            CdpTool.from_cdp_action(
+                cdp_action=action,
                 cdp_agentkit_wrapper=cdp_agentkit_wrapper,
-                args_schema=action.args_schema,
-                func=action.func,
             )
             for action in actions
         ]

--- a/python/cdp-langchain/cdp_langchain/tools/cdp_tool.py
+++ b/python/cdp-langchain/cdp_langchain/tools/cdp_tool.py
@@ -14,6 +14,7 @@ from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 
+from cdp_agentkit_core.actions import CdpAction
 from cdp_langchain.utils.cdp_agentkit_wrapper import CdpAgentkitWrapper
 
 
@@ -25,6 +26,17 @@ class CdpTool(BaseTool):  # type: ignore[override]
     description: str = ""
     args_schema: type[BaseModel] | None = None
     func: Callable[..., str]
+
+    @classmethod
+    def from_cdp_action(cls, cdp_action: CdpAction, cdp_agentkit_wrapper: CdpAgentkitWrapper) -> "CdpTool":
+        """Create a CdpTool from a CdpAction."""
+        return cls(
+            name=cdp_action.name,
+            description=cdp_action.description,
+            cdp_agentkit_wrapper=cdp_agentkit_wrapper,
+            args_schema=cdp_action.args_schema,
+            func=cdp_action.func,
+        )
 
     def _run(
         self,

--- a/python/cdp-langchain/tests/tools/test_cdp_tool.py
+++ b/python/cdp-langchain/tests/tools/test_cdp_tool.py
@@ -7,11 +7,12 @@ import pytest
 from langchain_core.callbacks import CallbackManager
 from pydantic import BaseModel
 
+from cdp_agentkit_core.actions import CdpAction
 from cdp_langchain.tools import CdpTool
 from cdp_langchain.utils import CdpAgentkitWrapper
 
 
-class TestArgsSchema(BaseModel):
+class EmptyArgsSchema(BaseModel):
     """Test schema for validating input arguments."""
 
     test_param: str
@@ -44,7 +45,7 @@ def cdp_tool_with_schema(mock_cdp_agentkit_wrapper):
         cdp_agentkit_wrapper=mock_cdp_agentkit_wrapper,
         name="test_action_with_schema",
         description="Test CDP Tool",
-        args_schema=TestArgsSchema,
+        args_schema=EmptyArgsSchema,
         func=lambda x: x,
     )
 
@@ -58,6 +59,25 @@ def test_initialization(mock_cdp_agentkit_wrapper):
         func=lambda x: x,
     )
     assert tool.name == "test_action"
+    assert tool.description == "Test CDP Tool"
+    assert tool.func("test") == "test"
+
+
+def test_from_action(mock_cdp_agentkit_wrapper):
+    """Test basic creation of CDP Tool from an action."""
+    cdp_action = CdpAction(
+        name="test_action",
+        description="Test CDP Tool",
+        args_schema=None,
+        func=lambda x: x,
+    )
+    tool = CdpTool.from_cdp_action(
+        cdp_action=cdp_action,
+        cdp_agentkit_wrapper=mock_cdp_agentkit_wrapper,
+    )
+    assert tool.name == "test_action"
+    assert tool.description == "Test CDP Tool"
+    assert tool.func("test") == "test"
 
 
 def test_run_with_instructions(cdp_tool):


### PR DESCRIPTION
### What changed? Why?

I added from_cdp_action to CdpTool. This makes using custom actions slightly less verbose.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

Only additions so no major impact, can be trivially rolled back.
