### PR TITLE
Enable source maps during the build process to simplify debugging.

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
+    "sourceMap": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,


### PR DESCRIPTION
### What changed? Why?

I just changed the source maps when building the library

#### Qualified Impact
Currently, the library is quite new and serves as a framework for building new tools. However, its documentation is still limited, making it difficult to understand its inner workings without attaching a debugger. Adding source maps will make debugging much easier and more convenient for users who install the package and begin to use the library.