### PR TITLE
chore: Updated the repository field in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "author": "Coinbase Inc.",
   "license": "Apache-2.0",
-  "repository": "https://github.com/coinbase/cdp-agentkit-nodejs",
+  "repository": "https://github.com/coinbase/agentkit",
   "keywords": [
     "coinbase",
     "sdk",


### PR DESCRIPTION
### What changed? Why?

The old repository url `https://github.com/coinbase/cdp-agentkit-nodejs` in the `package.json` has been changed to the new one `https://github.com/coinbase/agentkit`. As simple as that.

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->

No or minimal impact to the users. The impact can only be noticeable if the entire monorepo gets published to NPM, or in some Github analytic/statistic tools.