### PR TITLE
fix: use HTTPProvider

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -26,7 +26,7 @@ class EthAccountWalletProvider(EvmWalletProvider):
     def __init__(self, config: EthAccountWalletProviderConfig):
         """Initialize the wallet provider with a private key and RPC URL."""
         self.config = config
-        self.web3 = Web3(Web3.http_provider(config.rpc_url))
+        self.web3 = Web3(Web3.HTTPProvider(config.rpc_url))
         self.account = Account.from_key(config.private_key)
 
     def get_address(self) -> str:


### PR DESCRIPTION
### What changed? Why?
Basically a typo

Tested with:
```python
if __name__ == "__main__":
    w3 = Web3()
    private_key = os.environ.get("PRIVATE_KEY")
    assert private_key is not None, "You must set PRIVATE_KEY environment variable"
    assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"

    account: LocalAccount = Account.from_key(private_key)
    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(account), layer=0)

    print(f"Your hot wallet address is {account.address}")

    wallet = EthAccountWalletProvider(
        config=EthAccountWalletProviderConfig(
            private_key=private_key,
            rpc_url="https://sepolia.base.org",
            chain_id=84532,
        )
    )

    print(wallet.read_contract(
        contract_address=Web3.to_checksum_address("0x4200000000000000000000000000000000000006"),
        abi=ERC20_ABI,
        function_name="balanceOf",
        args=[wallet.get_address()],
    ))

    print(wallet.sign_message("Hello, world!"))
```

Output was:
```
Your hot wallet address is 0x9Dcd61940a94c921d8CC77472ac396deB112852E
0
67167234f530abed8ea1b4877da92f3fd25eb45ddce89752e1aae5f7045e07705909237a97fc245ea3216a06fcabd23a427ab1eacc8b96654d69823f1e9d5d721b
```