### PR TITLE
PayloadSignature.wait for Server-Signers

### DIFF
--- a/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
@@ -175,6 +175,10 @@ export class CdpWalletProvider extends EvmWalletProvider {
     const messageHash = hashMessage(message);
     const payload = await this.#cdpWallet.createPayloadSignature(messageHash);
 
+    if (payload.getStatus() === "pending" && payload?.wait) {
+      await payload.wait(); // needed for Server-Signers
+    }
+
     return payload.getSignature() as `0x${string}`;
   }
 
@@ -198,6 +202,10 @@ export class CdpWalletProvider extends EvmWalletProvider {
 
     const payload = await this.#cdpWallet.createPayloadSignature(messageHash);
 
+    if (payload.getStatus() === "pending" && payload?.wait) {
+      await payload.wait(); // needed for Server-Signers
+    }
+
     return payload.getSignature() as `0x${string}`;
   }
 
@@ -216,6 +224,10 @@ export class CdpWalletProvider extends EvmWalletProvider {
     const transactionHash = keccak256(serializedTx);
 
     const payload = await this.#cdpWallet.createPayloadSignature(transactionHash);
+
+    if (payload.getStatus() === "pending" && payload?.wait) {
+      await payload.wait(); // needed for Server-Signers
+    }
 
     return payload.getSignature() as `0x${string}`;
   }


### PR DESCRIPTION
### What changed? Why?
CDPWalletProvider.sendTransaction was missing the signature for Server-Signers wallets.


#### Qualified Impact
Now the CDPWalletProvider can be used for Server-Signers wallets to send custom contract calls.