### PR TITLE
fix: viem chainId from number to string

### DIFF
--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
@@ -130,7 +130,7 @@ export class ViemWalletProvider extends EvmWalletProvider {
   getNetwork(): Network {
     return {
       protocolFamily: "evm" as const,
-      chainId: this.#walletClient.chain!.id! as any as string,
+      chainId: String(this.#walletClient.chain!.id!),
       networkId: CHAIN_ID_TO_NETWORK_ID[this.#walletClient.chain!.id!],
     };
   }


### PR DESCRIPTION
### What changed? Why?

One-liner: viem's chainId is a number, [agentkit expects a string ](https://github.com/coinbase/agentkit/blob/master/typescript/agentkit/src/network/types.ts#L18)

#### Qualified Impact
Avoids potential footgun when action providers are checking networks e.g. [in this line](https://github.com/coinbase/agentkit/blob/master/typescript/agentkit/src/agentkit.ts#L74)
