### PR TITLE
chore: add web3.py transaction gas fee estimation

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/__init__.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/__init__.py
@@ -2,4 +2,10 @@ from .action_decorator import create_action
 from .action_provider import Action, ActionProvider
 from .pyth.pyth_action_provider import PythActionProvider, pyth_action_provider
 
-__all__ = ["Action", "ActionProvider", "create_action", "PythActionProvider", "pyth_action_provider"]
+__all__ = [
+    "Action",
+    "ActionProvider",
+    "create_action",
+    "PythActionProvider",
+    "pyth_action_provider",
+]


### PR DESCRIPTION
### What changed? Why?

Tested with:
```
import os

from eth_account import Account
from web3 import Web3

from coinbase_agentkit.wallet_providers import EthAccountWalletProvider
from coinbase_agentkit.wallet_providers.eth_account_wallet_provider import (
    EthAccountWalletProviderConfig,
)

private_key = os.environ.get("PRIVATE_KEY")
assert private_key is not None, "You must set PRIVATE_KEY environment variable"
assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"

account = Account.from_key(private_key)

print(account.address)

wallet_provider = EthAccountWalletProvider(
    EthAccountWalletProviderConfig(
        private_key=private_key, rpc_url="https://mainnet.base.org", chain_id=8453
    )
)

hash = wallet_provider.send_transaction(
    {
        "from": account.address,
        "to": "0xb6D94932CDA2A2b0989a5A77ca5935b9D2964ec6",
        "value": Web3.to_wei(0.00001, "ether"),
    }
)

receipt = wallet_provider.wait_for_transaction_receipt(hash)

if receipt["status"]:
    print("Transaction successful!")
    print("Transaction hash:", hash)
    print(f"Explorer link: https://basescan.org/tx/{hash}")
else:
    print("Transaction failed.")
```
