### PR TITLE
Sushi: swap, quote and find-token actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1888,6 +1888,14 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
     },
+    "node_modules/@uniswap/token-lists": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz",
+      "integrity": "sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/abitype": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
@@ -2437,6 +2445,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/big.js": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
+      "integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
       }
     },
     "node_modules/binary-extensions": {
@@ -3033,6 +3053,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -3087,6 +3116,11 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/dedent": {
       "version": "1.5.3",
@@ -8034,6 +8068,11 @@
       "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "node_modules/semver": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
@@ -8528,6 +8567,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sushi": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/sushi/-/sushi-5.0.13.tgz",
+      "integrity": "sha512-G6fHMUfpFHQrmJ2kdcjC0iIUT82VHN7/QOSHW+EOSj94irZBBsZqMVTZiLLJGTGNL64VKvl50YtwH70xqnBwCA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sushi-labs"
+        }
+      ],
+      "dependencies": {
+        "@uniswap/token-lists": "1.0.0-beta.33",
+        "big.js": "6.1.1",
+        "date-fns": "3.3.1",
+        "decimal.js-light": "2.5.1",
+        "seedrandom": "3.0.5",
+        "tiny-invariant": "1.3.3",
+        "toformat": "2.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 5.5.4 < 6",
+        "viem": "*",
+        "zod": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/synckit": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
@@ -8586,6 +8661,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -8603,6 +8683,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toformat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/toformat/-/toformat-2.0.0.tgz",
+      "integrity": "sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ=="
     },
     "node_modules/touch": {
       "version": "3.1.1",
@@ -9529,6 +9614,7 @@
         "@coinbase/coinbase-sdk": "^0.17.0",
         "md5": "^2.3.0",
         "reflect-metadata": "^0.2.2",
+        "sushi": "5.0.13",
         "twitter-api-v2": "^1.18.2",
         "viem": "^2.22.16",
         "zod": "^3.23.8"
@@ -10074,6 +10160,7 @@
         "md5": "^2.3.0",
         "mock-fs": "^5.2.0",
         "reflect-metadata": "^0.2.2",
+        "sushi": "5.0.13",
         "ts-jest": "^29.2.5",
         "tsd": "^0.31.2",
         "twitter-api-v2": "^1.18.2",
@@ -11238,6 +11325,11 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
     },
+    "@uniswap/token-lists": {
+      "version": "1.0.0-beta.33",
+      "resolved": "https://registry.npmjs.org/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz",
+      "integrity": "sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg=="
+    },
     "abitype": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
@@ -11626,6 +11718,11 @@
       "requires": {
         "safe-buffer": "5.1.2"
       }
+    },
+    "big.js": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.1.1.tgz",
+      "integrity": "sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg=="
     },
     "binary-extensions": {
       "version": "2.3.0",
@@ -12037,6 +12134,11 @@
         "is-data-view": "^1.0.1"
       }
     },
+    "date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw=="
+    },
     "debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -12073,6 +12175,11 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
+    },
+    "decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "dedent": {
       "version": "1.5.3",
@@ -15628,6 +15735,11 @@
       "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
       "dev": true
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "semver": {
       "version": "7.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
@@ -15997,6 +16109,20 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "sushi": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/sushi/-/sushi-5.0.13.tgz",
+      "integrity": "sha512-G6fHMUfpFHQrmJ2kdcjC0iIUT82VHN7/QOSHW+EOSj94irZBBsZqMVTZiLLJGTGNL64VKvl50YtwH70xqnBwCA==",
+      "requires": {
+        "@uniswap/token-lists": "1.0.0-beta.33",
+        "big.js": "6.1.1",
+        "date-fns": "3.3.1",
+        "decimal.js-light": "2.5.1",
+        "seedrandom": "3.0.5",
+        "tiny-invariant": "1.3.3",
+        "toformat": "2.0.0"
+      }
+    },
     "synckit": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
@@ -16045,6 +16171,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -16059,6 +16190,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toformat": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/toformat/-/toformat-2.0.0.tgz",
+      "integrity": "sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ=="
     },
     "touch": {
       "version": "3.1.1",

--- a/typescript/agentkit/CHANGELOG.md
+++ b/typescript/agentkit/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Added `sushiRouterActionProvider` to provide swap and quote functionality using the Sushi Router API.
+- Added `swap` action for swaps.
+- Added `quote` action for fetching quotes for swaps.
+- Added `sushiDataActionProvider` to provide token finding functionality using the Sushi Data API.
+- Added `find-tokens` action for fetching tokens by symbols or addresses.
+
 ## [0.1.2] - 2025-02-07
 
 ### Added

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -42,6 +42,7 @@
     "@coinbase/coinbase-sdk": "^0.17.0",
     "md5": "^2.3.0",
     "reflect-metadata": "^0.2.2",
+    "sushi": "5.0.13",
     "twitter-api-v2": "^1.18.2",
     "viem": "^2.22.16",
     "zod": "^3.23.8"

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -14,3 +14,4 @@ export * from "./wallet";
 export * from "./customActionProvider";
 export * from "./alchemy";
 export * from "./moonwell";
+export * from "./sushi";

--- a/typescript/agentkit/src/action-providers/sushi/README.md
+++ b/typescript/agentkit/src/action-providers/sushi/README.md
@@ -1,0 +1,1 @@
+# Sushi Swap, Quote and Token provider

--- a/typescript/agentkit/src/action-providers/sushi/constants.ts
+++ b/typescript/agentkit/src/action-providers/sushi/constants.ts
@@ -1,0 +1,5 @@
+import { parseAbi } from "viem";
+
+export const routeProcessor5Abi_Route = parseAbi([
+  "event Route(address indexed from, address to, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOutMin, uint256 amountOut)",
+]);

--- a/typescript/agentkit/src/action-providers/sushi/index.ts
+++ b/typescript/agentkit/src/action-providers/sushi/index.ts
@@ -1,0 +1,4 @@
+export * from "./sushiDataSchemas";
+export * from "./sushiDataActionProvider";
+export * from "./sushiRouterSchemas";
+export * from "./sushiRouterActionProvider";

--- a/typescript/agentkit/src/action-providers/sushi/sushiDataActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiDataActionProvider.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import { ViemWalletProvider } from "../../wallet-providers";
+import { CreateAction } from "../actionDecorator";
+import { ActionProvider } from "../actionProvider";
+import { Network } from "../../network";
+import { FindTokenSchema } from "./sushiDataSchemas";
+import { EvmChain, isEvmChainId } from "sushi";
+import { SUSHI_DATA_API_HOST } from "sushi/config/subgraph";
+import { isAddress } from "viem";
+
+/**
+ * SushiDataActionProvider is an action provider for Sushi.
+ *
+ * This provider is used for any action that uses the Sushi Data API.
+ */
+export class SushiDataActionProvider extends ActionProvider<ViemWalletProvider> {
+  /**
+   * Constructor for the SushiDataActionProvider class.
+   */
+  constructor() {
+    super("sushi-data", []);
+  }
+
+  /**
+   * Swaps a specified amount of a from token to a to token for the wallet.
+   *
+   * @param walletProvider - The wallet provider to swap the tokens from.
+   * @param args - The input arguments for the action.
+   * @returns A message containing the swap details.
+   */
+  @CreateAction({
+    name: "find-token",
+    description: `This tool finds tokens (erc20) using the Sushi Data API
+It takes the following inputs:
+- Search: Either the token symbol (either full or partial) or token address to search for
+
+Important notes:
+- Only returns the first 10 tokens found
+- Always use the full token symbol for better results
+- Always use this tool to verify the token address if you are not sure about the address
+`,
+    schema: FindTokenSchema,
+  })
+  async findToken(
+    walletProvider: ViemWalletProvider,
+    args: z.infer<typeof FindTokenSchema>,
+  ): Promise<string> {
+    try {
+      const chainId = Number((await walletProvider.getNetwork()).chainId);
+
+      const request = await fetch(`${SUSHI_DATA_API_HOST}/graphql`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: `{"query":"query { tokenList(chainId: ${chainId}, first: 10, search: \\"${args.search}\\") { address symbol name decimals } }"}`,
+      });
+
+      const response = await request.json();
+
+      const schema = z.object({
+        data: z.object({
+          tokenList: z.array(
+            z.object({
+              address: z.string().refine(val => isAddress(val, { strict: false })),
+              symbol: z.string(),
+              name: z.string(),
+              decimals: z.number(),
+            }),
+          ),
+        }),
+      });
+
+      const result = schema.safeParse(response);
+
+      if (!result.success) {
+        return `Error parsing response: ${result.error.message}`;
+      }
+
+      const tokens = result.data.data.tokenList;
+
+      const chain = EvmChain.from(chainId)!;
+
+      let message = `Found ${tokens.length} tokens on ${chain.shortName}:`;
+      tokens.forEach(token => {
+        message += `\n- ${token.symbol} (${token.name}) - ${token.address}`;
+      });
+      return message;
+    } catch (error) {
+      return `Error finding tokens: ${error}`;
+    }
+  }
+
+  /**
+   * Custom action providers are supported on all networks
+   *
+   * @param network - The network to checkpointSaver
+   * @returns True if the network is supported, false otherwise
+   */
+  supportsNetwork(network: Network): boolean {
+    if (network.protocolFamily !== "evm" || !network.chainId) {
+      return false;
+    }
+
+    return isEvmChainId(Number(network.chainId));
+  }
+}
+
+export const sushiDataActionProvider = () => new SushiDataActionProvider();

--- a/typescript/agentkit/src/action-providers/sushi/sushiDataSchemas.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiDataSchemas.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+/**
+ * Input schema for find token action
+ */
+export const FindTokenSchema = z
+  .object({
+    search: z
+      .string()
+      .min(2)
+      .describe("Either the (partial or complete) symbol OR the address of the token to find"),
+  })
+  .strip()
+  .describe("Instructions for finding a token");

--- a/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.test.ts
@@ -1,0 +1,520 @@
+import { ViemWalletProvider } from "../../wallet-providers";
+import { QuoteSchema, SwapSchema } from "./sushiRouterSchemas";
+import { getSwap, SwapResponse } from "sushi";
+import { SushiRouterActionProvider } from "./sushiRouterActionProvider";
+import { RouteStatus } from "sushi/router";
+import {
+  Address,
+  encodeAbiParameters,
+  encodeEventTopics,
+  formatUnits,
+  parseAbiParameters,
+} from "viem";
+import { routeProcessor5Abi_Route } from "./constants";
+import { nativeAddress } from "sushi/config";
+
+// Mock the entire module
+jest.mock("sushi");
+const mockedGetSwap = getSwap as jest.MockedFunction<typeof getSwap>;
+const EvmChain = jest.requireActual("sushi/chain").EvmChain;
+
+describe("Sushi Action Provider Input Schemas", () => {
+  describe("Swap Schema", () => {
+    it("should successfully parse valid input", () => {
+      const validInput = {
+        fromAssetAddress: "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83",
+        amount: "0.0001",
+        toAssetAddress: "0x1234567890123456789012345678901234567890",
+        maxSlippage: 0.005,
+      };
+
+      const result = SwapSchema.safeParse(validInput);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(validInput);
+    });
+
+    it("should fail parsing invalid fromAssetAddress", () => {
+      const invalidInput = {
+        fromAssetAddress: "invalid-address",
+        amount: "0.0001",
+        toAssetAddress: "0x1234567890123456789012345678901234567890",
+        maxSlippage: 0.005,
+      };
+      const result = SwapSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail parsing invalid toAssetAddress", () => {
+      const invalidInput = {
+        fromAssetAddress: "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83",
+        amount: "0.0001",
+        toAssetAddress: "invalid-address",
+        maxSlippage: 0.005,
+      };
+      const result = SwapSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail parsing invalid maxSlippage (>1)", () => {
+      const invalidInput = {
+        fromAssetAddress: "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83",
+        amount: "0.0001",
+        toAssetAddress: "0x1234567890123456789012345678901234567890",
+        maxSlippage: 1.1,
+      };
+      const result = SwapSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail parsing invalid maxSlippage (<0)", () => {
+      const invalidInput = {
+        fromAssetAddress: "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83",
+        amount: "0.0001",
+        toAssetAddress: "0x1234567890123456789012345678901234567890",
+        maxSlippage: -1.1,
+      };
+      const result = SwapSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Quote Schema", () => {
+    it("should successfully parse valid input", () => {
+      const validInput = {
+        fromAssetAddress: "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83",
+        amount: "0.0001",
+        toAssetAddress: "0x1234567890123456789012345678901234567890",
+        chainId: 1,
+      };
+
+      const result = QuoteSchema.safeParse(validInput);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual(validInput);
+    });
+
+    it("should fail parsing invalid fromAssetAddress", () => {
+      const invalidInput = {
+        fromAssetAddress: "invalid-address",
+        amount: "0.0001",
+        toAssetAddress: "0x1234567890123456789012345678901234567890",
+        maxSlippage: 0.005,
+      };
+      const result = QuoteSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should fail parsing invalid toAssetAddress", () => {
+      const invalidInput = {
+        fromAssetAddress: "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83",
+        amount: "0.0001",
+        toAssetAddress: "invalid-address",
+        maxSlippage: 0.005,
+      };
+      const result = QuoteSchema.safeParse(invalidInput);
+
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("Sushi Action Provider", () => {
+  let actionProvider: SushiRouterActionProvider;
+  let mockWallet: jest.Mocked<ViemWalletProvider>;
+
+  type Token = { address: Address; decimals: number; symbol: string; name: string };
+
+  const amountIn = BigInt(1000000);
+  const amountOut = BigInt(500000);
+
+  const nativeToken: Token = {
+    address: nativeAddress,
+    symbol: "ETH",
+    name: "Ether",
+    decimals: 18,
+  };
+  const tokenIn: Token = {
+    address: "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+    symbol: "TIN",
+    name: "Token In",
+    decimals: 18,
+  };
+  const tokenOut: Token = {
+    address: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+    symbol: "TOU",
+    name: "Token Out",
+    decimals: 18,
+  } as const;
+
+  const user = "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF";
+
+  const txHash = "0xhash";
+
+  const chainId = 1;
+
+  const getRouteLog = ({
+    tokenIn,
+    tokenOut,
+    amountIn,
+    amountOut,
+  }: {
+    tokenIn: Token;
+    tokenOut: Token;
+    amountIn: bigint;
+    amountOut: bigint;
+  }) => [
+    {
+      data: encodeAbiParameters(
+        parseAbiParameters("address to, uint256 amountIn, uint256 amountOutMin, uint256 amountOut"),
+        [user, amountIn, amountOut, amountOut],
+      ),
+      topics: encodeEventTopics({
+        abi: routeProcessor5Abi_Route,
+        eventName: "Route",
+        args: {
+          from: user,
+          tokenIn: tokenIn.address,
+          tokenOut: tokenOut.address,
+        },
+      }),
+    },
+  ];
+
+  const getSuccessfullSwapResponse = async ({
+    tokenIn,
+    amountIn,
+    tokenOut,
+    amountOut,
+  }: {
+    tokenIn: Token;
+    amountIn: bigint;
+    tokenOut: Token;
+    amountOut: bigint;
+  }): Promise<SwapResponse> => ({
+    amountIn: String(amountIn),
+    assumedAmountOut: String(amountOut),
+    priceImpact: 0,
+    status: RouteStatus.Success,
+    swapPrice: 1,
+    tokens: [tokenIn, tokenOut],
+    tokenFrom: tokenIn,
+    tokenTo: tokenOut,
+    tx: {
+      to: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+      data: "0x",
+      from: user,
+      value: BigInt(0),
+    },
+  });
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+
+    actionProvider = new SushiRouterActionProvider();
+    mockWallet = {
+      readContract: jest.fn(),
+      sendTransaction: jest.fn(),
+      waitForTransactionReceipt: jest.fn(),
+      getBalance: jest.fn(),
+      getNetwork: jest.fn().mockResolvedValue({
+        protocolFamily: "evm",
+        networkId: "ethereum-mainnet",
+        chainId: String(chainId),
+      }),
+      getAddress: jest.fn().mockReturnValue(user),
+    } satisfies Partial<
+      jest.Mocked<ViemWalletProvider>
+    > as unknown as jest.Mocked<ViemWalletProvider>;
+  });
+
+  describe("swap", () => {
+    it("should successfully perform a swap (token -> token)", async () => {
+      const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: tokenIn.address,
+        toAssetAddress: tokenOut.address,
+        maxSlippage: 0.005,
+      };
+
+      /*
+       * 1. Mock the readContract which checks the decimals of the fromAssetAddress token (18, default)
+       * 2. Mock the readContract which checks for the balance of the fromAssetAddress token (1000000, enough balance)
+       * 3. Mock the readContract which checks for the approval (0, not approved)
+       */
+      mockWallet.readContract
+        .mockResolvedValueOnce(tokenIn.decimals)
+        .mockResolvedValueOnce(amountIn)
+        .mockResolvedValueOnce(BigInt(0));
+
+      mockWallet.sendTransaction.mockResolvedValue(txHash);
+
+      /*
+       * 1. Mock the waitForTransactionReceipt to return success for the approval tx
+       * 2. Mock the waitForTransactionReceipt to return success for the swap tx, including the Route log
+       */
+      mockWallet.waitForTransactionReceipt
+        .mockResolvedValueOnce({
+          status: "success",
+        })
+        .mockResolvedValueOnce({
+          status: "success",
+          logs: getRouteLog({
+            tokenIn,
+            tokenOut,
+            amountIn,
+            amountOut,
+          }),
+        });
+
+      mockedGetSwap.mockReturnValue(
+        getSuccessfullSwapResponse({
+          tokenIn,
+          amountIn,
+          tokenOut,
+          amountOut,
+        }),
+      );
+
+      const result = await actionProvider.swap(mockWallet, args);
+
+      expect(mockWallet.readContract).toHaveBeenCalledTimes(3); // Decimals + Balance + Approval
+      expect(mockWallet.sendTransaction).toHaveBeenCalledTimes(2); // Approval + Swap
+      expect(mockedGetSwap).toHaveBeenCalledTimes(2);
+
+      expect(result).toContain(
+        `Swapped ${formatUnits(amountIn, tokenIn.decimals)} of ${tokenIn.symbol} (${tokenIn.address}) for ${formatUnits(amountOut, tokenOut.decimals)} of ${tokenOut.symbol} (${tokenOut.address})`,
+      );
+      expect(result).toContain(`Transaction hash: ${txHash}`);
+      expect(result).toContain(`Transaction link: ${EvmChain.from(chainId)!.getTxUrl(txHash)}`);
+      expect(result).toContain(`on ${EvmChain.from(chainId)!.shortName}`);
+    });
+
+    it("should successfully perform a swap (native -> token)", async () => {
+      const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: nativeToken.address,
+        toAssetAddress: tokenOut.address,
+        maxSlippage: 0.005,
+      };
+
+      // Mock the readContract which checks for the balance of the fromAssetAddress token (1000000, enough balance)
+      mockWallet.getBalance.mockResolvedValue(amountIn);
+
+      mockWallet.sendTransaction.mockResolvedValue(txHash);
+
+      // Mock the waitForTransactionReceipt to return success for the swap tx, including the Route log
+      mockWallet.waitForTransactionReceipt.mockResolvedValueOnce({
+        status: "success",
+        logs: getRouteLog({
+          tokenIn: nativeToken,
+          tokenOut,
+          amountIn,
+          amountOut,
+        }),
+      });
+
+      mockedGetSwap.mockReturnValue(
+        getSuccessfullSwapResponse({
+          tokenIn: nativeToken,
+          amountIn,
+          tokenOut,
+          amountOut,
+        }),
+      );
+
+      const result = await actionProvider.swap(mockWallet, args);
+
+      expect(mockWallet.getBalance).toHaveBeenCalledTimes(1);
+      expect(mockWallet.readContract).toHaveBeenCalledTimes(0); // No balance check nor approval
+      expect(mockWallet.sendTransaction).toHaveBeenCalledTimes(1); // Swap
+      expect(mockedGetSwap).toHaveBeenCalledTimes(2);
+
+      expect(result).toContain(
+        `Swapped ${formatUnits(amountIn, nativeToken.decimals)} of ${nativeToken.symbol} (${nativeToken.address}) for ${formatUnits(amountOut, tokenOut.decimals)} of ${tokenOut.symbol} (${tokenOut.address})`,
+      );
+      expect(result).toContain(`Transaction hash: ${txHash}`);
+      expect(result).toContain(`Transaction link: ${EvmChain.from(chainId)!.getTxUrl(txHash)}`);
+      expect(result).toContain(`on ${EvmChain.from(chainId)!.shortName}`);
+    });
+
+    it("should fail if there isn't enough balance (native)", async () => {
+      const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: nativeToken.address,
+        toAssetAddress: tokenOut.address,
+        maxSlippage: 0.005,
+      };
+
+      // Mock the readContract which checks for the balance of the fromAssetAddress token (99, not enough balance)
+      mockWallet.getBalance.mockResolvedValue(amountIn - BigInt(1));
+
+      const result = await actionProvider.swap(mockWallet, args);
+
+      expect(mockWallet.getBalance).toHaveBeenCalledTimes(1);
+      expect(mockWallet.readContract).toHaveBeenCalledTimes(0);
+      expect(mockWallet.sendTransaction).toHaveBeenCalledTimes(0);
+      expect(mockedGetSwap).toHaveBeenCalledTimes(1);
+
+      expect(result).toContain(
+        `Swap failed: Insufficient balance for ${nativeToken.symbol} (${nativeToken.address})`,
+      );
+    });
+
+    it("should fail if there isn't enough balance (token)", async () => {
+      const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: tokenIn.address,
+        toAssetAddress: tokenOut.address,
+        maxSlippage: 0.005,
+      };
+
+      /*
+       * 1. Mock the readContract which checks the decimals of the fromAssetAddress token (18, default)
+       * 2. Mock the readContract which checks for the balance of the fromAssetAddress token (1000000, enough balance)
+       */
+      mockWallet.readContract.mockResolvedValueOnce(18).mockResolvedValue(amountIn - BigInt(1));
+
+      mockedGetSwap.mockReturnValue(
+        getSuccessfullSwapResponse({
+          tokenIn,
+          amountIn,
+          tokenOut,
+          amountOut,
+        }),
+      );
+
+      const result = await actionProvider.swap(mockWallet, args);
+
+      expect(mockWallet.getBalance).toHaveBeenCalledTimes(0);
+      expect(mockWallet.readContract).toHaveBeenCalledTimes(2);
+      expect(mockWallet.sendTransaction).toHaveBeenCalledTimes(0);
+      expect(mockedGetSwap).toHaveBeenCalledTimes(1);
+
+      expect(result).toContain(
+        `Swap failed: Insufficient balance for ${tokenIn.symbol} (${tokenIn.address})`,
+      );
+    });
+
+    it("should not approve if already approved", async () => {
+      const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: tokenIn.address,
+        toAssetAddress: tokenOut.address,
+        maxSlippage: 0.005,
+      };
+
+      /*
+       * 1. Mock the readContract which checks the decimals of the fromAssetAddress token (18, default)
+       * 2. Mock the readContract which checks for the balance of the fromAssetAddress token (1000000, enough balance)
+       * 3. Mock the readContract which checks for the approval (1000000, approved)
+       */
+      mockWallet.readContract
+        .mockResolvedValueOnce(tokenIn.decimals)
+        .mockResolvedValueOnce(amountIn)
+        .mockResolvedValueOnce(amountIn);
+
+      mockWallet.sendTransaction.mockResolvedValue(txHash);
+
+      // Mock the waitForTransactionReceipt to return success for the swap tx, including the Route log
+      mockWallet.waitForTransactionReceipt.mockResolvedValueOnce({
+        status: "success",
+        logs: getRouteLog({
+          tokenIn,
+          tokenOut,
+          amountIn,
+          amountOut,
+        }),
+      });
+
+      mockedGetSwap.mockReturnValue(
+        getSuccessfullSwapResponse({
+          tokenIn,
+          amountIn,
+          tokenOut,
+          amountOut,
+        }),
+      );
+      const result = await actionProvider.swap(mockWallet, args);
+
+      expect(mockWallet.getBalance).toHaveBeenCalledTimes(0);
+      expect(mockWallet.readContract).toHaveBeenCalledTimes(3); // Decimals + Balance + Allowance
+      expect(mockWallet.sendTransaction).toHaveBeenCalledTimes(1); // Swap
+      expect(mockedGetSwap).toHaveBeenCalledTimes(2);
+
+      expect(result).toContain(`Swapped`);
+    });
+
+    it("should fail if there's no route", async () => {
+      const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: tokenIn.address,
+        toAssetAddress: tokenOut.address,
+        maxSlippage: 0.005,
+      };
+
+      /*
+       * 1. Mock the readContract which checks for decimals of the fromAssetAddress token (18, default)
+       * 2. Mock the readContract which checks for the balance of the fromAssetAddress token (1000000, enough balance)
+       */
+      mockWallet.readContract
+        .mockResolvedValueOnce(tokenIn.decimals)
+        .mockResolvedValueOnce(amountIn);
+
+      mockedGetSwap.mockReturnValue(
+        new Promise(r =>
+          r({
+            status: RouteStatus.NoWay,
+          }),
+        ),
+      );
+
+      const result = await actionProvider.swap(mockWallet, args);
+
+      expect(mockWallet.getBalance).toHaveBeenCalledTimes(0);
+      expect(mockWallet.readContract).toHaveBeenCalledTimes(1); // Decimals
+      expect(mockWallet.sendTransaction).toHaveBeenCalledTimes(0);
+      expect(mockedGetSwap).toHaveBeenCalledTimes(1);
+
+      expect(result).toContain(
+        `No route found to swap ${amountIn} of ${tokenIn.address} for ${tokenOut.address}`,
+      );
+    });
+  });
+
+  describe("quote", () => {
+    it("should successfully fetch a quote (token -> token)", async () => {
+      const args: Parameters<(typeof actionProvider)["quote"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: tokenIn.address,
+        toAssetAddress: tokenOut.address,
+        chainId: 1,
+      };
+
+      mockedGetSwap.mockReturnValue(
+        getSuccessfullSwapResponse({
+          tokenIn,
+          amountIn,
+          tokenOut,
+          amountOut,
+        }),
+      );
+
+      const result = await actionProvider.quote(mockWallet, args);
+
+      expect(mockedGetSwap).toHaveBeenCalledTimes(1);
+
+      expect(result).toContain(
+        `Found a quote for ${tokenIn.symbol} (${tokenIn.address}) -> ${tokenOut.symbol} (${tokenOut.address})`,
+      );
+      expect(result).toContain(`AmountIn: ${formatUnits(amountIn, tokenIn.decimals)}`);
+      expect(result).toContain(`AmountOut: ${formatUnits(amountOut, tokenOut.decimals)}`);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.ts
@@ -1,0 +1,457 @@
+import { z } from "zod";
+import { isExtractorSupportedChainId, nativeAddress } from "sushi/config";
+import { ViemWalletProvider } from "../../wallet-providers";
+import { CreateAction } from "../actionDecorator";
+import { ActionProvider } from "../actionProvider";
+import { QuoteSchema, SwapSchema } from "./sushiRouterSchemas";
+import { Network } from "../../network";
+import { getSwap, SwapResponse } from "sushi";
+import { RouteStatus } from "sushi/router";
+import {
+  Address,
+  decodeEventLog,
+  encodeEventTopics,
+  encodeFunctionData,
+  erc20Abi,
+  formatUnits,
+  parseUnits,
+  TransactionReceipt,
+} from "viem";
+import { EvmChain } from "sushi/chain";
+import { routeProcessor5Abi_Route } from "./constants";
+import { Native } from "sushi/currency";
+
+/**
+ * SushiRouterActionProvider is an action provider for Sushi.
+ *
+ * This provider is used for any action that uses the Sushi Router API.
+ */
+export class SushiRouterActionProvider extends ActionProvider<ViemWalletProvider> {
+  /**
+   * Constructor for the SushiRouterActionProvider class.
+   */
+  constructor() {
+    super("sushi-router", []);
+  }
+
+  /**
+   * Swaps a specified amount of a from token to a to token for the wallet.
+   *
+   * @param walletProvider - The wallet provider to swap the tokens from.
+   * @param args - The input arguments for the action.
+   * @returns A message containing the swap details.
+   */
+  @CreateAction({
+    name: "swap",
+    description: `This tool will swap a specified amount of a 'from token' (erc20) to a 'to token' (erc20) for the wallet.
+It takes the following inputs:
+- The human-readable amount of the 'from token' to swap
+- The from token address to trade
+- The token address to receive from the swap
+- The maximum slippage allowed for the swap, where 0 is 0% and 1 is 100%, the default is 0.005 (0.05%)
+
+Important notes:
+- The native asset (ie 'eth' on 'ethereum-mainnet') is represented by ${nativeAddress} (not the wrapped native asset!)
+- Fetch a quote first before the swap action. Stop, ask the user if they want to proceed. If the user answers affirmatively, then swap
+- If you are not absolutely sure about token addresses, either use an action to fetch the token address or ask the user
+`,
+    schema: SwapSchema,
+  })
+  async swap(
+    walletProvider: ViemWalletProvider,
+    args: z.infer<typeof SwapSchema>,
+  ): Promise<string> {
+    try {
+      // Compatible chainId is expected since it should be pre-checked in supportsNetwork
+      const chainId = Number((await walletProvider.getNetwork()).chainId);
+      const chain = EvmChain.from(chainId)!;
+
+      const decimalsIn = await fetchDecimals({ walletProvider, token: args.fromAssetAddress });
+
+      if (!decimalsIn.success) {
+        return decimalsIn.message;
+      }
+
+      const amountIn = parseUnits(args.amount, decimalsIn.decimals);
+
+      // First fetch to see if the swap is even possible
+      const firstSwap = await handleGetSwap({
+        amount: amountIn,
+        chainId,
+        tokenIn: args.fromAssetAddress,
+        tokenOut: args.toAssetAddress,
+        maxSlippage: args.maxSlippage,
+        recipient: walletProvider.getAddress() as Address,
+      });
+
+      if (firstSwap.swap.status !== RouteStatus.Success) {
+        return firstSwap.message;
+      }
+
+      // Check if the wallet has enough balance to perform the swap
+      const balance = await handleBalance({
+        walletProvider,
+        token: firstSwap.swap.tokenFrom,
+        minAmount: amountIn,
+      });
+
+      if (!balance.success) {
+        return balance.message;
+      }
+
+      const approval = await handleApproval({
+        walletProvider,
+        token: args.fromAssetAddress,
+        to: firstSwap.swap.tx.to,
+        amount: amountIn,
+      });
+
+      if (!approval.success) {
+        return approval.message;
+      }
+
+      // Refetch in case the route changed during approval
+      const secondSwap = await handleGetSwap({
+        amount: amountIn,
+        chainId,
+        tokenIn: args.fromAssetAddress,
+        tokenOut: args.toAssetAddress,
+        maxSlippage: args.maxSlippage,
+        recipient: walletProvider.getAddress() as Address,
+      });
+
+      if (secondSwap.swap.status !== RouteStatus.Success) {
+        return secondSwap.message;
+      }
+
+      const swapHash = await walletProvider.sendTransaction(secondSwap.swap.tx);
+      const swapReceipt: TransactionReceipt =
+        await walletProvider.waitForTransactionReceipt(swapHash);
+
+      if (swapReceipt.status === "reverted") {
+        return `Swap failed: Transaction Reverted.\n - Transaction hash: ${swapHash}\n - Transaction link: ${chain.getTxUrl(swapHash)}`;
+      }
+
+      // Find the Route event log, which includes the actual amountOut
+      const [routeLog] = swapReceipt.logs
+        .filter(
+          log =>
+            encodeEventTopics({
+              abi: routeProcessor5Abi_Route,
+              eventName: "Route",
+            })[0] === log.topics[0],
+        )
+        .map(log =>
+          decodeEventLog({
+            abi: routeProcessor5Abi_Route,
+            data: log.data,
+            topics: log.topics,
+          }),
+        );
+
+      return `Swapped ${formatUnits(routeLog.args.amountIn, secondSwap.swap.tokenFrom.decimals)} of ${secondSwap.swap.tokenFrom.symbol} (${args.fromAssetAddress}) for ${formatUnits(routeLog.args.amountOut, secondSwap.swap.tokenTo.decimals)} of ${secondSwap.swap.tokenTo.symbol} (${args.toAssetAddress}) on ${chain.shortName}
+ - Transaction hash: ${swapHash}
+ - Transaction link: ${chain.getTxUrl(swapHash)}`;
+    } catch (error) {
+      return `Error swapping tokens: ${error}`;
+    }
+  }
+
+  /**
+   * Gets a quote for a specified amount of a from token to a to token
+   *
+   * @param walletProvider - The wallet provider to swap the tokens from.
+   * @param args - The input arguments for the action.
+   * @returns A message containing the quote details.
+   */
+  @CreateAction({
+    name: "quote",
+    description: `This tool will fetch a quote for a specified amount of a 'from token' (erc20) to a 'to token' (erc20).
+It takes the following inputs:
+- The human-readable amount of the 'from token' to fetch a quote for
+- The from token address to fetch a quote for
+- The token address to receive from the quoted swap
+
+Important notes:
+- The native asset (ie 'eth' on 'ethereum-mainnet') is represented by ${nativeAddress} (not the wrapped native asset!)
+- This action does not require any on-chain transactions or gas
+- If you are not 100% certain about token addresses, use an action to fetch the token address first or ask the user
+- NEVER assume that tokens have the same address on across networks (ie the address of 'usdc' on 'ethereum-mainnet' is different from 'usdc' on 'base-mainnet')
+`,
+    schema: QuoteSchema,
+  })
+  async quote(
+    walletProvider: ViemWalletProvider,
+    args: z.infer<typeof QuoteSchema>,
+  ): Promise<string> {
+    try {
+      // Compatible chainId is expected since it should be pre-checked in supportsNetwork
+      const chainId = Number((await walletProvider.getNetwork()).chainId);
+
+      const decimalsIn = await fetchDecimals({ walletProvider, token: args.fromAssetAddress });
+
+      if (!decimalsIn.success) {
+        return decimalsIn.message;
+      }
+
+      const amountIn = parseUnits(args.amount, decimalsIn.decimals);
+
+      const swap = await handleGetSwap({
+        amount: amountIn,
+        chainId,
+        tokenIn: args.fromAssetAddress,
+        tokenOut: args.toAssetAddress,
+        maxSlippage: 0.999, // ~100%
+        recipient: walletProvider.getAddress() as Address,
+      });
+
+      return swap.message;
+    } catch (error) {
+      return `Error quoting for tokens: ${error}`;
+    }
+  }
+
+  /**
+   * Custom action providers are supported on all networks
+   *
+   * @param network - The network to checkpointSaver
+   * @returns True if the network is supported, false otherwise
+   */
+  supportsNetwork(network: Network): boolean {
+    if (network.protocolFamily !== "evm" || !network.chainId) {
+      return false;
+    }
+
+    return isExtractorSupportedChainId(Number(network.chainId));
+  }
+}
+
+/**
+ * Fetches the number of decimals for the token
+ *
+ * @param root0 - The input arguments for the action
+ * @param root0.walletProvider - The wallet provider to fetch the decimals from
+ * @param root0.token - The token address to fetch the decimals for
+ *
+ * @returns The number of decimals for the token
+ */
+async function fetchDecimals({
+  walletProvider,
+  token,
+}: {
+  walletProvider: ViemWalletProvider;
+  token: Address;
+}): Promise<{ success: true; decimals: number } | { success: false; message: string }> {
+  const chainId = Number((await walletProvider.getNetwork()).chainId);
+  if (!isExtractorSupportedChainId(chainId)) {
+    return {
+      success: false,
+      message: `Unsupported chainId: ${chainId}`,
+    };
+  }
+
+  if (token === nativeAddress) {
+    return { success: true, decimals: Native.onChain(chainId).decimals };
+  }
+
+  const decimals = (await walletProvider.readContract({
+    address: token,
+    abi: erc20Abi,
+    functionName: "decimals",
+  } as const)) as number;
+
+  return { success: true, decimals };
+}
+
+/**
+ * Checks if the wallet has enough balance to perform the swap
+ *
+ * @param root0 - The input arguments for the action
+ * @param root0.walletProvider - The wallet provider to fetch the balance from
+ * @param root0.token - The token address to fetch the balance for
+ * @param root0.token.address - The token address to fetch the balance for
+ * @param root0.token.symbol - The token symbol to fetch the balance for
+ * @param root0.token.decimals - The token decimals to fetch the balance for
+ * @param root0.minAmount - The minimum amount to check for
+ *
+ * @returns The balance of the wallet
+ */
+async function handleBalance({
+  walletProvider,
+  token,
+  minAmount,
+}: {
+  walletProvider: ViemWalletProvider;
+  token: {
+    address: Address;
+    symbol: string;
+    decimals: number;
+  };
+  minAmount: bigint;
+}): Promise<{ success: true } | { success: false; message: string }> {
+  let balance: bigint;
+
+  if (token.address.toLowerCase() === nativeAddress) {
+    balance = await walletProvider.getBalance();
+  } else {
+    balance = (await walletProvider.readContract({
+      address: token.address,
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      args: [walletProvider.getAddress() as Address],
+    } as const)) as bigint;
+  }
+
+  if (balance < minAmount) {
+    return {
+      success: false,
+      message: `Swap failed: Insufficient balance for ${token.symbol} (${token.address})
+ - Balance: ${formatUnits(balance, token.decimals)}
+ - Required: ${formatUnits(minAmount, token.decimals)}`,
+    };
+  }
+
+  return {
+    success: true,
+  };
+}
+
+/**
+ *
+ * Wraps the getSwap function, providing messages for possible states
+ *
+ * @param root0 - The input arguments for the action
+ * @param root0.amount - The amount to swap
+ * @param root0.chainId - The chainId to swap on
+ * @param root0.tokenIn - The input token address
+ * @param root0.tokenOut - The output token address
+ * @param root0.maxSlippage - The maximum slippage allowed
+ * @param root0.recipient - The recipient of the swap
+ *
+ * @returns The result of the swap and a message
+ */
+async function handleGetSwap({
+  amount,
+  chainId,
+  tokenIn,
+  tokenOut,
+  maxSlippage,
+  recipient,
+}: {
+  amount: bigint;
+  chainId: number;
+  tokenIn: Address;
+  tokenOut: Address;
+  maxSlippage: number;
+  recipient: Address;
+}): Promise<{ swap: SwapResponse<true>; message: string }> {
+  if (!isExtractorSupportedChainId(chainId)) {
+    return {
+      swap: { status: RouteStatus.NoWay },
+      message: `Unsupported chainId: ${chainId}`,
+    };
+  }
+
+  const swap = await getSwap({
+    amount,
+    chainId,
+    tokenIn,
+    tokenOut,
+    maxSlippage,
+    includeTransaction: true,
+    to: recipient,
+  });
+
+  const chain = EvmChain.from(chainId)!;
+
+  if (swap.status === RouteStatus.NoWay) {
+    return {
+      swap,
+      message: `No route found to swap ${amount} of ${tokenIn} for ${tokenOut} on ${chain.shortName}`,
+    };
+  }
+
+  if (swap.status === RouteStatus.Partial) {
+    return {
+      swap,
+      message: `Found a partial quote for ${swap.tokenFrom.symbol} -> ${swap.tokenTo.symbol}. Swapping the full amount is not possible.
+ - AmountIn: ${formatUnits(BigInt(swap.amountIn), swap.tokenFrom.decimals)}
+ - AmountOut: ${formatUnits(BigInt(swap.assumedAmountOut), swap.tokenTo.decimals)}`,
+    };
+  }
+
+  return {
+    swap,
+    message: `Found a quote for ${swap.tokenFrom.symbol} (${swap.tokenFrom.address}) -> ${swap.tokenTo.symbol} (${swap.tokenTo.address})
+ - AmountIn: ${formatUnits(BigInt(swap.amountIn), swap.tokenFrom.decimals)} ${swap.tokenFrom.symbol}
+ - AmountOut: ${formatUnits(BigInt(swap.assumedAmountOut), swap.tokenTo.decimals)} ${swap.tokenTo.symbol}`,
+  };
+}
+
+/**
+ *
+ * Handles the approval for the token
+ *
+ * @param root0 - The input arguments for the action
+ * @param root0.walletProvider - The wallet provider to handle the approval with
+ * @param root0.token - The token address to approve
+ * @param root0.to - The address to approve the token to
+ * @param root0.amount - The amount to approve
+ *
+ * @returns Either success: true on success or success: false with a message containing the reason for failure
+ */
+async function handleApproval({
+  walletProvider,
+  token,
+  to,
+  amount,
+}: {
+  walletProvider: ViemWalletProvider;
+  token: Address;
+  to: Address;
+  amount: bigint;
+}): Promise<{ success: true } | { success: false; message: string }> {
+  // No need to approve if the token is the native token
+  if (token.toLowerCase() === nativeAddress) {
+    return { success: true };
+  }
+
+  // Check if the wallet already has enough allowance
+  const allowance = (await walletProvider.readContract({
+    address: token,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: [walletProvider.getAddress() as Address, to],
+  } as const)) as bigint;
+
+  if (allowance >= amount) {
+    return { success: true };
+  }
+
+  // Exact approval
+  const approvalHash = await walletProvider.sendTransaction({
+    to: token,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [to, BigInt(amount)],
+    }),
+  });
+  const approvalReceipt: TransactionReceipt =
+    await walletProvider.waitForTransactionReceipt(approvalHash);
+
+  const chain = EvmChain.from(Number((await walletProvider.getNetwork()).chainId))!;
+
+  if (approvalReceipt.status === "reverted") {
+    return {
+      success: false,
+      message: `Swap failed: Approval Reverted.
+ - Transaction hash: ${approvalHash}
+ - Transaction link: ${chain.getTxUrl(approvalHash)}`,
+    };
+  }
+
+  return { success: true };
+}
+
+export const sushiRouterActionProvider = () => new SushiRouterActionProvider();

--- a/typescript/agentkit/src/action-providers/sushi/sushiRouterSchemas.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiRouterSchemas.ts
@@ -1,0 +1,60 @@
+import { isExtractorSupportedChainId } from "sushi/config";
+import type { Address } from "viem";
+import { z } from "zod";
+
+/**
+ * Input schema for asset swap action
+ */
+export const SwapSchema = z
+  .object({
+    fromAssetAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .transform(val => val as Address)
+      .describe("The Ethereum address of the input asset"),
+    amount: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/, "Invalid number format")
+      .describe("The amount of the input asset to swap, in the human readable format"),
+    toAssetAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .transform(val => val as Address)
+      .describe("The Ethereum address of the output asset"),
+    maxSlippage: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .default(0.005) // 0.05%
+      .describe("The maximum slippage allowed for the swap, where 0 is 0% and 1 is 100%"),
+  })
+  .strip()
+  .describe("Instructions for trading assets");
+
+/**
+ * Input schema for quote action
+ */
+export const QuoteSchema = z
+  .object({
+    fromAssetAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .transform(val => val as Address)
+      .describe("The Ethereum address of the input asset"),
+    amount: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/, "Invalid number format")
+      .describe("The amount of the input asset to get a quote for"),
+    toAssetAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .transform(val => val as Address)
+      .describe("The Ethereum address of the output asset"),
+    chainId: z
+      .number()
+      .refine(isExtractorSupportedChainId, { message: "Unsupported chainId" })
+      .describe("The chainId to get the quote for"),
+  })
+  .strip()
+  .describe("Instructions for fetching a quote for a trade");


### PR DESCRIPTION
### What changed? Why?
- Added `sushiRouterActionProvider` to provide swap and quote functionality using the Sushi Router API.
- Added `swap` action for swaps.
- Added `quote` action for fetching quotes for swaps.
- Added `sushiDataActionProvider` to provide token finding functionality using the Sushi Data API.
- Added `find-tokens` action for fetching tokens by symbols or addresses.

Why? No on-chain swap solution was present. Also, the agent didn't have a repository to pull token details from.

### Features
End-to-End swap on-chain experience. Asking the agent to "Swap 1 ETH to USDC" results in a successful swap. The agent first looks up the address of "USDC" (it already knows that ETH is 0xee...ee in the context of Sushi), then, it fetches a quote and asks the user if they want to continue. If they do, the swap is executed. Cases like insufficient balance or allowance is handled.

#### Qualified Impact
Nothing should be affected, worst case, the user can remove the sushi actions.
