### PR TITLE
fix: update cdp-langchain path in CONTRIBUTING-PYTHON.md

### DIFF
--- a/CONTRIBUTING-PYTHON.md
+++ b/CONTRIBUTING-PYTHON.md
@@ -229,7 +229,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 - cdp-langchain = "^0.0.11"
-+ cdp-langchain = { path: "../cdp-agentkit-core", develop: true }
++ cdp-langchain = { path: "../../cdp-langchain", develop: true }
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
### What changed? Why?
This pull request includes a small change to the `CONTRIBUTING-PYTHON.md` file. The change updates the path for the `cdp-langchain` dependency to ensure it points to the correct directory.

* [`CONTRIBUTING-PYTHON.md`](diffhunk://#diff-32aba84783588bcd1b0985a7581b0f2c96f8ba45c22142683ec24cfebc437df5L232-R232): Updated the `cdp-langchain` dependency path to `../../cdp-langchain` for proper resolution.

#### Qualified Impact
It would help people who are setting up python code and attract more contributor
