### PR TITLE
chore: migrate morpho actions

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/__init__.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/__init__.py
@@ -1,5 +1,6 @@
 from .action_decorator import create_action
 from .action_provider import Action, ActionProvider
+from .morpho.morpho_action_provider import MorphoActionProvider, morpho_action_provider
 from .pyth.pyth_action_provider import PythActionProvider, pyth_action_provider
 
 __all__ = [
@@ -8,4 +9,6 @@ __all__ = [
     "create_action",
     "PythActionProvider",
     "pyth_action_provider",
+    "MorphoActionProvider",
+    "morpho_action_provider",
 ]

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/constants.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/constants.py
@@ -1,0 +1,23 @@
+METAMORPHO_ABI = [
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "assets", "type": "uint256"},
+            {"internalType": "address", "name": "receiver", "type": "address"},
+        ],
+        "name": "deposit",
+        "outputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "assets", "type": "uint256"},
+            {"internalType": "address", "name": "receiver", "type": "address"},
+            {"internalType": "address", "name": "owner", "type": "address"},
+        ],
+        "name": "withdraw",
+        "outputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/morpho_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/morpho_action_provider.py
@@ -1,0 +1,123 @@
+from decimal import Decimal
+from typing import Any
+
+from web3 import Web3
+
+from coinbase_agentkit.action_providers.action_decorator import create_action
+from coinbase_agentkit.action_providers.action_provider import ActionProvider
+from coinbase_agentkit.action_providers.morpho.constants import METAMORPHO_ABI
+from coinbase_agentkit.action_providers.morpho.schemas import (
+    MorphoDepositInput,
+    MorphoWithdrawInput,
+)
+from coinbase_agentkit.action_providers.morpho.utils import approve
+from coinbase_agentkit.network import Network
+from coinbase_agentkit.wallet_providers import EvmWalletProvider
+
+SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"]
+
+
+class MorphoActionProvider(ActionProvider[EvmWalletProvider]):
+    """Provides actions for interacting with Morpho Vaults."""
+
+    def __init__(self):
+        super().__init__("morpho", [])
+
+    @create_action(
+        name="deposit",
+        description="""
+This tool allows depositing assets into a Morpho Vault.
+It takes:
+- vault_address: The address of the Morpho Vault to deposit to
+- assets: The amount of assets to deposit in whole units
+    Examples for WETH:
+    - 1 WETH
+    - 0.1 WETH
+    - 0.01 WETH
+- receiver: The address to receive the shares
+- token_address: The address of the token to approve
+Important notes:
+- Make sure to use the exact amount provided. Do not convert units for assets for this action.
+- Please use a token address (example 0x4200000000000000000000000000000000000006) for the token_address field. If you are unsure of the token address, please clarify what the requested token address is before continuing.""",
+        schema=MorphoDepositInput,
+    )
+    def deposit(self, wallet: EvmWalletProvider, args: dict[str, Any]) -> str:
+        """Deposit assets into a Morpho Vault."""
+        assets = Decimal(args["assets"])
+
+        if assets <= Decimal("0.0"):
+            return "Error: Assets amount must be greater than 0"
+
+        try:
+            atomic_assets = Web3.to_wei(assets, "ether")
+
+            try:
+                approve(wallet, args["token_address"], args["vault_address"], atomic_assets)
+            except Exception as e:
+                return f"Error approving Morpho Vault as spender: {e!s}"
+
+            morpho_contract = Web3().eth.contract(address=args["vault_address"], abi=METAMORPHO_ABI)
+
+            encoded_data = morpho_contract.encode_abi(
+                "deposit", args=[atomic_assets, args["receiver"]]
+            )
+
+            params = {
+                "to": args["vault_address"],
+                "data": encoded_data,
+            }
+
+            hash = wallet.send_transaction(params)
+            wallet.wait_for_transaction_receipt(hash)
+
+            return f"Deposited {args['assets']} to Morpho Vault {args['vault_address']} with transaction hash: {hash}"
+
+        except Exception as e:
+            return f"Error depositing to Morpho Vault: {e!s}"
+
+    @create_action(
+        name="withdraw",
+        description="""
+This tool allows withdrawing assets from a Morpho Vault. It takes:
+- vault_address: The address of the Morpho Vault to withdraw from
+- assets: The amount of assets to withdraw in atomic units
+- receiver: The address to receive the shares
+""",
+        schema=MorphoWithdrawInput,
+    )
+    def withdraw(self, wallet: EvmWalletProvider, args: dict[str, Any]) -> str:
+        """Withdraw assets from a Morpho Vault."""
+        assets = Decimal(args["assets"])
+
+        if assets <= Decimal("0.0"):
+            return "Error: Assets amount must be greater than 0"
+
+        atomic_assets = Web3.to_wei(assets, "ether")
+
+        contract = Web3().eth.contract(address=args["vault_address"], abi=METAMORPHO_ABI)
+        encoded_data = contract.encode_abi(
+            "withdraw", args=[atomic_assets, args["receiver"], args["receiver"]]
+        )
+
+        try:
+            params = {
+                "to": args["vault_address"],
+                "data": encoded_data,
+            }
+
+            hash = wallet.send_transaction(params)
+            wallet.wait_for_transaction_receipt(hash)
+
+            return f"Withdrawn {args['assets']} from Morpho Vault {args['vault_address']} with transaction hash: {hash}"
+
+        except Exception as e:
+            return f"Error withdrawing from Morpho Vault: {e!s}"
+
+    def supports_network(self, network: Network) -> bool:
+        """Check if network is supported by Morpho."""
+        return network.protocol_family == "evm" and network.network_id in SUPPORTED_NETWORKS
+
+
+def morpho_action_provider() -> MorphoActionProvider:
+    """Create a new MorphoActionProvider instance."""
+    return MorphoActionProvider()

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/schemas.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/schemas.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel, Field
+
+
+class MorphoDepositInput(BaseModel):
+    """Input schema for Morpho Vault deposit action."""
+
+    assets: str = Field(..., description="The quantity of assets to deposit, in whole units")
+    receiver: str = Field(
+        ...,
+        description="The address that will own the position on the vault which will receive the shares",
+    )
+    token_address: str = Field(
+        ..., description="The address of the assets token to approve for deposit"
+    )
+    vault_address: str = Field(..., description="The address of the Morpho Vault to deposit to")
+
+
+class MorphoWithdrawInput(BaseModel):
+    """Input schema for Morpho Vault withdraw action."""
+
+    vault_address: str = Field(..., description="The address of the Morpho Vault to withdraw from")
+    assets: str = Field(..., description="The amount of assets to withdraw in atomic units")
+    receiver: str = Field(..., description="The address to receive the withdrawn assets")

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/utils.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/utils.py
@@ -1,0 +1,34 @@
+from web3 import Web3
+
+from coinbase_agentkit.wallet_providers import EvmWalletProvider
+
+ERC20_APPROVE_ABI = [
+    {
+        "inputs": [
+            {"name": "spender", "type": "address"},
+            {"name": "amount", "type": "uint256"},
+        ],
+        "name": "approve",
+        "outputs": [{"name": "", "type": "bool"}],
+        "type": "function",
+    }
+]
+
+
+def approve(wallet: EvmWalletProvider, token_address: str, spender_address: str, amount: int):
+    """Approve a spender to spend tokens on behalf of the owner."""
+    try:
+        contract = Web3().eth.contract(address=token_address, abi=ERC20_APPROVE_ABI)
+        encoded_data = contract.encode_abi("approve", args=[spender_address, amount])
+
+        params = {
+            "to": token_address,
+            "data": encoded_data,
+        }
+
+        hash = wallet.send_transaction(params)
+        receipt = wallet.wait_for_transaction_receipt(hash)
+
+        return receipt
+    except Exception as e:
+        return f"Error approving tokens: {e!s}"

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -95,21 +95,21 @@ class EthAccountWalletProvider(EvmWalletProvider):
 
     def send_transaction(self, transaction: TxParams) -> HexStr:
         """Send a signed transaction to the network."""
-        max_priority_fee_per_gas, max_fee_per_gas = self.estimate_fees()
-
-        transaction["maxFeePerGas"] = max_fee_per_gas
-        transaction["maxPriorityFeePerGas"] = max_priority_fee_per_gas
-
-        gas = self.web3.eth.estimate_gas(transaction)
-        transaction["gas"] = gas
+        transaction["from"] = self.account.address
+        transaction["chainId"] = self.config.chain_id
 
         nonce = self.web3.eth.get_transaction_count(self.account.address)
         transaction["nonce"] = nonce
 
-        transaction["chainId"] = self.config.chain_id
+        max_priority_fee_per_gas, max_fee_per_gas = self.estimate_fees()
+        transaction["maxPriorityFeePerGas"] = max_priority_fee_per_gas
+        transaction["maxFeePerGas"] = max_fee_per_gas
 
-        tx_hash = self.web3.eth.send_transaction(transaction)
-        return Web3.to_hex(tx_hash)
+        gas = self.web3.eth.estimate_gas(transaction)
+        transaction["gas"] = gas
+
+        hash = self.web3.eth.send_transaction(transaction)
+        return Web3.to_hex(hash)
 
     def wait_for_transaction_receipt(
         self, tx_hash: HexStr, timeout: float = 120, poll_latency: float = 0.1

--- a/python/coinbase-agentkit/tests/test_morpho_action_provider.py
+++ b/python/coinbase-agentkit/tests/test_morpho_action_provider.py
@@ -1,0 +1,220 @@
+import decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from coinbase_agentkit.action_providers.morpho.morpho_action_provider import morpho_action_provider
+from coinbase_agentkit.network import Network
+
+MOCK_VAULT_ADDRESS = "0x1234567890123456789012345678901234567890"
+MOCK_TOKEN_ADDRESS = "0x0987654321098765432109876543210987654321"
+MOCK_RECEIVER = "0x5555555555555555555555555555555555555555"
+MOCK_TX_HASH = "0xabcdef1234567890"
+
+
+# Deposit Tests
+def test_morpho_deposit_success():
+    """Test successful morpho deposit with valid parameters."""
+    mock_wallet = MagicMock()
+    mock_wallet.send_transaction.return_value = MOCK_TX_HASH
+
+    with patch(
+        "coinbase_agentkit.action_providers.morpho.morpho_action_provider.approve"
+    ) as mock_approve:
+        mock_approve.return_value = True
+
+        result = morpho_action_provider().deposit(
+            mock_wallet,
+            {
+                "vault_address": MOCK_VAULT_ADDRESS,
+                "token_address": MOCK_TOKEN_ADDRESS,
+                "assets": "1.0",
+                "receiver": MOCK_RECEIVER,
+            },
+        )
+
+        mock_approve.assert_called_once_with(
+            mock_wallet, MOCK_TOKEN_ADDRESS, MOCK_VAULT_ADDRESS, 1000000000000000000
+        )
+
+        assert MOCK_TX_HASH in result
+        assert "Deposited 1.0" in result
+        mock_wallet.send_transaction.assert_called_once()
+        mock_wallet.wait_for_transaction_receipt.assert_called_once_with(MOCK_TX_HASH)
+
+
+def test_morpho_deposit_zero_amount():
+    """Test morpho deposit with zero amount."""
+    mock_wallet = MagicMock()
+
+    result = morpho_action_provider().deposit(
+        mock_wallet,
+        {
+            "vault_address": MOCK_VAULT_ADDRESS,
+            "token_address": MOCK_TOKEN_ADDRESS,
+            "assets": "0.0",
+            "receiver": MOCK_RECEIVER,
+        },
+    )
+
+    assert "Error: Assets amount must be greater than 0" in result
+    mock_wallet.send_transaction.assert_not_called()
+
+
+def test_morpho_deposit_negative_amount():
+    """Test morpho deposit with negative amount."""
+    mock_wallet = MagicMock()
+
+    result = morpho_action_provider().deposit(
+        mock_wallet,
+        {
+            "vault_address": MOCK_VAULT_ADDRESS,
+            "token_address": MOCK_TOKEN_ADDRESS,
+            "assets": "-1.0",
+            "receiver": MOCK_RECEIVER,
+        },
+    )
+
+    assert "Error: Assets amount must be greater than 0" in result
+
+
+def test_morpho_deposit_invalid_amount():
+    """Test morpho deposit with invalid amount string."""
+    mock_wallet = MagicMock()
+
+    with pytest.raises(decimal.InvalidOperation):
+        morpho_action_provider().deposit(
+            mock_wallet,
+            {
+                "vault_address": MOCK_VAULT_ADDRESS,
+                "token_address": MOCK_TOKEN_ADDRESS,
+                "assets": "invalid_amount",
+                "receiver": MOCK_RECEIVER,
+            },
+        )
+
+
+def test_morpho_deposit_approval_error():
+    """Test morpho deposit with approval error."""
+    mock_wallet = MagicMock()
+
+    with patch(
+        "coinbase_agentkit.action_providers.morpho.morpho_action_provider.approve"
+    ) as mock_approve:
+        mock_approve.side_effect = Exception("Approval failed")
+
+        result = morpho_action_provider().deposit(
+            mock_wallet,
+            {
+                "vault_address": MOCK_VAULT_ADDRESS,
+                "token_address": MOCK_TOKEN_ADDRESS,
+                "assets": "1.0",
+                "receiver": MOCK_RECEIVER,
+            },
+        )
+
+        assert "Error approving Morpho Vault as spender" in result
+        mock_wallet.send_transaction.assert_not_called()
+
+
+# Withdraw Tests
+def test_morpho_withdraw_success():
+    """Test successful morpho withdraw with valid parameters."""
+    mock_wallet = MagicMock()
+    mock_wallet.send_transaction.return_value = MOCK_TX_HASH
+
+    with patch("web3.eth.Contract") as mock_contract:
+        mock_contract.return_value.encode_abi.return_value = b"encoded_data"
+
+        result = morpho_action_provider().withdraw(
+            mock_wallet,
+            {"vault_address": MOCK_VAULT_ADDRESS, "assets": "1.0", "receiver": MOCK_RECEIVER},
+        )
+
+        assert MOCK_TX_HASH in result
+        assert "Withdrawn 1.0" in result
+        mock_wallet.send_transaction.assert_called_once()
+        mock_wallet.wait_for_transaction_receipt.assert_called_once_with(MOCK_TX_HASH)
+
+
+def test_morpho_withdraw_zero_amount():
+    """Test morpho withdraw with zero amount."""
+    mock_wallet = MagicMock()
+
+    result = morpho_action_provider().withdraw(
+        mock_wallet,
+        {"vault_address": MOCK_VAULT_ADDRESS, "assets": "0.0", "receiver": MOCK_RECEIVER},
+    )
+
+    assert "Error: Assets amount must be greater than 0" in result
+    mock_wallet.send_transaction.assert_not_called()
+
+
+def test_morpho_withdraw_negative_amount():
+    """Test morpho withdraw with negative amount."""
+    mock_wallet = MagicMock()
+
+    result = morpho_action_provider().withdraw(
+        mock_wallet,
+        {"vault_address": MOCK_VAULT_ADDRESS, "assets": "-1.0", "receiver": MOCK_RECEIVER},
+    )
+
+    assert "Error: Assets amount must be greater than 0" in result
+
+
+def test_morpho_withdraw_invalid_amount():
+    """Test morpho withdraw with invalid amount string."""
+    mock_wallet = MagicMock()
+
+    with pytest.raises(decimal.InvalidOperation):
+        morpho_action_provider().withdraw(
+            mock_wallet,
+            {
+                "vault_address": MOCK_VAULT_ADDRESS,
+                "assets": "invalid_amount",
+                "receiver": MOCK_RECEIVER,
+            },
+        )
+
+
+def test_morpho_withdraw_transaction_error():
+    """Test morpho withdraw with transaction error."""
+    mock_wallet = MagicMock()
+    mock_wallet.send_transaction.side_effect = Exception("Transaction failed")
+
+    with patch("web3.eth.Contract") as mock_contract:
+        mock_contract.return_value.encode_abi.return_value = b"encoded_data"
+
+        result = morpho_action_provider().withdraw(
+            mock_wallet,
+            {"vault_address": MOCK_VAULT_ADDRESS, "assets": "1.0", "receiver": MOCK_RECEIVER},
+        )
+
+        assert "Error withdrawing from Morpho Vault" in result
+
+
+# Network Support Tests
+def test_supports_network():
+    """Test network support checking."""
+    provider = morpho_action_provider()
+
+    # Test supported network
+    supported_network = Network(protocol_family="evm", network_id="base-mainnet")
+    assert provider.supports_network(supported_network) is True
+
+    # Test unsupported network
+    unsupported_network = Network(protocol_family="evm", network_id="ethereum-mainnet")
+    assert provider.supports_network(unsupported_network) is False
+
+    # Test unsupported protocol family
+    wrong_family_network = Network(protocol_family="solana", network_id="base-mainnet")
+    assert provider.supports_network(wrong_family_network) is False
+
+
+def test_morpho_invalid_network():
+    """Test morpho with invalid network."""
+    provider = morpho_action_provider()
+
+    # Create a valid Network object but with unsupported values
+    invalid_network = Network(protocol_family="invalid", network_id=None)
+    assert provider.supports_network(invalid_network) is False


### PR DESCRIPTION
### What changed? Why?
This PR
* Migrates Morpho deposit/withdraw
* Makes a small change to `EthAccountWalletProvider#send_transaction` to have more reliable gas estimation

While it's possible to use Web3.py Contract to perform contract interactions, I'm opting to rely more on the standard methods (`send_transaction`) to keep the wallet provider interface generic.

This was tested with the following script:
```python
import os

from eth_account import Account
from eth_account.signers.local import LocalAccount
from web3 import Web3

from coinbase_agentkit.action_providers.morpho.morpho_action_provider import morpho_action_provider
from coinbase_agentkit.wallet_providers import (
    EthAccountWalletProvider,
    EthAccountWalletProviderConfig,
)

if __name__ == "__main__":
    private_key = os.environ.get("PRIVATE_KEY")
    assert private_key is not None, "You must set PRIVATE_KEY environment variable"
    assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"

    account: LocalAccount = Account.from_key(private_key)

    print("Address:", account.address)

    wallet = EthAccountWalletProvider(
        config=EthAccountWalletProviderConfig(
            private_key=private_key,
            rpc_url="https://mainnet.base.org",
            chain_id=8453,
        )
    )

    provider = morpho_action_provider()

    print("wallet getaddress", wallet.get_address())
    print("eth balance", Web3.from_wei(wallet.get_balance(), "ether"))

    try:
        print(
            provider.deposit(
                wallet,
                {
                    "vault_address": "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1",
                    "assets": 0.00001,
                    "receiver": wallet.get_address(),
                    "token_address": "0x4200000000000000000000000000000000000006",
                },
            )
        )

        print(
            provider.withdraw(
                wallet,
                {
                    "vault_address": "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1",
                    "assets": 0.0001,
                    "receiver": wallet.get_address(),
                },
            )
        )
    except Exception as e:
        print(e)
```

Output:
```
Address: 0x9Dcd61940a94c921d8CC77472ac396deB112852E
wallet getaddress 0x9Dcd61940a94c921d8CC77472ac396deB112852E
eth balance 0.001088924264095434
Deposited 0.0001 to Morpho Vault 0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1 with transaction hash: 0x58ec53b929613cae5124a47f02c3028e6a1960a02579faacc3768f528ca2661c
Withdrawn 0.0001 from Morpho Vault 0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1 with transaction hash: 0xfa42622171fcd6e988cd44e8cdd47e3c613d1a588f5b3eb557f15f115ec183ef
```

#### Qualified Impact
<!-- Please evaluate what components could be affected and what the impact would be if there was an
error. How would this error be resolved, e.g. rollback a deploy, push a new fix, disable a feature
flag, etc... -->
