### PR TITLE
chore: fix python action decorator

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/action_decorator.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/action_decorator.py
@@ -10,7 +10,7 @@ class ActionMetadata(BaseModel):
 
     name: str
     description: str
-    schema: type[BaseModel] | None
+    _schema: type[BaseModel] | None
     invoke: Callable
     wallet_provider: bool = False
 
@@ -26,7 +26,7 @@ def create_action(name: str, description: str, schema: type[BaseModel] | None = 
         wrapper._action_metadata = ActionMetadata(
             name=name,
             description=description,
-            schema=schema,
+            _schema=schema,
             invoke=func,
             wallet_provider=len(func.__code__.co_varnames) > 1
             and func.__code__.co_varnames[1] == "wallet_provider",

--- a/python/coinbase-agentkit/pyth_price_example.py
+++ b/python/coinbase-agentkit/pyth_price_example.py
@@ -40,11 +40,11 @@ def main():
 
     try:
         # Get BTC price feed ID
-        feed_id_result = agent_kit.get_actions()[0].invoke({"token_symbol": "BTC"})
+        feed_id_result = agent_kit.get_actions()[1].invoke({"token_symbol": "BTC"})
         print(f"BTC Price Feed ID: {feed_id_result}")
 
         # Get BTC price using the feed ID
-        price_result = agent_kit.get_actions()[1].invoke({"price_feed_id": feed_id_result})
+        price_result = agent_kit.get_actions()[0].invoke({"price_feed_id": feed_id_result})
         print(f"Current BTC Price: ${price_result}")
 
     except Exception as e:


### PR DESCRIPTION
### What changed?
- [x] Bug fix

### Why was this change implemented?
This PR
* Fixes action decorator by calling the wrapper method to register actions, and updating the invoke lambda to pass through the provider argument to the `invoke` call
* Updated the pyth example with the correct action ordering
* Silences Pydantic warning about shadowing `schema`

### How has it been tested?
- [x] Local Pyth example
```
poetry run python pyth_price_example.py
BTC Price Feed ID: e62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43
Current BTC Price: $97302.07
```
