### PR TITLE
chore: add network mappings

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/network/__init__.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/network/__init__.py
@@ -1,0 +1,35 @@
+from .chain_definitions import (
+    arbitrum,
+    arbitrum_sepolia,
+    base,
+    base_sepolia,
+    mainnet,
+    optimism,
+    optimism_sepolia,
+    polygon,
+    polygon_mumbai,
+    sepolia,
+)
+from .network import (
+    CHAIN_ID_TO_NETWORK_ID,
+    NETWORK_ID_TO_CHAIN,
+    NETWORK_ID_TO_CHAIN_ID,
+    Network,
+)
+
+__all__ = [
+    "Network",
+    "CHAIN_ID_TO_NETWORK_ID",
+    "NETWORK_ID_TO_CHAIN_ID",
+    "NETWORK_ID_TO_CHAIN",
+    "mainnet",
+    "sepolia",
+    "base_sepolia",
+    "arbitrum_sepolia",
+    "optimism_sepolia",
+    "base",
+    "arbitrum",
+    "optimism",
+    "polygon_mumbai",
+    "polygon",
+]

--- a/python/coinbase-agentkit/coinbase_agentkit/network/chain_definitions.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/network/chain_definitions.py
@@ -1,0 +1,359 @@
+from pydantic import BaseModel
+
+
+class NativeCurrency(BaseModel):
+    """Represents the native currency for a blockchain network."""
+
+    name: str
+    symbol: str
+    decimals: int
+
+
+class RpcUrls(BaseModel):
+    """Represents the RPC URLs for a blockchain network."""
+
+    http: list[str]
+
+
+class BlockExplorer(BaseModel):
+    """Represents a block explorer for a blockchain network."""
+
+    name: str
+    url: str
+    api_url: str
+
+
+class Contract(BaseModel):
+    """Represents a contract on a blockchain network."""
+
+    address: str
+    block_created: int | None = None
+
+
+class Chain(BaseModel):
+    """Represents a blockchain network."""
+
+    id: int
+    name: str
+    network: str | None = None
+    native_currency: NativeCurrency
+    rpc_urls: dict[str, RpcUrls]
+    block_explorers: dict[str, BlockExplorer]
+    contracts: dict[str, Contract]
+    testnet: bool | None = False
+
+
+# Convert existing dictionaries to Chain instances
+mainnet = Chain(
+    id=1,
+    name="Ethereum",
+    native_currency={"name": "Ether", "symbol": "ETH", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://eth.merkle.io"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Etherscan",
+            "url": "https://etherscan.io",
+            "api_url": "https://api.etherscan.io/api",
+        },
+    },
+    contracts={
+        "ens_registry": {
+            "address": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        },
+        "ens_universal_resolver": {
+            "address": "0xce01f8eee7E479C928F8919abD53E553a36CeF67",
+            "block_created": 19_258_213,
+        },
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 14_353_601,
+        },
+    },
+)
+
+sepolia = Chain(
+    id=11_155_111,
+    name="Sepolia",
+    native_currency={"name": "Sepolia Ether", "symbol": "ETH", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://sepolia.drpc.org"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Etherscan",
+            "url": "https://sepolia.etherscan.io",
+            "api_url": "https://api-sepolia.etherscan.io/api",
+        },
+    },
+    contracts={
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 751532,
+        },
+        "ens_registry": {"address": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"},
+        "ens_universal_resolver": {
+            "address": "0xc8Af999e38273D658BE1b921b88A9Ddf005769cC",
+            "block_created": 5_317_080,
+        },
+    },
+    testnet=True,
+)
+
+base_sepolia = Chain(
+    id=84532,
+    network="base-sepolia",
+    name="Base Sepolia",
+    native_currency={"name": "Sepolia Ether", "symbol": "ETH", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://sepolia.base.org"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Basescan",
+            "url": "https://sepolia.basescan.org",
+            "api_url": "https://api-sepolia.basescan.org/api",
+        },
+    },
+    contracts={
+        "dispute_game_factory": {
+            "address": "0xd6E6dBf4F7EA0ac412fD8b65ED297e64BB7a06E1",
+        },
+        "l2_output_oracle": {
+            "address": "0x84457ca9D0163FbC4bbfe4Dfbb20ba46e48DF254",
+        },
+        "portal": {
+            "address": "0x49f53e41452c74589e85ca1677426ba426459e85",
+            "block_created": 4446677,
+        },
+        "l1_standard_bridge": {
+            "address": "0xfd0Bf71F60660E2f608ed56e1659C450eB113120",
+            "block_created": 4446677,
+        },
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 1059647,
+        },
+    },
+    testnet=True,
+)
+
+arbitrum_sepolia = Chain(
+    id=421_614,
+    name="Arbitrum Sepolia",
+    native_currency={
+        "name": "Arbitrum Sepolia Ether",
+        "symbol": "ETH",
+        "decimals": 18,
+    },
+    rpc_urls={
+        "default": {
+            "http": ["https://sepolia-rollup.arbitrum.io/rpc"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Arbiscan",
+            "url": "https://sepolia.arbiscan.io",
+            "api_url": "https://api-sepolia.arbiscan.io/api",
+        },
+    },
+    contracts={
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 81930,
+        },
+    },
+    testnet=True,
+)
+
+optimism_sepolia = Chain(
+    id=11155420,
+    name="OP Sepolia",
+    native_currency={"name": "Sepolia Ether", "symbol": "ETH", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://sepolia.optimism.io"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Blockscout",
+            "url": "https://optimism-sepolia.blockscout.com",
+            "api_url": "https://optimism-sepolia.blockscout.com/api",
+        },
+    },
+    contracts={
+        "dispute_game_factory": {
+            "address": "0x05F9613aDB30026FFd634f38e5C4dFd30a197Fa1",
+        },
+        "l2_output_oracle": {
+            "address": "0x90E9c4f8a994a250F6aEfd61CAFb4F2e895D458F",
+        },
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 1620204,
+        },
+        "portal": {
+            "address": "0x16Fc5058F25648194471939df75CF27A2fdC48BC",
+        },
+        "l1_standard_bridge": {
+            "address": "0xFBb0621E0B23b5478B630BD55a5f21f67730B0F1",
+        },
+    },
+    testnet=True,
+)
+
+base = Chain(
+    id=8453,
+    name="Base",
+    native_currency={"name": "Ether", "symbol": "ETH", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://mainnet.base.org"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Basescan",
+            "url": "https://basescan.org",
+            "api_url": "https://api.basescan.org/api",
+        },
+    },
+    contracts={
+        "dispute_game_factory": {
+            "address": "0x43edB88C4B80fDD2AdFF2412A7BebF9dF42cB40e",
+        },
+        "l2_output_oracle": {
+            "address": "0x56315b90c40730925ec5485cf004d835058518A0",
+        },
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 5022,
+        },
+        "portal": {
+            "address": "0x49048044D57e1C92A77f79988d21Fa8fAF74E97e",
+            "block_created": 17482143,
+        },
+        "l1_standard_bridge": {
+            "address": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
+            "block_created": 17482143,
+        },
+    },
+)
+
+arbitrum = Chain(
+    id=42_161,
+    name="Arbitrum One",
+    native_currency={"name": "Ether", "symbol": "ETH", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://arb1.arbitrum.io/rpc"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Arbiscan",
+            "url": "https://arbiscan.io",
+            "api_url": "https://api.arbiscan.io/api",
+        },
+    },
+    contracts={
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 7654707,
+        },
+    },
+)
+
+optimism = Chain(
+    id=10,
+    name="OP Mainnet",
+    native_currency={"name": "Ether", "symbol": "ETH", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://mainnet.optimism.io"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Optimism Explorer",
+            "url": "https://optimistic.etherscan.io",
+            "api_url": "https://api-optimistic.etherscan.io/api",
+        },
+    },
+    contracts={
+        "dispute_game_factory": {
+            "address": "0xe5965Ab5962eDc7477C8520243A95517CD252fA9",
+        },
+        "l2_output_oracle": {
+            "address": "0xdfe97868233d1aa22e815a266982f2cf17685a27",
+        },
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 4286263,
+        },
+        "portal": {
+            "address": "0xbEb5Fc579115071764c7423A4f12eDde41f106Ed",
+        },
+        "l1_standard_bridge": {
+            "address": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+        },
+    },
+)
+
+polygon_mumbai = Chain(
+    id=80_001,
+    name="Polygon Mumbai",
+    native_currency={"name": "MATIC", "symbol": "MATIC", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://rpc.ankr.com/polygon_mumbai"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "PolygonScan",
+            "url": "https://mumbai.polygonscan.com",
+            "api_url": "https://api-testnet.polygonscan.com/api",
+        },
+    },
+    contracts={
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 25770160,
+        },
+    },
+    testnet=True,
+)
+
+polygon = Chain(
+    id=137,
+    name="Polygon",
+    native_currency={"name": "POL", "symbol": "POL", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://polygon-rpc.com"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "PolygonScan",
+            "url": "https://polygonscan.com",
+            "api_url": "https://api.polygonscan.com/api",
+        },
+    },
+    contracts={
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+            "block_created": 25770160,
+        },
+    },
+)

--- a/python/coinbase-agentkit/coinbase_agentkit/network/network.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/network/network.py
@@ -1,0 +1,56 @@
+from pydantic import BaseModel
+
+from .chain_definitions import (
+    arbitrum,
+    arbitrum_sepolia,
+    base,
+    base_sepolia,
+    mainnet,
+    optimism,
+    optimism_sepolia,
+    polygon,
+    polygon_mumbai,
+    sepolia,
+)
+
+
+class Network(BaseModel):
+    """Represents a blockchain network."""
+
+    protocol_family: str
+    network_id: str | None = None
+    chain_id: int | None = None
+
+
+# Maps EVM chain IDs to Coinbase network IDs
+CHAIN_ID_TO_NETWORK_ID: dict[int, str] = {
+    1: "ethereum-mainnet",
+    11155111: "ethereum-sepolia",
+    137: "polygon-mainnet",
+    80001: "polygon-mumbai",
+    8453: "base-mainnet",
+    84532: "base-sepolia",
+    42161: "arbitrum-mainnet",
+    421614: "arbitrum-sepolia",
+    10: "optimism-mainnet",
+    11155420: "optimism-sepolia",
+}
+
+# Maps Coinbase network IDs to EVM chain IDs
+NETWORK_ID_TO_CHAIN_ID: dict[str, int] = {
+    network_id: chain_id for chain_id, network_id in CHAIN_ID_TO_NETWORK_ID.items()
+}
+
+# Maps Coinbase network IDs to chain objects
+NETWORK_ID_TO_CHAIN: dict[str, dict] = {
+    "ethereum-mainnet": mainnet,
+    "ethereum-sepolia": sepolia,
+    "polygon-mainnet": polygon,
+    "polygon-mumbai": polygon_mumbai,
+    "base-mainnet": base,
+    "base-sepolia": base_sepolia,
+    "arbitrum-mainnet": arbitrum,
+    "arbitrum-sepolia": arbitrum_sepolia,
+    "optimism-mainnet": optimism,
+    "optimism-sepolia": optimism_sepolia,
+}

--- a/python/coinbase-agentkit/tests/action_providers/cdp/test_api_address_reputation_action.py
+++ b/python/coinbase-agentkit/tests/action_providers/cdp/test_api_address_reputation_action.py
@@ -1,6 +1,5 @@
 """Tests for CDP API address reputation action."""
 
-
 from cdp.address_reputation import (
     AddressReputation,
     AddressReputationMetadata,

--- a/python/coinbase-agentkit/tests/action_providers/wallet/conftest.py
+++ b/python/coinbase-agentkit/tests/action_providers/wallet/conftest.py
@@ -11,7 +11,7 @@ from coinbase_agentkit.wallet_providers import WalletProvider
 
 MOCK_ADDRESS = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
 MOCK_BALANCE = Decimal("1000000000000000000")  # 1 ETH in wei
-MOCK_NETWORK = Network(protocol_family="evm", chain_id=1, network_id="base-sepolia")
+MOCK_NETWORK = Network(protocol_family="evm", chain_id=84532, network_id="base-sepolia")
 MOCK_PROVIDER_NAME = "TestWallet"
 
 


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other


### Why was this change implemented?
Adds network mappings to easily map from network_id to chain_id and chain data.

Testing locally with chatbot:
```
Prompt: what network are you on

-------------------
Wallet Details:
- Provider: cdp_wallet_provider
- Address: 0x234d74b45c3A942E425363C9C491C3C3B1A80986
- Network:
  * Protocol Family: evm
  * Network ID: base-sepolia
  * Chain ID: 84532
- Native Balance: 0
-------------------
I am on the Base Sepolia network.
-------------------
```
