### PR TITLE
0.1.0(py): ensure chatbot action provider parity with (ts)

### DIFF
--- a/python/examples/langchain-cdp-chatbot/chatbot.py
+++ b/python/examples/langchain-cdp-chatbot/chatbot.py
@@ -19,12 +19,12 @@ from coinbase_agentkit import (
     EthAccountWalletProvider,
     EthAccountWalletProviderConfig,
 
-    pyth_action_provider,
-    morpho_action_provider,
-    wallet_action_provider,
     cdp_api_action_provider,
+    cdp_wallet_action_provider,
+    erc20_action_provider,
+    pyth_action_provider,
+    wallet_action_provider,
     weth_action_provider,
-    superfluid_action_provider,
 )
 from coinbase_agentkit_langchain import get_langchain_tools
 
@@ -39,9 +39,9 @@ def initialize_agent():
     # Initialize LLM
     llm = ChatOpenAI(model="gpt-4o-mini")
 
-     # Initialize CDP Wallet Provider
-     # mnemonic_phrase = os.environ.get("MNEMONIC_PHRASE")
-     # assert mnemonic_phrase is not None, "You must set MNEMONIC_PHRASE environment variable"
+    # Initialize CDP Wallet Provider
+    # mnemonic_phrase = os.environ.get("MNEMONIC_PHRASE")
+    # assert mnemonic_phrase is not None, "You must set MNEMONIC_PHRASE environment variable"
 
     wallet_data = None
     if os.path.exists(wallet_data_file):
@@ -51,12 +51,12 @@ def initialize_agent():
     cdp_config = None
     if wallet_data is not None:
         cdp_config = CdpWalletProviderConfig(wallet_data=wallet_data)
-         # config=CdpWalletProviderConfig(
-         #     mnemonic_phrase=mnemonic_phrase,
-         #     chain_id=84532,
-         #     network_id="base-sepolia",
-         #     rpc_url="https://sepolia.base.org",
-         # )
+        # cdp_config = CdpWalletProviderConfig(
+        #     mnemonic_phrase=mnemonic_phrase,
+        #     chain_id=8453,
+        #     network_id="base-mainnet",
+        #     rpc_url="https://mainnet.base.org",
+        # )
 
     # Initialize ETH Wallet Provider
     # private_key = os.environ.get("PRIVATE_KEY")
@@ -76,12 +76,12 @@ def initialize_agent():
     agentkit = AgentKit.from_options(AgentKitOptions(
         wallet_provider=wallet_provider,
         action_providers=[
-            pyth_action_provider(),
-            morpho_action_provider(),
-            wallet_action_provider(),
             cdp_api_action_provider(),
+            cdp_wallet_action_provider(),
+            erc20_action_provider(),
+            pyth_action_provider(),
+            wallet_action_provider(),
             weth_action_provider(),
-            superfluid_action_provider(),
         ]
     ))
 

--- a/python/examples/langchain-cdp-chatbot/chatbot.py
+++ b/python/examples/langchain-cdp-chatbot/chatbot.py
@@ -53,9 +53,9 @@ def initialize_agent():
         cdp_config = CdpWalletProviderConfig(wallet_data=wallet_data)
         # cdp_config = CdpWalletProviderConfig(
         #     mnemonic_phrase=mnemonic_phrase,
-        #     chain_id=8453,
-        #     network_id="base-mainnet",
-        #     rpc_url="https://mainnet.base.org",
+        #     chain_id=84532,
+        #     network_id="base-sepolia",
+        #     rpc_url="https://sepolia.base.org",
         # )
 
     # Initialize ETH Wallet Provider

--- a/python/examples/langchain-cdp-chatbot/chatbot.py
+++ b/python/examples/langchain-cdp-chatbot/chatbot.py
@@ -40,9 +40,6 @@ def initialize_agent():
     llm = ChatOpenAI(model="gpt-4o-mini")
 
     # Initialize CDP Wallet Provider
-    # mnemonic_phrase = os.environ.get("MNEMONIC_PHRASE")
-    # assert mnemonic_phrase is not None, "You must set MNEMONIC_PHRASE environment variable"
-
     wallet_data = None
     if os.path.exists(wallet_data_file):
         with open(wallet_data_file) as f:
@@ -51,12 +48,6 @@ def initialize_agent():
     cdp_config = None
     if wallet_data is not None:
         cdp_config = CdpWalletProviderConfig(wallet_data=wallet_data)
-        # cdp_config = CdpWalletProviderConfig(
-        #     mnemonic_phrase=mnemonic_phrase,
-        #     chain_id=84532,
-        #     network_id="base-sepolia",
-        #     rpc_url="https://sepolia.base.org",
-        # )
 
     # Initialize ETH Wallet Provider
     # private_key = os.environ.get("PRIVATE_KEY")


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other

* ensure (py) chatbot has the same action providers as (ts) chatbot

### Why was this change implemented?
<!-- please provide a summary of the changes -->

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [ ] Other
<!-- please specify -->

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [ ] Other
<!-- please specify -->

### Checklist
- [ ] Changelog updated
- [ ] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [x] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests

cherry picking:

cdp wallet trade
```
-------------------
Wallet Details:
- Provider: cdp_wallet_provider
- Address: 0x349002E7213E7F7CF68a8368ca83Fd85CEC4DDB0
- Network:
  * Protocol Family: evm
  * Network ID: base-mainnet
  * Chain ID: 8453
- Native Balance: 18648725318222
-------------------

-------------------
Traded 0.000001 of eth for 0.002654 of usdc.
Transaction hash for the trade: 0x661c9e477f64d495a9a17b61ca503e855c00ce33c0fb4e1a3579e450b90c4228
Transaction link for the trade: https://basescan.org/tx/0x661c9e477f64d495a9a17b61ca503e855c00ce33c0fb4e1a3579e450b90c4228
-------------------
I successfully traded 0.000001 ETH for 0.002654 USDC. 

- **Transaction Hash:** [0x661c9e477f64d495a9a17b61ca503e855c00ce33c0fb4e1a3579e450b90c4228](https://basescan.org/tx/0x661c9e477f64d495a9a17b61ca503e855c00ce33c0fb4e1a3579e450b90c4228)
-------------------
```

weth wrap eth:
```
Prompt: can you wrap 0.0001 eth as weth?

-------------------
Wallet Details:
- Provider: cdp_wallet_provider
- Address: 0x349002E7213E7F7CF68a8368ca83Fd85CEC4DDB0
- Network:
  * Protocol Family: evm
  * Network ID: base-sepolia
  * Chain ID: 84532
- Native Balance: 947228848233781285
-------------------

-------------------
Wrapped ETH with transaction hash: 0x41d52fe7db586fbf544c3fe4da300daa7a0570b8a0c9ea05bb56b201d315e2c0
-------------------
I successfully wrapped 0.0001 ETH as WETH. The transaction hash is: [0x41d52fe7db586fbf544c3fe4da300daa7a0570b8a0c9ea05bb56b201d315e2c0](https://sepolia.etherscan.io/tx/0x41d52fe7db586fbf544c3fe4da300daa7a0570b8a0c9ea05bb56b201d315e2c0).
-------------------
```

### Notes to reviewers
