### PR TITLE
chore: fix deploy nft

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/cdp/cdp_wallet_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/cdp/cdp_wallet_action_provider.py
@@ -75,7 +75,7 @@ and the base URI for the token metadata as inputs.
         except Exception as e:
             return f"Error deploying NFT {e!s}"
 
-        return f"Deployed NFT Collection {args['name']} to address {nft_contract.contract_address} on network {wallet_provider.network_id}.\nTransaction hash for the deployment: {nft_contract.transaction.transaction_hash}\nTransaction link for the deployment: {nft_contract.transaction.transaction_link}"
+        return f"Deployed NFT Collection {args['name']} to address {nft_contract.contract_address} on network {wallet_provider.get_network().network_id}.\nTransaction hash for the deployment: {nft_contract.transaction.transaction_hash}\nTransaction link for the deployment: {nft_contract.transaction.transaction_link}"
 
     @create_action(
         name="deploy_token",

--- a/python/coinbase-agentkit/tests/action_providers/cdp/test_cdp_wallet_action_provider.py
+++ b/python/coinbase-agentkit/tests/action_providers/cdp/test_cdp_wallet_action_provider.py
@@ -23,6 +23,7 @@ from .conftest import (
     MOCK_NFT_SYMBOL,
     MOCK_SOLIDITY_INPUT_JSON,
     MOCK_SOLIDITY_VERSION,
+    MOCK_TESTNET_NETWORK_ID,
     MOCK_TO_AMOUNT,
     MOCK_TO_ASSET_ID,
     MOCK_TOKEN_SUPPLY,
@@ -76,6 +77,7 @@ def test_deploy_nft(mock_wallet, mock_contract_result):
     """Test NFT deployment."""
     provider = cdp_wallet_action_provider()
 
+    mock_wallet.get_network.return_value.network_id = MOCK_TESTNET_NETWORK_ID
     mock_wallet.deploy_nft.return_value.wait.return_value = mock_contract_result
 
     args = {
@@ -92,6 +94,7 @@ def test_deploy_nft(mock_wallet, mock_contract_result):
         base_uri=MOCK_NFT_BASE_URI,
     )
     assert f"Deployed NFT Collection {MOCK_NFT_NAME}" in result
+    assert f"on network {MOCK_TESTNET_NETWORK_ID}" in result
     assert f"to address {MOCK_CONTRACT_ADDRESS}" in result
     assert f"Transaction hash for the deployment: {MOCK_TX_HASH}" in result
     assert f"Transaction link for the deployment: {MOCK_EXPLORER_URL}/{MOCK_TX_HASH}" in result


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other
<!-- please specify -->

### Why was this change implemented?
* Calls get_network instead of accessing network_id directly off cdp_wallet_provider