### PR TITLE
chore: temp rm pypi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
     Every agent deserves a wallet.
   </p>
 
-[![PyPI - Downloads](https://img.shields.io/pypi/dm/coinbase-agentkit?style=flat-square)](https://pypistats.org/packages/coinbase-agentkit)
 [![npm downloads](https://img.shields.io/npm/dm/@coinbase/agentkit?style=flat-square)](https://www.npmjs.com/package/@coinbase/agentkit)
 [![GitHub star chart](https://img.shields.io/github/stars/coinbase/agentkit?style=flat-square)](https://star-history.com/#coinbase/agentkit)
 [![Open Issues](https://img.shields.io/github/issues-raw/coinbase/agentkit?style=flat-square)](https://github.com/coinbase/agentkit/issues)


### PR DESCRIPTION
The new `coinbase-agentkit` PyPi package stats are not up yet, so removing the badge for now.