### PR TITLE
Added GasConfig parameter & usage in CdpWalletProvider/EthAccountWalletProvider

### DIFF
--- a/python/coinbase-agentkit/CHANGELOG.md
+++ b/python/coinbase-agentkit/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added gas configuration parameters (`gas_limit_multiplier`, `fee_per_gas_multiplier`) to `CdpWalletProvider`.
+
 ## [0.1.1] - 2025-02-13
 
 ### Fixed

--- a/python/coinbase-agentkit/CHANGELOG.md
+++ b/python/coinbase-agentkit/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added gas configuration parameters (`gas_limit_multiplier`, `fee_per_gas_multiplier`) to `CdpWalletProvider`.
+- Added gas configuration parameters (`gas_limit_multiplier`, `fee_per_gas_multiplier`) to `CdpWalletProvider` and `EthAccountWalletProvider`.
 
 ## [0.1.1] - 2025-02-13
 

--- a/python/coinbase-agentkit/README.md
+++ b/python/coinbase-agentkit/README.md
@@ -306,6 +306,7 @@ wallet_provider = CdpWalletProvider(CdpWalletProviderConfig(
 Example usage with a private key:
 
 ```python
+import os
 from eth_account import Account
 
 from coinbase_agentkit import (
@@ -340,6 +341,7 @@ agent_kit = AgentKit(AgentKitConfig(
 The `EthAccountWalletProvider` also exposes parameters for effecting the gas calculations.
 
 ```python
+import os
 from eth_account import Account
 
 from coinbase_agentkit import (

--- a/python/coinbase-agentkit/README.md
+++ b/python/coinbase-agentkit/README.md
@@ -22,6 +22,7 @@ AgentKit is a framework for easily enabling AI agents to take actions onchain. I
     - [Configuring from a mnemonic phrase](#configuring-from-a-mnemonic-phrase)
     - [Exporting a wallet](#exporting-a-wallet)
     - [Importing a wallet from WalletData JSON string](#importing-a-wallet-from-walletdata-json-string)
+    - [Configuring gas parameters](#configuring-cdpwalletprovider-gas-parameters)
   - [EthAccountWalletProvider](#ethaccountwalletprovider)
 - [Contributing](#contributing)
 
@@ -280,7 +281,7 @@ wallet_provider = CdpWalletProvider(CdpWalletProviderConfig(
 ))
 ```
 
-#### Configuring `CdpWalletProvider` Gas Parameters
+#### Configuring `CdpWalletProvider` gas parameters
 
 The `CdpWalletProvider` also exposes parameters for effecting the gas calculations.
 

--- a/python/coinbase-agentkit/README.md
+++ b/python/coinbase-agentkit/README.md
@@ -24,8 +24,8 @@ AgentKit is a framework for easily enabling AI agents to take actions onchain. I
     - [Importing a wallet from WalletData JSON string](#importing-a-wallet-from-walletdata-json-string)
     - [Configuring gas parameters](#configuring-cdpwalletprovider-gas-parameters)
   - [EthAccountWalletProvider](#ethaccountwalletprovider)
+    - [Configuring gas parameters](#configuring-ethaccountwalletprovider-gas-parameters)
 - [Contributing](#contributing)
-
 ## Getting Started
 
 *Prerequisites*:
@@ -327,6 +327,42 @@ wallet_provider = EthAccountWalletProvider(
     config=EthAccountWalletProviderConfig(
         account=account,
         chain_id="84532",
+    )
+)
+
+agent_kit = AgentKit(AgentKitConfig(
+    wallet_provider=wallet_provider
+))
+```
+
+#### Configuring `EthAccountWalletProvider` gas parameters
+
+The `EthAccountWalletProvider` also exposes parameters for effecting the gas calculations.
+
+```python
+from eth_account import Account
+
+from coinbase_agentkit import (
+    AgentKit, 
+    AgentKitConfig, 
+    EthAccountWalletProvider, 
+    EthAccountWalletProviderConfig
+)
+
+private_key = os.environ.get("PRIVATE_KEY")
+assert private_key is not None, "You must set PRIVATE_KEY environment variable"
+assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"
+
+account = Account.from_key(private_key)
+
+wallet_provider = EthAccountWalletProvider(
+    config=EthAccountWalletProviderConfig(
+        account=account,
+        chain_id=84532,
+        gas={
+            "gas_limit_multiplier": 2,
+            "fee_per_gas_multiplier": 2
+        }
     )
 )
 

--- a/python/coinbase-agentkit/README.md
+++ b/python/coinbase-agentkit/README.md
@@ -358,7 +358,7 @@ account = Account.from_key(private_key)
 wallet_provider = EthAccountWalletProvider(
     config=EthAccountWalletProviderConfig(
         account=account,
-        chain_id=84532,
+        chain_id="84532",
         gas={
             "gas_limit_multiplier": 2,
             "fee_per_gas_multiplier": 2

--- a/python/coinbase-agentkit/README.md
+++ b/python/coinbase-agentkit/README.md
@@ -280,6 +280,26 @@ wallet_provider = CdpWalletProvider(CdpWalletProviderConfig(
 ))
 ```
 
+#### Configuring `CdpWalletProvider` Gas Parameters
+
+The `CdpWalletProvider` also exposes parameters for effecting the gas calculations.
+
+```python
+from coinbase_agentkit import CdpWalletProvider, CdpWalletProviderConfig
+
+wallet_provider = CdpWalletProvider(CdpWalletProviderConfig(
+    wallet_data="WALLET DATA JSON STRING",
+    api_key_name="CDP API KEY NAME",
+    api_key_private="CDP API KEY PRIVATE KEY",
+    gas={
+        "gas_limit_multiplier": 2.0,   # Adjusts gas limit estimation
+        "fee_per_gas_multiplier": 2.0  # Adjusts max fee per gas
+    }
+))
+```
+
+**Note**: Gas parameters only impact the `wallet_provider.send_transaction` behavior. Actions that do not rely on direct transaction calls, such as `deploy_token`, `deploy_contract`, and `native_transfer`, remain unaffected.
+
 ### EthAccountWalletProvider
 
 Example usage with a private key:

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
@@ -36,9 +36,10 @@ class CdpWalletProviderConfig(CdpProviderConfig):
     network_id: str | None = Field("base-sepolia", description="The network id")
     mnemonic_phrase: str | None = Field(None, description="The mnemonic phrase of the wallet")
     wallet_data: str | None = Field(None, description="The data of the CDP Wallet as a JSON string")
-    
+
     class GasConfig(BaseModel):
         """Configuration for gas multipliers."""
+
         gas_limit_multiplier: float | None = Field(None, description="An internal multiplier on gas limit estimation")
         fee_per_gas_multiplier: float | None = Field(None, description="An internal multiplier on fee per gas estimation")
 

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
@@ -20,7 +20,7 @@ from web3 import Web3
 from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
 
 from ..network import NETWORK_ID_TO_CHAIN, Network
-from .evm_wallet_provider import EvmWalletProvider, EvmWalletProviderGasConfig
+from .evm_wallet_provider import EvmWalletProvider, EvmGasConfig
 
 
 class CdpProviderConfig(BaseModel):
@@ -36,7 +36,7 @@ class CdpWalletProviderConfig(CdpProviderConfig):
     network_id: str | None = Field("base-sepolia", description="The network id")
     mnemonic_phrase: str | None = Field(None, description="The mnemonic phrase of the wallet")
     wallet_data: str | None = Field(None, description="The data of the CDP Wallet as a JSON string")
-    gas: EvmWalletProviderGasConfig | None = Field(None, description="Gas configuration settings")
+    gas: EvmGasConfig | None = Field(None, description="Gas configuration settings")
 
 
 class CdpWalletProvider(EvmWalletProvider):

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
@@ -20,7 +20,7 @@ from web3 import Web3
 from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
 
 from ..network import NETWORK_ID_TO_CHAIN, Network
-from .evm_wallet_provider import EvmWalletProvider, EvmGasConfig
+from .evm_wallet_provider import EvmGasConfig, EvmWalletProvider
 
 
 class CdpProviderConfig(BaseModel):

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
@@ -20,7 +20,7 @@ from web3 import Web3
 from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
 
 from ..network import NETWORK_ID_TO_CHAIN, Network
-from .evm_wallet_provider import EvmWalletProvider
+from .evm_wallet_provider import EvmWalletProvider, EvmWalletProviderGasConfig
 
 
 class CdpProviderConfig(BaseModel):
@@ -36,14 +36,7 @@ class CdpWalletProviderConfig(CdpProviderConfig):
     network_id: str | None = Field("base-sepolia", description="The network id")
     mnemonic_phrase: str | None = Field(None, description="The mnemonic phrase of the wallet")
     wallet_data: str | None = Field(None, description="The data of the CDP Wallet as a JSON string")
-
-    class GasConfig(BaseModel):
-        """Configuration for gas multipliers."""
-
-        gas_limit_multiplier: float | None = Field(None, description="An internal multiplier on gas limit estimation")
-        fee_per_gas_multiplier: float | None = Field(None, description="An internal multiplier on fee per gas estimation")
-
-    gas: GasConfig | None = Field(None, description="Gas configuration settings")
+    gas: EvmWalletProviderGasConfig | None = Field(None, description="Gas configuration settings")
 
 
 class CdpWalletProvider(EvmWalletProvider):

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/cdp_wallet_provider.py
@@ -36,6 +36,13 @@ class CdpWalletProviderConfig(CdpProviderConfig):
     network_id: str | None = Field("base-sepolia", description="The network id")
     mnemonic_phrase: str | None = Field(None, description="The mnemonic phrase of the wallet")
     wallet_data: str | None = Field(None, description="The data of the CDP Wallet as a JSON string")
+    
+    class GasConfig(BaseModel):
+        """Configuration for gas multipliers."""
+        gas_limit_multiplier: float | None = Field(None, description="An internal multiplier on gas limit estimation")
+        fee_per_gas_multiplier: float | None = Field(None, description="An internal multiplier on fee per gas estimation")
+
+    gas: GasConfig | None = Field(None, description="Gas configuration settings")
 
 
 class CdpWalletProvider(EvmWalletProvider):
@@ -90,6 +97,19 @@ class CdpWalletProvider(EvmWalletProvider):
                 chain_id=chain.id,
             )
             self._web3 = Web3(Web3.HTTPProvider(rpc_url))
+
+            self._gas_limit_multiplier = (
+                max(config.gas.gas_limit_multiplier, 1)
+                if config and config.gas and config.gas.gas_limit_multiplier is not None
+                else 1.2
+            )
+
+            self._fee_per_gas_multiplier = (
+                max(config.gas.fee_per_gas_multiplier, 1)
+                if config and config.gas and config.gas.fee_per_gas_multiplier is not None
+                else 1
+            )
+
 
         except ImportError as e:
             raise ImportError(
@@ -364,18 +384,15 @@ class CdpWalletProvider(EvmWalletProvider):
         transaction["maxPriorityFeePerGas"] = max_priority_fee_per_gas
         transaction["maxFeePerGas"] = max_fee_per_gas
 
-        gas = self._web3.eth.estimate_gas(transaction)
+        gas = int(self._web3.eth.estimate_gas(transaction) * self._gas_limit_multiplier)
         transaction["gas"] = gas
 
         del transaction["from"]
 
         return transaction
 
-    def _estimate_fees(self, multiplier=1.2):
-        """Estimate gas fees for a transaction.
-
-        Args:
-            multiplier (float): Buffer multiplier for base fee, defaults to 1.2
+    def _estimate_fees(self):
+        """Estimate gas fees for a transaction, applying the configured fee multipliers.
 
         Returns:
             tuple[int, int]: Tuple of (max_priority_fee_per_gas, max_fee_per_gas) in wei
@@ -385,11 +402,16 @@ class CdpWalletProvider(EvmWalletProvider):
         def get_base_fee():
             latest_block = self._web3.eth.get_block("latest")
             base_fee = latest_block["baseFeePerGas"]
-            # Multiply by 1.2 to give some buffer
-            return int(base_fee * multiplier)
+            # Multiply the configured fee multiplier to give some buffer
+            return int(base_fee * self._fee_per_gas_multiplier)
+
+        def get_max_priority_fee():
+            max_priority_fee_per_gas = Web3.to_wei(0.1, "gwei")
+            # Multiply the configured fee multiplier to give some buffer
+            return int(max_priority_fee_per_gas * self._fee_per_gas_multiplier)
 
         base_fee_per_gas = get_base_fee()
-        max_priority_fee_per_gas = Web3.to_wei(0.1, "gwei")
+        max_priority_fee_per_gas = get_max_priority_fee()
         max_fee_per_gas = base_fee_per_gas + max_priority_fee_per_gas
 
         return (max_priority_fee_per_gas, max_fee_per_gas)

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -6,13 +6,13 @@ from typing import Any
 from eth_account.account import LocalAccount
 from eth_account.datastructures import SignedTransaction
 from eth_account.messages import encode_defunct
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from web3 import Web3
 from web3.middleware import SignAndSendRawMiddlewareBuilder
 from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
 
 from ..network import CHAIN_ID_TO_NETWORK_ID, NETWORK_ID_TO_CHAIN, Network
-from .evm_wallet_provider import EvmWalletProvider
+from .evm_wallet_provider import EvmWalletProvider, EvmGasConfig
 
 
 class EthAccountWalletProviderConfig(BaseModel):
@@ -20,6 +20,7 @@ class EthAccountWalletProviderConfig(BaseModel):
 
     account: LocalAccount
     chain_id: str
+    gas: EvmGasConfig | None = Field(None, description="Gas configuration settings")
 
     class Config:
         """Configuration for EthAccountWalletProvider."""
@@ -52,6 +53,18 @@ class EthAccountWalletProvider(EvmWalletProvider):
             protocol_family="evm",
             chain_id=self.config.chain_id,
             network_id=CHAIN_ID_TO_NETWORK_ID[self.config.chain_id],
+        )
+
+        self._gas_limit_multiplier = (
+            max(config.gas.gas_limit_multiplier, 1)
+            if config and config.gas and config.gas.gas_limit_multiplier is not None
+            else 1.2
+        )
+
+        self._fee_per_gas_multiplier = (
+            max(config.gas.fee_per_gas_multiplier, 1)
+            if config and config.gas and config.gas.fee_per_gas_multiplier is not None
+            else 1
         )
 
     def get_address(self) -> str:
@@ -137,11 +150,8 @@ class EthAccountWalletProvider(EvmWalletProvider):
 
         return self.account.sign_transaction(transaction)
 
-    def estimate_fees(self, multiplier=1.2):
-        """Estimate gas fees for a transaction.
-
-        Args:
-            multiplier (float): Buffer multiplier for base fee, defaults to 1.2
+    def estimate_fees(self):
+        """Estimate gas fees for a transaction, applying the configured fee multipliers.
 
         Returns:
             tuple[int, int]: Tuple of (max_priority_fee_per_gas, max_fee_per_gas) in wei
@@ -157,11 +167,16 @@ class EthAccountWalletProvider(EvmWalletProvider):
             """
             latest_block = self.web3.eth.get_block("latest")
             base_fee = latest_block["baseFeePerGas"]
-            # Multiply by 1.2 to give some buffer
-            return int(base_fee * multiplier)
+            # Multiply the configured fee multiplier to give some buffer
+            return int(base_fee * self._fee_per_gas_multiplier)
+
+        def get_max_priority_fee():
+            max_priority_fee_per_gas = Web3.to_wei(0.1, "gwei")
+            # Multiply the configured fee multiplier to give some buffer
+            return int(max_priority_fee_per_gas * self._fee_per_gas_multiplier)
 
         base_fee_per_gas = get_base_fee()
-        max_priority_fee_per_gas = Web3.to_wei(0.1, "gwei")
+        max_priority_fee_per_gas = get_max_priority_fee()
         max_fee_per_gas = base_fee_per_gas + max_priority_fee_per_gas
 
         return (max_priority_fee_per_gas, max_fee_per_gas)
@@ -189,7 +204,8 @@ class EthAccountWalletProvider(EvmWalletProvider):
         transaction["maxPriorityFeePerGas"] = max_priority_fee_per_gas
         transaction["maxFeePerGas"] = max_fee_per_gas
 
-        gas = self.web3.eth.estimate_gas(transaction)
+
+        gas = int(self.web3.eth.estimate_gas(transaction) * self._gas_limit_multiplier)
         transaction["gas"] = gas
 
         hash = self.web3.eth.send_transaction(transaction)

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -19,7 +19,7 @@ class EthAccountWalletProviderConfig(BaseModel):
     """Configuration for EthAccountWalletProvider."""
 
     account: LocalAccount
-    chain_id: int
+    chain_id: str
     gas: EvmGasConfig | None = Field(None, description="Gas configuration settings")
 
     class Config:
@@ -41,7 +41,7 @@ class EthAccountWalletProvider(EvmWalletProvider):
         self.config = config
         self.account = config.account
 
-        chain = NETWORK_ID_TO_CHAIN[CHAIN_ID_TO_NETWORK_ID[config.chain_id]]
+        chain = NETWORK_ID_TO_CHAIN[config.chain_id]
         rpc_url = chain.rpc_urls["default"].http[0]
 
         self.web3 = Web3(Web3.HTTPProvider(rpc_url))

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -19,7 +19,7 @@ class EthAccountWalletProviderConfig(BaseModel):
     """Configuration for EthAccountWalletProvider."""
 
     account: LocalAccount
-    chain_id: str
+    chain_id: int
     gas: EvmGasConfig | None = Field(None, description="Gas configuration settings")
 
     class Config:

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -41,7 +41,7 @@ class EthAccountWalletProvider(EvmWalletProvider):
         self.config = config
         self.account = config.account
 
-        chain = NETWORK_ID_TO_CHAIN[config.chain_id]
+        chain = NETWORK_ID_TO_CHAIN[CHAIN_ID_TO_NETWORK_ID[config.chain_id]]
         rpc_url = chain.rpc_urls["default"].http[0]
 
         self.web3 = Web3(Web3.HTTPProvider(rpc_url))

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -12,7 +12,7 @@ from web3.middleware import SignAndSendRawMiddlewareBuilder
 from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
 
 from ..network import CHAIN_ID_TO_NETWORK_ID, NETWORK_ID_TO_CHAIN, Network
-from .evm_wallet_provider import EvmWalletProvider, EvmGasConfig
+from .evm_wallet_provider import EvmGasConfig, EvmWalletProvider
 
 
 class EthAccountWalletProviderConfig(BaseModel):

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/evm_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/evm_wallet_provider.py
@@ -4,10 +4,17 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from eth_account.datastructures import SignedTransaction
+from pydantic import BaseModel, Field
 from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
 
 from .wallet_provider import WalletProvider
 
+
+class EvmWalletProviderGasConfig(BaseModel):
+    """Configuration for gas multipliers."""
+
+    gas_limit_multiplier: float | None = Field(None, description="An internal multiplier on gas limit estimation")
+    fee_per_gas_multiplier: float | None = Field(None, description="An internal multiplier on fee per gas estimation")
 
 class EvmWalletProvider(WalletProvider, ABC):
     """Abstract base class for all EVM wallet providers."""

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/evm_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/evm_wallet_provider.py
@@ -10,7 +10,7 @@ from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
 from .wallet_provider import WalletProvider
 
 
-class EvmWalletProviderGasConfig(BaseModel):
+class EvmGasConfig(BaseModel):
     """Configuration for gas multipliers."""
 
     gas_limit_multiplier: float | None = Field(None, description="An internal multiplier on gas limit estimation")


### PR DESCRIPTION
*This PR is recreating #361 in Python*

### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other
* Exposed gas configuration during wallet provider creation

### Why was this change implemented?
Users were requesting the ability to control gas estimations.
The two main benefits for users are:
1. Reduce `Out of Gas` failures by increasing the gas limit.
2. Speed up the rate a transaction will be picked up by increasing the fee per gas price.

### Network support
- [x] All EVM
- [ ] Base
- [ ] Base Sepolia
- [ ] Other

### Wallet support
- [x] CDP Wallet
- [ ] EVM Wallet
- [ ] Other

### Checklist
- [x] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [x] Doc strings
- [x] Readme updates
- [x] Rebased against main
- [x] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests

LLM: gpt-4o-mini

Prompt: "Transfer 1 ERC20 token of contract 0x04Ce21CCf093BeC08F4aaF89E1859A67c88f8fc2 to the receiver 0x7Af173A33786C26f92D325c3522F4fB434351b7F"

Configurations for each test:
`gas: undefined` -> [Txn: 42k gas limit, 0.001 max gwei, 0.001 max priority gwei](https://sepolia.basescan.org/tx/0xe80af72ec8ba45a78616c70c87d73f858f0a9632b8f5d872cadb70a49c821497)
`gas: { gas_limit_multiplier: 2 }` -> [Txn: 69k gas limit, 0.001 max gwei, 0.001 max priority gwei](https://sepolia.basescan.org/tx/0x17fe203e2bf4803ebc1ad59e32bff422eefeef8975b102b1869dece0fa144064)
`gas: { fee_per_gas_multiplier: 2 }` -> [Txn: 42k gas limit, 0.002 max gwei, 0.002 max priority gwei](https://sepolia.basescan.org/tx/0x2c70520f78320583fadfae0a613f617b91f57db3287836cd6927609ed48ca1e1)
`gas: { gas_limit_multiplier: 2, fee_per_gas_multiplier: 2 }` -> [Txn: 69k gas limit, 0.002 max gwei, 0.002 max priority gwei](https://sepolia.basescan.org/tx/0xe80af72ec8ba45a78616c70c87d73f858f0a9632b8f5d872cadb70a49c821497)

### Notes to reviewers