### PR TITLE
feat: viem signing hex or uint8array

### DIFF
--- a/typescript/.changeset/stupid-goats-march.md
+++ b/typescript/.changeset/stupid-goats-march.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Allowed passing of a "hex" or bytes to "signMessage" for Viem & Viem-derived Wallet Providers

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.test.ts
@@ -94,6 +94,8 @@ jest.mock("viem", () => {
     fromHex: jest.fn(),
     formatEther: jest.fn(),
     privateKeyToAccount: jest.fn(),
+    isHex: jest.fn(value => typeof value === "string" && value.startsWith("0x")),
+    toHex: jest.fn(value => `0x${value}`),
   };
 });
 
@@ -222,7 +224,17 @@ describe("ViemWalletProvider", () => {
       const signature = await provider.signMessage(MOCK_MESSAGE);
       expect(mockWalletClient.signMessage).toHaveBeenCalledWith({
         account: mockWalletClient.account,
-        message: MOCK_MESSAGE,
+        message: { raw: `0x${MOCK_MESSAGE}` },
+      });
+      expect(signature).toBe(MOCK_SIGNATURE);
+    });
+
+    it("should sign a hex message", async () => {
+      const hexMessage = "0x48656c6c6f2c20576f726c6421"; // "Hello, World!" in hex
+      const signature = await provider.signMessage(hexMessage);
+      expect(mockWalletClient.signMessage).toHaveBeenCalledWith({
+        account: mockWalletClient.account,
+        message: { raw: hexMessage },
       });
       expect(signature).toBe(MOCK_SIGNATURE);
     });

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
@@ -13,6 +13,8 @@ import {
   Abi,
   ContractFunctionName,
   ContractFunctionArgs,
+  isHex,
+  toHex,
 } from "viem";
 import { EvmWalletProvider } from "./evmWalletProvider";
 import { Network } from "../network";
@@ -67,13 +69,19 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * @param message - The message to sign.
    * @returns The signed message.
    */
-  async signMessage(message: string): Promise<`0x${string}`> {
+  async signMessage(message: string | Uint8Array): Promise<`0x${string}`> {
     const account = this.#walletClient.account;
     if (!account) {
       throw new Error("Account not found");
     }
 
-    return this.#walletClient.signMessage({ account, message });
+    const hexMessage =
+      typeof message === "string" ? (isHex(message) ? message : toHex(message)) : message;
+
+    return this.#walletClient.signMessage({
+      account,
+      message: { raw: hexMessage },
+    });
   }
 
   /**

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
@@ -75,12 +75,12 @@ export class ViemWalletProvider extends EvmWalletProvider {
       throw new Error("Account not found");
     }
 
-    const hexMessage =
+    const _message =
       typeof message === "string" ? (isHex(message) ? message : toHex(message)) : message;
 
     return this.#walletClient.signMessage({
       account,
-      message: { raw: hexMessage },
+      message: { raw: _message },
     });
   }
 


### PR DESCRIPTION
### What changed?
Allowed passing of a "hex" or bytes to "signMessage" for Viem & Viem-derived Wallet Providers

### Why was this change implemented?

Currently Viem signing only supports strings. Viem itself can support Uint8Array & Hex ([code](https://github.com/wevm/viem/blob/main/src/actions/wallet/signMessage.ts#L82), [docs](https://viem.sh/experimental/erc7739/signMessage#message)).

As the `evmWalletProvider` doesn't support the `{ raw: <input> }`, we cast everything to a hex string based on the following logic and pass it into raw:

```
    const hexMessage =
      typeof message === "string" ? (isHex(message) ? message : toHex(message)) : message;

    return this.#walletClient.signMessage({
      account,
      message: { raw: hexMessage },
    });
```

This is to enable signing Hex messages as well as bytes (e.g. transaction hashes - this came up while trying to sign Gnosis Safe messages) - which otherwise get "hex'd" again by Viem when passed as string messages.

cc @escottalexander

