### PR TITLE
feat: added fromNetwork function to SolanaKeypairWalletProvider

### DIFF
--- a/typescript/agentkit/CHANGELOG.md
+++ b/typescript/agentkit/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-- Added `fromNetwork` to `solanaKeypairWalletProvider`
+
 ### Added
 
 - Added `svmWalletProvider` abstract class for interacting with Solana.

--- a/typescript/agentkit/src/network/svm.ts
+++ b/typescript/agentkit/src/network/svm.ts
@@ -4,6 +4,10 @@ import { Network } from "./types";
 export const SOLANA_MAINNET_NETWORK_ID = "solana-mainnet";
 export const SOLANA_TESTNET_NETWORK_ID = "solana-testnet";
 export const SOLANA_DEVNET_NETWORK_ID = "solana-devnet";
+export type SOLANA_NETWORK_ID = 
+  | typeof SOLANA_MAINNET_NETWORK_ID 
+  | typeof SOLANA_TESTNET_NETWORK_ID 
+  | typeof SOLANA_DEVNET_NETWORK_ID
 
 // AgentKit Protocol Family
 export const SOLANA_PROTOCOL_FAMILY = "svm";

--- a/typescript/agentkit/src/network/svm.ts
+++ b/typescript/agentkit/src/network/svm.ts
@@ -4,10 +4,10 @@ import { Network } from "./types";
 export const SOLANA_MAINNET_NETWORK_ID = "solana-mainnet";
 export const SOLANA_TESTNET_NETWORK_ID = "solana-testnet";
 export const SOLANA_DEVNET_NETWORK_ID = "solana-devnet";
-export type SOLANA_NETWORK_ID = 
-  | typeof SOLANA_MAINNET_NETWORK_ID 
-  | typeof SOLANA_TESTNET_NETWORK_ID 
-  | typeof SOLANA_DEVNET_NETWORK_ID
+export type SOLANA_NETWORK_ID =
+  | typeof SOLANA_MAINNET_NETWORK_ID
+  | typeof SOLANA_TESTNET_NETWORK_ID
+  | typeof SOLANA_DEVNET_NETWORK_ID;
 
 // AgentKit Protocol Family
 export const SOLANA_PROTOCOL_FAMILY = "svm";

--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
@@ -114,8 +114,7 @@ export class SolanaKeypairWalletProvider extends SvmWalletProvider {
         throw new Error(`${networkId} is not a valid SVM networkId`);
     }
     const rpcUrl = this.urlForCluster(genesisHash);
-    const connection = new Connection(rpcUrl);
-    return await this.fromConnection(connection, keypair);
+    return await this.fromRpcUrl(rpcUrl, keypair);
   }
 
   /**

--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
@@ -100,7 +100,7 @@ export class SolanaKeypairWalletProvider extends SvmWalletProvider {
     keypair: Uint8Array | string,
   ): Promise<T> {
     let genesisHash: SOLANA_CLUSTER;
-    switch(networkId) {
+    switch (networkId) {
       case SOLANA_MAINNET_NETWORK_ID:
         genesisHash = SOLANA_MAINNET_GENESIS_BLOCK_HASH;
         break;

--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
@@ -15,9 +15,13 @@ import bs58 from "bs58";
 import {
   SOLANA_CLUSTER,
   SOLANA_DEVNET_GENESIS_BLOCK_HASH,
+  SOLANA_DEVNET_NETWORK_ID,
   SOLANA_MAINNET_GENESIS_BLOCK_HASH,
+  SOLANA_MAINNET_NETWORK_ID,
+  SOLANA_NETWORK_ID,
   SOLANA_NETWORKS,
   SOLANA_TESTNET_GENESIS_BLOCK_HASH,
+  SOLANA_TESTNET_NETWORK_ID,
 } from "../network/svm";
 
 /**
@@ -82,6 +86,36 @@ export class SolanaKeypairWalletProvider extends SvmWalletProvider {
     } else {
       throw new Error(`Unknown cluster: ${cluster}`);
     }
+  }
+
+  /**
+   * Create a new SolanaKeypairWalletProvider from an SVM networkId and a keypair
+   *
+   * @param networkId - The SVM networkId
+   * @param keypair - Either a Uint8Array or a base58 encoded string representing a 32-byte secret key
+   * @returns The new SolanaKeypairWalletProvider
+   */
+  static async fromNetwork<T extends SolanaKeypairWalletProvider>(
+    networkId: SOLANA_NETWORK_ID,
+    keypair: Uint8Array | string,
+  ): Promise<T> {
+    let genesisHash: SOLANA_CLUSTER;
+    switch(networkId) {
+      case SOLANA_MAINNET_NETWORK_ID:
+        genesisHash = SOLANA_MAINNET_GENESIS_BLOCK_HASH;
+        break;
+      case SOLANA_DEVNET_NETWORK_ID:
+        genesisHash = SOLANA_DEVNET_GENESIS_BLOCK_HASH;
+        break;
+      case SOLANA_TESTNET_NETWORK_ID:
+        genesisHash = SOLANA_TESTNET_GENESIS_BLOCK_HASH;
+        break;
+      default:
+        throw new Error(`${networkId} is not a valid SVM networkId`);
+    }
+    const rpcUrl = this.urlForCluster(genesisHash);
+    const connection = new Connection(rpcUrl);
+    return await this.fromConnection(connection, keypair);
   }
 
   /**


### PR DESCRIPTION
*Once #385 is merged, this PR will be rebased, I will merge together the updated `SolanaKeypairWalletProvider`, and then publish the PR for review*

### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other
Added `SolanaKeypairWalletProvider.fromNetwork` to construct a `SolanaKeypairWalletProvider` with default RPC url's based on the provided network.

### Why was this change implemented?
To allow users to more easily get started without supplying their own RPC url.

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [x] Other
SVM

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [x] Other
SolanaKeypairWalletProvider

### Checklist
- [x] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [x] Doc strings
- [ ] Readme updates
Solana has not been in the readme. I would delay this until we're closer to completion.
- [ ] Rebased against master
*Will do after #385  is merged*
- [x] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests


`SolanaKeypairWalletProvider.fromNetwork('solana-mainnet', privateKey)`
```
Prompt: What is your network?

-------------------
Wallet Details:
- Provider: solana_keypair_wallet_provider
- Address: 5RGNssB9BY1kmZDHUWZtVnYpZpV4JzzwqmbX4orYBh4s
- Network: 
  * Protocol Family: svm
  * Network ID: solana-mainnet
  * Chain ID: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
- ETH Balance: 0.000000 ETH
- Native Balance: 0 WEI
-------------------
You are currently on the Solana mainnet network. If you need any assistance or want to perform actions related to this network, feel free to let me know!
```

`SolanaKeypairWalletProvider.fromNetwork('solana-devnet', privateKey)`
```
Prompt: What is your network?

-------------------
Wallet Details:
- Provider: solana_keypair_wallet_provider
- Address: 5RGNssB9BY1kmZDHUWZtVnYpZpV4JzzwqmbX4orYBh4s
- Network: 
  * Protocol Family: svm
  * Network ID: solana-devnet
  * Chain ID: EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG
- ETH Balance: 0.000000 ETH
- Native Balance: 3500000000 WEI
-------------------
Your wallet is on the Solana Devnet network. If you need any assistance or actions to be taken on this network, let me know!
-------------------
```

`SolanaKeypairWalletProvider.fromNetwork('solana-testnet', privateKey)`
```
Prompt: What is your network

-------------------
Wallet Details:
- Provider: solana_keypair_wallet_provider
- Address: 5RGNssB9BY1kmZDHUWZtVnYpZpV4JzzwqmbX4orYBh4s
- Network: 
  * Protocol Family: svm
  * Network ID: solana-testnet
  * Chain ID: 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY
- ETH Balance: 0.000000 ETH
- Native Balance: 0 WEI
-------------------
You are on the Solana testnet. My current wallet address is `5RGNssB9BY1kmZDHUWZtVnYpZpV4JzzwqmbX4orYBh4s`. If you need any assistance or have specific requests on this network, let me know!
```

### Notes to reviewers
