### PR TITLE
feat: add signAndSendTransaction

### DIFF
--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
@@ -10,6 +10,9 @@ import {
   MessageV0,
   ComputeBudgetProgram,
   clusterApiUrl,
+  RpcResponseAndContext,
+  SignatureStatus,
+  SignatureStatusConfig,
 } from "@solana/web3.js";
 import bs58 from "bs58";
 import {
@@ -184,21 +187,35 @@ export class SolanaKeypairWalletProvider extends SvmWalletProvider {
    * Send a transaction
    *
    * @param transaction - The transaction to send
-   * @returns The transaction hash
+   * @returns The transaction signature
    */
-  sendTransaction(transaction: VersionedTransaction): Promise<string> {
+  async sendTransaction(transaction: VersionedTransaction): Promise<string> {
     return this.#connection.sendTransaction(transaction);
   }
 
   /**
-   * Wait for a transaction receipt
+   * Sign and send a transaction
    *
-   * @param txHash - The transaction hash
-   * @returns The transaction receipt
+   * @param transaction - The transaction to sign and send
+   * @returns The transaction signature
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  waitForTransactionReceipt(txHash: string): Promise<any> {
-    return this.#connection.confirmTransaction(txHash);
+  async signAndSendTransaction(transaction: VersionedTransaction): Promise<string> {
+    const signedTransaction = await this.signTransaction(transaction);
+    return this.sendTransaction(signedTransaction);
+  }
+
+  /**
+   * Get the status of a transaction
+   *
+   * @param signature - The transaction signature
+   * @param options - The options for the transaction status
+   * @returns The transaction status
+   */
+  async getSignatureStatus(
+    signature: string,
+    options?: SignatureStatusConfig,
+  ): Promise<RpcResponseAndContext<SignatureStatus | null>> {
+    return this.#connection.getSignatureStatus(signature, options);
   }
 
   /**

--- a/typescript/agentkit/src/wallet-providers/svmWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/svmWalletProvider.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { WalletProvider } from "./walletProvider";
-import { VersionedTransaction } from "@solana/web3.js";
+import {
+  RpcResponseAndContext,
+  SignatureStatus,
+  SignatureStatusConfig,
+  VersionedTransaction,
+} from "@solana/web3.js";
 
 /**
  * SvmWalletProvider is the abstract base class for all Solana wallet providers (non browsers).
@@ -21,15 +26,26 @@ export abstract class SvmWalletProvider extends WalletProvider {
    * Send a transaction.
    *
    * @param transaction - The transaction to send.
-   * @returns The transaction hash.
+   * @returns The transaction signature.
    */
   abstract sendTransaction(transaction: VersionedTransaction): Promise<string>;
 
   /**
-   * Wait for a transaction receipt.
+   * Sign and send a transaction.
    *
-   * @param txHash - The transaction hash.
-   * @returns The transaction receipt.
+   * @param transaction - The transaction to sign and send.
+   * @returns The transaction signature.
    */
-  abstract waitForTransactionReceipt(txHash: string): Promise<any>;
+  abstract signAndSendTransaction(transaction: VersionedTransaction): Promise<string>;
+
+  /**
+   * Get the status of a transaction.
+   *
+   * @param signature - The transaction signature.
+   * @returns The transaction status.
+   */
+  abstract getSignatureStatus(
+    signature: string,
+    options?: SignatureStatusConfig,
+  ): Promise<RpcResponseAndContext<SignatureStatus | null>>;
 }


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other
<!-- please specify -->

### Why was this change implemented?
* Adding this standard Solana method. Will be used by incoming Privy Solana Wallet
* Also renamed `waitForReceipt` to `getSignatureStatus`, following the [docs](https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getsignaturestatus)

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [x] Other
Solana

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [ ] Other
<!-- please specify -->

### Checklist
- [ ] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [x] Doc strings
- [ ] Readme updates
- [x] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [ ] Agent tested
- [ ] Unit tests
<!-- please include the agent LLM -->
<!-- please include the agent prompt -->
<!-- please include the agent output -->

### Notes to reviewers
