### PR TITLE
fix: Morpho python action provider function headers

### DIFF
--- a/python/coinbase-agentkit/CHANGELOG.md
+++ b/python/coinbase-agentkit/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed Morpho `deposit` and `withdraw` function headers to conform to the Action Provider Paradigm.
+
 ## [0.1.2] - 2025-02-14
 
 - Added gas configuration parameters (`gas_limit_multiplier`, `fee_per_gas_multiplier`) to `CdpWalletProvider` and `EthAccountWalletProvider`.

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/morpho_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/morpho/morpho_action_provider.py
@@ -43,11 +43,11 @@ Important notes:
 - Please use a token address (example 0x4200000000000000000000000000000000000006) for the token_address field. If you are unsure of the token address, please clarify what the requested token address is before continuing.""",
         schema=MorphoDepositSchema,
     )
-    def deposit(self, wallet: EvmWalletProvider, args: dict[str, Any]) -> str:
+    def deposit(self, wallet_provider: EvmWalletProvider, args: dict[str, Any]) -> str:
         """Deposit assets into a Morpho Vault.
 
         Args:
-            wallet (EvmWalletProvider): The wallet provider instance.
+            wallet_provider (EvmWalletProvider): The wallet provider instance.
             args (dict[str, Any]): Input arguments for the action.
 
         Returns:
@@ -63,7 +63,7 @@ Important notes:
             atomic_assets = Web3.to_wei(assets, "ether")
 
             try:
-                approve(wallet, args["token_address"], args["vault_address"], atomic_assets)
+                approve(wallet_provider, args["token_address"], args["vault_address"], atomic_assets)
             except Exception as e:
                 return f"Error approving Morpho Vault as spender: {e!s}"
 
@@ -78,8 +78,8 @@ Important notes:
                 "data": encoded_data,
             }
 
-            tx_hash = wallet.send_transaction(params)
-            wallet.wait_for_transaction_receipt(tx_hash)
+            tx_hash = wallet_provider.send_transaction(params)
+            wallet_provider.wait_for_transaction_receipt(tx_hash)
 
             return f"Deposited {args['assets']} to Morpho Vault {args['vault_address']} with transaction hash: {tx_hash}"
 
@@ -96,11 +96,11 @@ This tool allows withdrawing assets from a Morpho Vault. It takes:
 """,
         schema=MorphoWithdrawSchema,
     )
-    def withdraw(self, wallet: EvmWalletProvider, args: dict[str, Any]) -> str:
+    def withdraw(self, wallet_provider: EvmWalletProvider, args: dict[str, Any]) -> str:
         """Withdraw assets from a Morpho Vault.
 
         Args:
-            wallet (EvmWalletProvider): The wallet provider instance.
+            wallet_provider (EvmWalletProvider): The wallet provider instance.
             args (dict[str, Any]): Input arguments for the action.
 
         Returns:
@@ -125,8 +125,8 @@ This tool allows withdrawing assets from a Morpho Vault. It takes:
                 "data": encoded_data,
             }
 
-            tx_hash = wallet.send_transaction(params)
-            wallet.wait_for_transaction_receipt(tx_hash)
+            tx_hash = wallet_provider.send_transaction(params)
+            wallet_provider.wait_for_transaction_receipt(tx_hash)
 
             return f"Withdrawn {args['assets']} from Morpho Vault {args['vault_address']} with transaction hash: {tx_hash}"
 


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other

### Why was this change implemented?
Fixed Morpho `deposit` and `withdraw` function headers to conform to the Action Provider Paradigm.

Resolves: #405

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [x] Other
N/A

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [x] Other
N/A

### Checklist
- [x] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [ ] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [x] Unit tests

### Notes to reviewers
I was going to make a yield optimizer agent example with Morpho and Compound but Morpho action was not working. 
