### PR TITLE
chore: rename privy evm wallet provider

### DIFF
--- a/typescript/agentkit/src/wallet-providers/privyEvmWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmWalletProvider.ts
@@ -1,0 +1,172 @@
+import { PrivyClient } from "@privy-io/server-auth";
+import { createViemAccount } from "@privy-io/server-auth/viem";
+import { ViemWalletProvider } from "./viemWalletProvider";
+import { createWalletClient, http, WalletClient } from "viem";
+import { getChain } from "../network/network";
+
+/**
+ * Configuration options for the Privy wallet provider.
+ *
+ * @interface
+ */
+export interface PrivyEvmWalletConfig {
+  /** The Privy application ID */
+  appId: string;
+  /** The Privy application secret */
+  appSecret: string;
+  /** The ID of the wallet to use, if not provided a new wallet will be created */
+  walletId?: string;
+  /** Optional chain ID to connect to */
+  chainId?: string;
+  /** Optional authorization key for the wallet API */
+  authorizationPrivateKey?: string;
+  /** Optional authorization key ID for creating new wallets */
+  authorizationKeyId?: string;
+}
+
+type PrivyWalletExport = {
+  walletId: string;
+  authorizationPrivateKey: string | undefined;
+  chainId: string | undefined;
+};
+
+/**
+ * A wallet provider that uses Privy's server wallet API.
+ * This provider extends the ViemWalletProvider to provide Privy-specific wallet functionality
+ * while maintaining compatibility with the base wallet provider interface.
+ */
+export class PrivyEvmWalletProvider extends ViemWalletProvider {
+  #walletId: string;
+  #authorizationPrivateKey: string | undefined;
+
+  /**
+   * Private constructor to enforce use of factory method.
+   *
+   * @param walletClient - The Viem wallet client instance
+   * @param config - The configuration options for the Privy wallet
+   */
+  private constructor(
+    walletClient: WalletClient,
+    config: PrivyEvmWalletConfig & { walletId: string }, // Require walletId in constructor
+  ) {
+    super(walletClient);
+    this.#walletId = config.walletId; // Now guaranteed to exist
+    this.#authorizationPrivateKey = config.authorizationPrivateKey;
+  }
+
+  /**
+   * Creates and configures a new PrivyWalletProvider instance.
+   *
+   * @param config - The configuration options for the Privy wallet
+   * @returns A configured PrivyWalletProvider instance
+   *
+   * @example
+   * ```typescript
+   * const provider = await PrivyWalletProvider.configureWithWallet({
+   *   appId: "your-app-id",
+   *   appSecret: "your-app-secret",
+   *   walletId: "wallet-id",
+   *   chainId: "84532"
+   * });
+   * ```
+   */
+  public static async configureWithWallet(
+    config: PrivyEvmWalletConfig,
+  ): Promise<PrivyEvmWalletProvider> {
+    const privy = new PrivyClient(config.appId, config.appSecret, {
+      walletApi: config.authorizationPrivateKey
+        ? {
+            authorizationPrivateKey: config.authorizationPrivateKey,
+          }
+        : undefined,
+    });
+
+    let walletId: string;
+    let address: `0x${string}`;
+
+    if (!config.walletId) {
+      if (config.authorizationPrivateKey && !config.authorizationKeyId) {
+        throw new Error(
+          "authorizationKeyId is required when creating a new wallet with an authorization key, this can be found in your Privy Dashboard",
+        );
+      }
+
+      if (config.authorizationKeyId && !config.authorizationPrivateKey) {
+        throw new Error(
+          "authorizationPrivateKey is required when creating a new wallet with an authorizationKeyId. " +
+            "If you don't have it, you can create a new one in your Privy Dashboard, or delete the authorization key.",
+        );
+      }
+
+      try {
+        const wallet = await privy.walletApi.create({
+          chainType: "ethereum",
+          authorizationKeyIds: config.authorizationKeyId ? [config.authorizationKeyId] : undefined,
+        });
+        walletId = wallet.id;
+        address = wallet.address as `0x${string}`;
+      } catch (error) {
+        console.error(error);
+        if (
+          error instanceof Error &&
+          error.message.includes("Missing `privy-authorization-signature` header")
+        ) {
+          // Providing a more informative error message, see context: https://github.com/coinbase/agentkit/pull/242#discussion_r1956428617
+          throw new Error(
+            "Privy error: you have an authorization key on your account which can create and modify wallets, please delete this key or pass it to the PrivyWalletProvider to create a new wallet",
+          );
+        }
+        throw new Error("Failed to create wallet");
+      }
+    } else {
+      walletId = config.walletId;
+      const wallet = await privy.walletApi.getWallet({ id: walletId });
+      if (!wallet) {
+        throw new Error(`Wallet with ID ${walletId} not found`);
+      }
+      address = wallet.address as `0x${string}`;
+    }
+
+    const account = await createViemAccount({
+      walletId,
+      address,
+      privy,
+    });
+
+    const chainId = config.chainId || "84532";
+
+    const chain = getChain(chainId);
+    if (!chain) {
+      throw new Error(`Chain with ID ${chainId} not found`);
+    }
+
+    const walletClient = createWalletClient({
+      account,
+      chain,
+      transport: http(),
+    });
+    return new PrivyEvmWalletProvider(walletClient, { ...config, walletId });
+  }
+
+  /**
+   * Gets the name of the wallet provider.
+   *
+   * @returns The string identifier for this wallet provider
+   */
+  getName(): string {
+    return "privy_evm_wallet_provider";
+  }
+
+  /**
+   * Exports the wallet data.
+   *
+   * @returns The wallet data
+   */
+  exportWallet(): PrivyWalletExport {
+    return {
+      walletId: this.#walletId,
+      authorizationPrivateKey: this.#authorizationPrivateKey,
+      chainId: this.getNetwork().chainId,
+    };
+  }
+}

--- a/typescript/agentkit/src/wallet-providers/privyWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyWalletProvider.ts
@@ -1,169 +1,31 @@
-import { PrivyClient } from "@privy-io/server-auth";
-import { createViemAccount } from "@privy-io/server-auth/viem";
-import { ViemWalletProvider } from "./viemWalletProvider";
-import { createWalletClient, http, WalletClient } from "viem";
-import { getChain } from "../network/network";
-/**
- * Configuration options for the Privy wallet provider.
- *
- * @interface
- */
-interface PrivyWalletConfig {
-  /** The Privy application ID */
-  appId: string;
-  /** The Privy application secret */
-  appSecret: string;
-  /** The ID of the wallet to use, if not provided a new wallet will be created */
-  walletId?: string;
-  /** Optional chain ID to connect to */
-  chainId?: string;
-  /** Optional authorization key for the wallet API */
-  authorizationPrivateKey?: string;
-  /** Optional authorization key ID for creating new wallets */
-  authorizationKeyId?: string;
-}
+import { PrivyEvmWalletProvider, PrivyEvmWalletConfig } from "./privyEvmWalletProvider";
 
-type PrivyWalletExport = {
-  walletId: string;
-  authorizationPrivateKey: string | undefined;
-  chainId: string | undefined;
-};
+export type PrivyWalletConfig = PrivyEvmWalletConfig;
 
 /**
- * A wallet provider that uses Privy's server wallet API.
- * This provider extends the ViemWalletProvider to provide Privy-specific wallet functionality
- * while maintaining compatibility with the base wallet provider interface.
+ * Factory class for creating chain-specific Privy wallet providers
  */
-export class PrivyWalletProvider extends ViemWalletProvider {
-  #walletId: string;
-  #authorizationPrivateKey: string | undefined;
-
+export class PrivyWalletProvider {
   /**
-   * Private constructor to enforce use of factory method.
-   *
-   * @param walletClient - The Viem wallet client instance
-   * @param config - The configuration options for the Privy wallet
-   */
-  private constructor(
-    walletClient: WalletClient,
-    config: PrivyWalletConfig & { walletId: string }, // Require walletId in constructor
-  ) {
-    super(walletClient);
-    this.#walletId = config.walletId; // Now guaranteed to exist
-    this.#authorizationPrivateKey = config.authorizationPrivateKey;
-  }
-
-  /**
-   * Creates and configures a new PrivyWalletProvider instance.
+   * Creates and configures a new wallet provider instance based on the chain type.
    *
    * @param config - The configuration options for the Privy wallet
-   * @returns A configured PrivyWalletProvider instance
+   * @returns A configured WalletProvider instance for the specified chain
    *
    * @example
    * ```typescript
-   * const provider = await PrivyWalletProvider.configureWithWallet({
+   * // For EVM (default)
+   * const evmWallet = await PrivyWalletProvider.configureWithWallet({
    *   appId: "your-app-id",
-   *   appSecret: "your-app-secret",
-   *   walletId: "wallet-id",
-   *   chainId: "84532"
+   *   appSecret: "your-app-secret"
    * });
    * ```
    */
-  public static async configureWithWallet(config: PrivyWalletConfig): Promise<PrivyWalletProvider> {
-    const privy = new PrivyClient(config.appId, config.appSecret, {
-      walletApi: config.authorizationPrivateKey
-        ? {
-            authorizationPrivateKey: config.authorizationPrivateKey,
-          }
-        : undefined,
-    });
-
-    let walletId: string;
-    let address: `0x${string}`;
-
-    if (!config.walletId) {
-      if (config.authorizationPrivateKey && !config.authorizationKeyId) {
-        throw new Error(
-          "authorizationKeyId is required when creating a new wallet with an authorization key, this can be found in your Privy Dashboard",
-        );
-      }
-
-      if (config.authorizationKeyId && !config.authorizationPrivateKey) {
-        throw new Error(
-          "authorizationPrivateKey is required when creating a new wallet with an authorizationKeyId. " +
-            "If you don't have it, you can create a new one in your Privy Dashboard, or delete the authorization key.",
-        );
-      }
-
-      try {
-        const wallet = await privy.walletApi.create({
-          chainType: "ethereum",
-          authorizationKeyIds: config.authorizationKeyId ? [config.authorizationKeyId] : undefined,
-        });
-        walletId = wallet.id;
-        address = wallet.address as `0x${string}`;
-      } catch (error) {
-        console.error(error);
-        if (
-          error instanceof Error &&
-          error.message.includes("Missing `privy-authorization-signature` header")
-        ) {
-          // Providing a more informative error message, see context: https://github.com/coinbase/agentkit/pull/242#discussion_r1956428617
-          throw new Error(
-            "Privy error: you have an authorization key on your account which can create and modify wallets, please delete this key or pass it to the PrivyWalletProvider to create a new wallet",
-          );
-        }
-        throw new Error("Failed to create wallet");
-      }
-    } else {
-      walletId = config.walletId;
-      const wallet = await privy.walletApi.getWallet({ id: walletId });
-      if (!wallet) {
-        throw new Error(`Wallet with ID ${walletId} not found`);
-      }
-      address = wallet.address as `0x${string}`;
-    }
-
-    const account = await createViemAccount({
-      walletId,
-      address,
-      privy,
-    });
-
-    const chainId = config.chainId || "84532";
-
-    const chain = getChain(chainId);
-    if (!chain) {
-      throw new Error(`Chain with ID ${chainId} not found`);
-    }
-
-    const walletClient = createWalletClient({
-      account,
-      chain,
-      transport: http(),
-    });
-    return new PrivyWalletProvider(walletClient, { ...config, walletId });
-  }
-
-  /**
-   * Gets the name of the wallet provider.
-   *
-   * @returns The string identifier for this wallet provider
-   */
-  getName(): string {
-    return "privy_wallet_provider";
-  }
-
-  /**
-   * Exports the wallet data.
-   *
-   * @returns The wallet data
-   */
-  exportWallet(): PrivyWalletExport {
-    return {
-      walletId: this.#walletId,
-      authorizationPrivateKey: this.#authorizationPrivateKey,
-      chainId: this.getNetwork().chainId,
-    };
+  static async configureWithWallet<T extends PrivyWalletConfig>(
+    config: T & { chainType?: "ethereum" },
+  ): Promise<PrivyEvmWalletProvider> {
+    return (await PrivyEvmWalletProvider.configureWithWallet(
+      config as PrivyEvmWalletConfig,
+    )) as PrivyEvmWalletProvider;
   }
 }


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other
<!-- please specify -->

### Why was this change implemented?
This PR simply renames `PrivyWalletProvider` to `PrivyEvmWalletProvider` in preparation for a new `PrivySolanaWalletProvider`. It also adds a new `PrivyWalletProvider` which acts as a factory to generate either a `PrivyEvmWalletProvider`, or (in a following PR) a `PrivySolanaWalletProvider`. This factory is backwards compatible with the existing `PrivyWalletProvider` API.

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests

Tested by running the existing privy chatbot example and verifying via the wallet details action:
```
Prompt: print wallet details

-------------------
Wallet Details:
- Provider: privy_evm_wallet_provider
- Address: 0x7a4b9B89C24c0acf3c4Ef5636755DBa908DB3bC2
- Network:
  * Protocol Family: evm
  * Network ID: base-sepolia
  * Chain ID: 84532
- Native Balance: 0 WEI
-------------------
Here are the wallet details:

- **Provider:** privy_evm_wallet_provider
- **Address:** 0x7a4b9B89C24c0acf3c4Ef5636755DBa908DB3bC2
- **Network:**
  - **Protocol Family:** EVM
  - **Network ID:** base-sepolia
  - **Chain ID:** 84532
- **Native Balance:** 0 WEI
```