### PR TITLE
chore: extract shared privy types and functions

### DIFF
--- a/typescript/agentkit/src/wallet-providers/privyEvmWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmWalletProvider.ts
@@ -3,32 +3,17 @@ import { createViemAccount } from "@privy-io/server-auth/viem";
 import { ViemWalletProvider } from "./viemWalletProvider";
 import { createWalletClient, http, WalletClient } from "viem";
 import { getChain } from "../network/network";
+import { PrivyWalletConfig, PrivyWalletExport } from "./privyShared";
 
 /**
  * Configuration options for the Privy wallet provider.
  *
  * @interface
  */
-export interface PrivyEvmWalletConfig {
-  /** The Privy application ID */
-  appId: string;
-  /** The Privy application secret */
-  appSecret: string;
-  /** The ID of the wallet to use, if not provided a new wallet will be created */
-  walletId?: string;
+export interface PrivyEvmWalletConfig extends PrivyWalletConfig {
   /** Optional chain ID to connect to */
   chainId?: string;
-  /** Optional authorization key for the wallet API */
-  authorizationPrivateKey?: string;
-  /** Optional authorization key ID for creating new wallets */
-  authorizationKeyId?: string;
 }
-
-type PrivyWalletExport = {
-  walletId: string;
-  authorizationPrivateKey: string | undefined;
-  chainId: string | undefined;
-};
 
 /**
  * A wallet provider that uses Privy's server wallet API.
@@ -47,7 +32,7 @@ export class PrivyEvmWalletProvider extends ViemWalletProvider {
    */
   private constructor(
     walletClient: WalletClient,
-    config: PrivyEvmWalletConfig & { walletId: string }, // Require walletId in constructor
+    config: PrivyWalletConfig & { walletId: string }, // Require walletId in constructor
   ) {
     super(walletClient);
     this.#walletId = config.walletId; // Now guaranteed to exist
@@ -167,6 +152,7 @@ export class PrivyEvmWalletProvider extends ViemWalletProvider {
       walletId: this.#walletId,
       authorizationPrivateKey: this.#authorizationPrivateKey,
       chainId: this.getNetwork().chainId,
+      networkId: this.getNetwork().networkId,
     };
   }
 }

--- a/typescript/agentkit/src/wallet-providers/privyShared.ts
+++ b/typescript/agentkit/src/wallet-providers/privyShared.ts
@@ -1,0 +1,92 @@
+import { PrivyClient, Wallet } from "@privy-io/server-auth";
+
+/**
+ * Configuration options for the Privy wallet provider.
+ *
+ * @interface
+ */
+export interface PrivyWalletConfig {
+  /** The Privy application ID */
+  appId: string;
+  /** The Privy application secret */
+  appSecret: string;
+  /** The ID of the wallet to use, if not provided a new wallet will be created */
+  walletId?: string;
+  /** Optional authorization key for the wallet API */
+  authorizationPrivateKey?: string;
+  /** Optional authorization key ID for creating new wallets */
+  authorizationKeyId?: string;
+  /** The chain type to create the wallet on */
+  chainType?: "ethereum" | "solana";
+}
+
+export type PrivyWalletExport = {
+  walletId: string;
+  authorizationPrivateKey: string | undefined;
+  chainId: string | undefined;
+  networkId: string | undefined;
+};
+
+type CreatePrivyWalletReturnType = {
+  wallet: Wallet & { id: string };
+  privy: PrivyClient;
+};
+
+/**
+ * Create a Privy wallet
+ *
+ * @param config - The configuration options for the Privy wallet
+ * @returns The created Privy wallet
+ */
+export async function createPrivyWallet(
+  config: PrivyWalletConfig,
+): Promise<CreatePrivyWalletReturnType> {
+  const privy = new PrivyClient(config.appId, config.appSecret, {
+    walletApi: config.authorizationPrivateKey
+      ? {
+          authorizationPrivateKey: config.authorizationPrivateKey,
+        }
+      : undefined,
+  });
+
+  if (config.walletId) {
+    const wallet = await privy.walletApi.getWallet({ id: config.walletId });
+    if (!wallet) {
+      throw new Error(`Wallet with ID ${config.walletId} not found`);
+    }
+    return { wallet, privy };
+  }
+
+  if (config.authorizationPrivateKey && !config.authorizationKeyId) {
+    throw new Error(
+      "authorizationKeyId is required when creating a new wallet with an authorization key, this can be found in your Privy Dashboard",
+    );
+  }
+
+  if (config.authorizationKeyId && !config.authorizationPrivateKey) {
+    throw new Error(
+      "authorizationPrivateKey is required when creating a new wallet with an authorizationKeyId. " +
+        "If you don't have it, you can create a new one in your Privy Dashboard, or delete the authorization key.",
+    );
+  }
+
+  try {
+    const wallet = await privy.walletApi.create({
+      chainType: config.chainType,
+      authorizationKeyIds: config.authorizationKeyId ? [config.authorizationKeyId] : undefined,
+    });
+    return { wallet, privy };
+  } catch (error) {
+    console.error(error);
+    if (
+      error instanceof Error &&
+      error.message.includes("Missing `privy-authorization-signature` header")
+    ) {
+      // Providing a more informative error message, see context: https://github.com/coinbase/agentkit/pull/242#discussion_r1956428617
+      throw new Error(
+        "Privy error: you have an authorization key on your account which can create and modify wallets, please delete this key or pass it to the PrivyWalletProvider to create a new wallet",
+      );
+    }
+    throw new Error("Failed to create wallet");
+  }
+}


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other
<!-- please specify -->

### Why was this change implemented?
This PR extracts Privy initialization code so that it can be used in `PrivyEvmWalletProvider` as well as the soon to be added `PrivySolanaWalletProvider`.

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests
Tested by running the existing privy chatbot example and verifying via the wallet details action:
```
Prompt: print wallet details

-------------------
Wallet Details:
- Provider: privy_evm_wallet_provider
- Address: 0x7a4b9B89C24c0acf3c4Ef5636755DBa908DB3bC2
- Network:
  * Protocol Family: evm
  * Network ID: base-sepolia
  * Chain ID: 84532
- Native Balance: 0 WEI
-------------------
Here are the wallet details:

- **Provider**: privy_evm_wallet_provider
- **Address**: 0x7a4b9B89C24c0acf3c4Ef5636755DBa908DB3bC2
- **Network**:
  - Protocol Family: EVM
  - Network ID: base-sepolia
  - Chain ID: 84532
- **Native Balance**: 0 WEI
```
