### PR TITLE
fix: move CDP_API_KEY_PRIVATE_KEY parsing into CDP classes

### DIFF
--- a/typescript/agentkit/CHANGELOG.md
+++ b/typescript/agentkit/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add support for fauceting SOL on `solana-devnet`.
 
 ### Fixed
-- Fixed `CDP_API_KEY_PRIVATE_KEY` by moving parsing into CDB classes.
+- Fixed handling of `CDP_API_KEY_PRIVATE_KEY` by moving parsing into CDP classes.
 
 ## [0.2.1] - 2025-02-18
 

--- a/typescript/agentkit/CHANGELOG.md
+++ b/typescript/agentkit/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Added `get_balance` to `splActionProvider` to fetch balance of an SPL token.
 - Added support for Privy Server Wallets on Solana. See [here](https://github.com/coinbase/agentkit/blob/main/typescript/agentkit/README.md#privywalletprovider-solana) for more details.
 
+### Fixed
+- Fixed `CDP_API_KEY_PRIVATE_KEY` by moving parsing into CDB classes.
+
 ## [0.2.0] - 2025-02-15
 
 ### Added

--- a/typescript/agentkit/CHANGELOG.md
+++ b/typescript/agentkit/CHANGELOG.md
@@ -6,15 +6,15 @@
 
 - Add support for fauceting SOL on `solana-devnet`.
 
+### Fixed
+- Fixed `CDP_API_KEY_PRIVATE_KEY` by moving parsing into CDB classes.
+
 ## [0.2.1] - 2025-02-18
 
 ### Added
 
 - Added `get_balance` to `splActionProvider` to fetch balance of an SPL token.
 - Added support for Privy Server Wallets on Solana. See [here](https://github.com/coinbase/agentkit/blob/main/typescript/agentkit/README.md#privywalletprovider-solana) for more details.
-
-### Fixed
-- Fixed `CDP_API_KEY_PRIVATE_KEY` by moving parsing into CDB classes.
 
 ## [0.2.0] - 2025-02-15
 

--- a/typescript/agentkit/src/action-providers/cdp/cdpApiActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpApiActionProvider.ts
@@ -24,7 +24,7 @@ export class CdpApiActionProvider extends ActionProvider<WalletProvider> {
     if (config.apiKeyName && config.apiKeyPrivateKey) {
       Coinbase.configure({
         apiKeyName: config.apiKeyName,
-        privateKey: config.apiKeyPrivateKey,
+        privateKey: config.apiKeyPrivateKey?.replace(/\\n/g, "\n"),
         source: "agentkit",
         sourceVersion: version,
       });

--- a/typescript/agentkit/src/action-providers/cdp/cdpWalletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpWalletActionProvider.ts
@@ -24,7 +24,10 @@ export class CdpWalletActionProvider extends ActionProvider<CdpWalletProvider> {
     super("cdp_wallet", []);
 
     if (config.apiKeyName && config.apiKeyPrivateKey) {
-      Coinbase.configure({ apiKeyName: config.apiKeyName, privateKey: config.apiKeyPrivateKey });
+      Coinbase.configure({
+        apiKeyName: config.apiKeyName,
+        privateKey: config.apiKeyPrivateKey?.replace(/\\n/g, "\n"),
+      });
     } else {
       Coinbase.configureFromJson();
     }

--- a/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
@@ -142,7 +142,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
     if (config.apiKeyName && config.apiKeyPrivateKey) {
       Coinbase.configure({
         apiKeyName: config.apiKeyName,
-        privateKey: config.apiKeyPrivateKey,
+        privateKey: config.apiKeyPrivateKey?.replace(/\\n/g, "\n"),
         source: "agentkit",
         sourceVersion: version,
       });

--- a/typescript/examples/langchain-cdp-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-cdp-chatbot/chatbot.ts
@@ -7,7 +7,7 @@ import {
   cdpApiActionProvider,
   cdpWalletActionProvider,
   pythActionProvider,
-} from "../../agentkit";
+} from "@coinbase/agentkit";
 import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { HumanMessage } from "@langchain/core/messages";
 import { MemorySaver } from "@langchain/langgraph";

--- a/typescript/examples/langchain-cdp-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-cdp-chatbot/chatbot.ts
@@ -7,7 +7,7 @@ import {
   cdpApiActionProvider,
   cdpWalletActionProvider,
   pythActionProvider,
-} from "@coinbase/agentkit";
+} from "../../agentkit";
 import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { HumanMessage } from "@langchain/core/messages";
 import { MemorySaver } from "@langchain/langgraph";
@@ -84,7 +84,7 @@ async function initializeAgent() {
     // Configure CDP Wallet Provider
     const config = {
       apiKeyName: process.env.CDP_API_KEY_NAME,
-      apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+      apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
       cdpWalletData: walletDataStr || undefined,
       networkId: process.env.NETWORK_ID || "base-sepolia",
     };
@@ -101,11 +101,11 @@ async function initializeAgent() {
         erc20ActionProvider(),
         cdpApiActionProvider({
           apiKeyName: process.env.CDP_API_KEY_NAME,
-          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),
         cdpWalletActionProvider({
           apiKeyName: process.env.CDP_API_KEY_NAME,
-          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),
       ],
     });

--- a/typescript/examples/langchain-farcaster-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-farcaster-chatbot/chatbot.ts
@@ -31,7 +31,7 @@ async function initialize() {
 
   const agentkit = await AgentKit.from({
     cdpApiKeyName: process.env.CDP_API_KEY_NAME,
-    cdpApiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+    cdpApiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
     actionProviders: [farcasterActionProvider()],
   });
 

--- a/typescript/examples/langchain-twitter-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-twitter-chatbot/chatbot.ts
@@ -31,7 +31,7 @@ async function initialize() {
 
   const agentkit = await AgentKit.from({
     cdpApiKeyName: process.env.CDP_API_KEY_NAME,
-    cdpApiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+    cdpApiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
     actionProviders: [twitterActionProvider()],
   });
 


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other
CDP_API_KEY_PRIVATE_KEY new-line parsing was being done in the chatbots, rather than in the CDP classes themselves. This meant new chatbot examples did not inherently work with CDP tooling unless you were aware of this quirk.

### Why was this change implemented?
To create a better devx

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [x] Other
All that use CDP tools

### Wallet support
- [x] CDP Wallet
- [ ] EVM Wallet
- [ ] Other


### Checklist
- [ ] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [x] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests

1. Removed parsing in chatbots, consistently received the error as expected
2. Moved parsing into CDP classes, built, pointed chat bots to import from agents and ran. No errors, worked perfectly

### Notes to reviewers
