### PR TITLE
fix: get_balance error handling invalid mintAddress

### DIFF
--- a/typescript/agentkit/src/action-providers/spl/splActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/spl/splActionProvider.ts
@@ -56,10 +56,9 @@ export class SplActionProvider extends ActionProvider<SvmWalletProvider> {
       const { getMint, getAssociatedTokenAddress, getAccount, TokenAccountNotFoundError } =
         await import("@solana/spl-token");
 
-      const mintInfo = await getMint(connection, mintPubkey);
-      const ata = await getAssociatedTokenAddress(mintPubkey, ownerPubkey);
-
       try {
+        const mintInfo = await getMint(connection, mintPubkey);
+        const ata = await getAssociatedTokenAddress(mintPubkey, ownerPubkey);
         const account = await getAccount(connection, ata);
         const balance = Number(account.amount) / Math.pow(10, mintInfo.decimals);
 


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other

There are two cases where `TokenAccountNotFoundError` gets thrown. One if the associated token address is invalid/not instantiated (which was already handled). The other is on getting the mintInfo for a invalid mintAddress.

This ensures the same code that handles the first case, also handles the second.

### Why was this change implemented?


### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [ ] Other

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [ ] Other

### Checklist
- [ ] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [ ] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests

Tested it by asking it "Get me my USDC balance?". It can't get a mintAddress out of a symbol, and will feed that symbol as the mintAddress, which then fails and throws the `TokenAccountNotFoundError` we are catching.

### Notes to reviewers
