### PR TITLE
docs: clarify Privy authorization key management

### DIFF
--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -588,7 +588,7 @@ const walletProvider = await PrivyWalletProvider.configureWithWallet(config);
 
 Privy offers the option to use authorization keys to secure your server wallets.
 
-You can manage authorization keys from your [Privy dashboard](https://dashboard.privy.io/account) or programmatically [using the API](https://docs.privy.io/guide/server-wallets/authorization/signatures).
+You can manage authorization keys from your [Privy dashboard](https://dashboard.privy.io/account).
 
 When using authorization keys, you must provide the `authorizationPrivateKey` and `authorizationKeyId` parameters to the `configureWithWallet` method if you are creating a new wallet. Please note that when creating a key, if you enable "Create and modify wallets", you will be required to use that key when creating new wallets via the PrivyWalletProvider.
 

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -701,7 +701,7 @@ const walletProvider = await PrivyWalletProvider.configureWithWallet(config);
 
 Privy offers the option to use authorization keys to secure your server wallets.
 
-You can manage authorization keys from your [Privy dashboard](https://dashboard.privy.io/account) or programmatically [using the API](https://docs.privy.io/guide/server-wallets/authorization/signatures).
+You can manage authorization keys from your [Privy dashboard](https://dashboard.privy.io/account).
 
 When using authorization keys, you must provide the `authorizationPrivateKey` and `authorizationKeyId` parameters to the `configureWithWallet` method if you are creating a new wallet. Please note that when creating a key, if you enable "Create and modify wallets", you will be required to use that key when creating new wallets via the PrivyWalletProvider.
 


### PR DESCRIPTION
### What changed?
- [x] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other
<!-- please specify -->

### Why was this change implemented?
Privy does not support API management of authorization keys yet, just through the dashboard.

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [ ] Other
<!-- please specify -->

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [ ] Other
<!-- please specify -->

### Checklist
- [ ] Changelog updated
- [ ] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [ ] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [ ] Agent tested
- [ ] Unit tests
<!-- please include the agent LLM -->
<!-- please include the agent prompt -->
<!-- please include the agent output -->

### Notes to reviewers
