### PR TITLE
fix: properly filter network-specific actions

### DIFF
--- a/typescript/agentkit/src/action-providers/alchemy/alchemyTokenPricesActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/alchemy/alchemyTokenPricesActionProvider.ts
@@ -161,9 +161,9 @@ A failure response will return an error message with details.
    *
    * @returns Always returns true.
    */
-  supportsNetwork(): boolean {
+  supportsNetwork = (): boolean => {
     return true;
-  }
+  };
 }
 
 /**

--- a/typescript/agentkit/src/action-providers/cdp/cdpWalletActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpWalletActionProvider.test.ts
@@ -317,4 +317,14 @@ describe("CDP Wallet Action Provider", () => {
       expect(result).toBe(`Error trading assets: ${error}`);
     });
   });
+
+  describe("supportsNetwork", () => {
+    it("should return true when protocolFamily is evm", () => {
+      expect(actionProvider.supportsNetwork({ protocolFamily: "evm" })).toBe(true);
+    });
+
+    it("should return false when protocolFamily is not evm", () => {
+      expect(actionProvider.supportsNetwork({ protocolFamily: "solana" })).toBe(false);
+    });
+  });
 });

--- a/typescript/agentkit/src/action-providers/cdp/cdpWalletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpWalletActionProvider.ts
@@ -207,10 +207,10 @@ Important notes:
   /**
    * Checks if the Cdp action provider supports the given network.
    *
-   * @param _ - The network to check.
+   * @param network - The network to check.
    * @returns True if the Cdp action provider supports the network, false otherwise.
    */
-  supportsNetwork = (_: Network) => true;
+  supportsNetwork = (network: Network) => network.protocolFamily === "evm";
 }
 
 export const cdpWalletActionProvider = (config: CdpProviderConfig = {}) =>

--- a/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
@@ -144,4 +144,14 @@ describe("Transfer Action", () => {
     });
     expect(response).toContain(`Error transferring the asset: ${error}`);
   });
+
+  describe("supportsNetwork", () => {
+    it("should return true when protocolFamily is evm", () => {
+      expect(actionProvider.supportsNetwork({ protocolFamily: "evm" })).toBe(true);
+    });
+
+    it("should return false when protocolFamily is not evm", () => {
+      expect(actionProvider.supportsNetwork({ protocolFamily: "solana" })).toBe(false);
+    });
+  });
 });

--- a/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.ts
@@ -100,10 +100,10 @@ Important notes:
   /**
    * Checks if the ERC20 action provider supports the given network.
    *
-   * @param _ - The network to check.
+   * @param network - The network to check.
    * @returns True if the ERC20 action provider supports the network, false otherwise.
    */
-  supportsNetwork = (_: Network) => true;
+  supportsNetwork = (network: Network) => network.protocolFamily === "evm";
 }
 
 export const erc20ActionProvider = () => new ERC20ActionProvider();

--- a/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.test.ts
@@ -173,4 +173,14 @@ describe("Farcaster Action Provider", () => {
       process.env = originalEnv;
     });
   });
+
+  describe("supportsNetwork", () => {
+    it("should return true when protocolFamily is evm", () => {
+      expect(actionProvider.supportsNetwork({ protocolFamily: "evm" })).toBe(true);
+    });
+
+    it("should return false when protocolFamily is not evm", () => {
+      expect(actionProvider.supportsNetwork({ protocolFamily: "solana" })).toBe(false);
+    });
+  });
 });

--- a/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.ts
@@ -145,10 +145,10 @@ A failure response will return a message with the Farcaster API request error:
   /**
    * Checks if the Farcaster action provider supports the given network.
    *
-   * @param _ - The network to check.
+   * @param network - The network to check.
    * @returns True if the Farcaster action provider supports the network, false otherwise.
    */
-  supportsNetwork = (_: Network) => true;
+  supportsNetwork = (network: Network) => network.protocolFamily === "evm";
 }
 
 export const farcasterActionProvider = (config: FarcasterActionProviderConfig = {}) =>

--- a/typescript/agentkit/src/agentkit.ts
+++ b/typescript/agentkit/src/agentkit.ts
@@ -70,10 +70,21 @@ export class AgentKit {
   public getActions(): Action[] {
     const actions: Action[] = [];
 
+    const unsupported: string[] = [];
+
     for (const actionProvider of this.actionProviders) {
       if (actionProvider.supportsNetwork(this.walletProvider.getNetwork())) {
         actions.push(...actionProvider.getActions(this.walletProvider));
+      } else {
+        unsupported.push(actionProvider.name);
       }
+    }
+
+    if (unsupported.length > 0) {
+      console.log(
+        `Warning: The following action providers are not supported on the current network and will be unavailable: ${unsupported.join(", ")}`,
+      );
+      console.log("Current network:", this.walletProvider.getNetwork());
     }
 
     return actions;

--- a/typescript/examples/langchain-privy-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-privy-chatbot/chatbot.ts
@@ -9,6 +9,7 @@ import {
   PrivyEvmWalletProvider,
   PrivySvmWalletProvider,
   cdpApiActionProvider,
+  splActionProvider,
 } from "@coinbase/agentkit";
 import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { HumanMessage } from "@langchain/core/messages";
@@ -133,6 +134,7 @@ async function initializeAgent() {
           apiKeyName: process.env.CDP_API_KEY_NAME as string,
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY as string,
         }),
+        splActionProvider(),
       ],
     });
 


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other

### Why was this change implemented?
A lot of the action providers have a naive filter for network:

```
  supportsNetwork = () => true;
```

This breaks down now that we have support for Solana.

This PR:
* updates all action providers to filter properly.
* adds a warning when using unsupported actions

### Checklist
- [ ] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [x] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [x] Unit tests

Tested with agent by adding these lines to the privy chatbot:
```
    const actions = agentkit.getActions();
    console.log(actions.map(action => action.name));
```

Before:
```
[
  'PythActionProvider_fetch_price_feed',
  'PythActionProvider_fetch_price',
  'WalletActionProvider_get_wallet_details',
  'WalletActionProvider_native_transfer',
  'ERC20ActionProvider_get_balance',
  'ERC20ActionProvider_transfer',
  'CdpApiActionProvider_address_reputation',
  'CdpApiActionProvider_request_faucet_funds',
  'SplActionProvider_get_balance',
  'SplActionProvider_transfer'
]
```

After:
```
[
  'WalletActionProvider_get_wallet_details',
  'WalletActionProvider_native_transfer',
  'CdpApiActionProvider_address_reputation',
  'CdpApiActionProvider_request_faucet_funds',
  'SplActionProvider_get_balance',
  'SplActionProvider_transfer'
]
```

Example of warning:
Setup: Solana Chatbot, importing weth and erc20 action providers:
```
Starting Agent...
Warning: The following action providers are not supported on the current network and will be unavailable: weth, erc20
Current network: {
  protocolFamily: 'svm',
  chainId: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
  networkId: 'solana-mainnet'
}
```