### PR TITLE
chore: add github pr labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,35 @@
+typescript:
+- changed-files:
+  - any-glob-to-any-file: '**/*.ts'
+
+python:
+- changed-files:
+  - any-glob-to-any-file: '**/*.py'
+
+'action provider':
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/action-providers/*'
+    - '**/action_providers/*'
+
+'wallet provider':
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/wallet-providers/*'
+    - '**/wallet_providers/*'
+
+'framework extension':
+- changed-files:
+  - any-glob-to-any-file: '**/framework-extensions/*'
+
+documentation:
+- changed-files:
+  - any-glob-to-any-file: '**/*.md'
+
+example:
+- changed-files:
+  - any-glob-to-any-file: '**/examples/*'
+
+'needs triage':
+- changed-files:
+  - any-glob-to-any-file: '**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        sync-labels: true


### PR DESCRIPTION
Uses: https://github.com/actions/labeler

Adding a `needs triage` label since there is still some manual triage required, specifically to assign priority.