### PR TITLE
chore: fix publish_nightly

### DIFF
--- a/.github/workflows/publish_nightly.yml
+++ b/.github/workflows/publish_nightly.yml
@@ -38,42 +38,55 @@ jobs:
         with:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Install jq
+        run: sudo apt-get install jq
+
+      - name: Install dependencies and build packages
+        run: |
+          npm ci
+          npm run build
       
       - name: Find NPM packages
         id: find-npm-packages
         run: |
-          PACKAGES=$(find . -name "package.json" -not -path "*/node_modules/*" -not -path "./package.json" -exec dirname {} \;)
-          echo "Found NPM packages in directories:"
-          echo "$PACKAGES"
+          PACKAGES=$(find . -name "package.json" \
+            -not -path "*/node_modules/*" \
+            -not -path "./package.json" \
+            -not -path "*/examples/*" \
+            -exec dirname {} \; | tr '\n' ' ')
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
       
-      - name: Update package versions
+      - name: Update NPM package versions
         run: |
-          while IFS= read -r pkg; do
+          for pkg in ${{ steps.find-npm-packages.outputs.packages }}; do
             if [ -f "$pkg/package.json" ]; then
               cd $pkg
               if ! grep -q '"private": true' package.json; then
-                echo "Updating version for $pkg"
-                npm version prerelease --preid=nightly.$(date +%Y%m%d) --no-git-tag-version
+                PKG_NAME=$(node -p "require('./package.json').name")
+                ALL_VERSIONS=$(npm view "$PKG_NAME" versions --all --json 2>/dev/null || echo "[]")
+                LATEST_NIGHTLY=$(echo "$ALL_VERSIONS" | jq -r '.[]' 2>/dev/null | grep -E "nightly\.[0-9]{8}\.[0-9]+$" | sort -V | tail -n1 || echo "")
+                TODAY=$(date +%Y%m%d)
+                if [ -z "$LATEST_NIGHTLY" ]; then
+                  npm version prerelease --preid=nightly.$TODAY --no-git-tag-version
+                else
+                  BUILD_NUM=$(echo $LATEST_NIGHTLY | grep -Eo '[0-9]+$')
+                  NEXT_BUILD=$((BUILD_NUM + 1))
+                  npm version "$(echo $LATEST_NIGHTLY | cut -d'-' -f1)-nightly.$TODAY.$NEXT_BUILD" --no-git-tag-version
+                fi
               fi
               cd - > /dev/null
             fi
-          done <<< "${{ steps.find-npm-packages.outputs.packages }}"
-      
-      - run: npm ci
-      
+          done
+
       - name: Publish packages
         run: |
-          while IFS= read -r pkg; do
-            if [ -f "$pkg/package.json" ]; then
-              cd $pkg
-              if ! grep -q '"private": true' package.json; then
-                echo "Publishing $pkg"
-                npm publish --tag nightly --provenance --access public
-              fi
+          for pkg in ${{ steps.find-npm-packages.outputs.packages }}; do
+            if [ -f "$pkg/package.json" ] && ! grep -q '"private": true' "$pkg/package.json"; then
+              cd $pkg && npm publish --tag nightly --provenance --access public
               cd - > /dev/null
             fi
-          done <<< "${{ steps.find-npm-packages.outputs.packages }}"
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -85,10 +98,12 @@ jobs:
         with:
           ref: nightly
       
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      - name: Install jq
+        run: sudo apt-get install jq
       
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -96,37 +111,56 @@ jobs:
       - name: Find Python packages
         id: find-python-packages
         run: |
-          PACKAGES=$(find . -name "pyproject.toml" -exec dirname {} \;)
-          echo "Found Python packages in directories:"
-          echo "$PACKAGES"
+          PACKAGES=$(find . -name "pyproject.toml" \
+            -not -path "*/examples/*" \
+            -exec dirname {} \; | tr '\n' ' ')
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
       
-      - name: Update package versions
+      - name: Update Python package versions
         run: |
-          while IFS= read -r pkg; do
+          for pkg in ${{ steps.find-python-packages.outputs.packages }}; do
             if [ -f "$pkg/pyproject.toml" ]; then
               cd $pkg
               if ! grep -q "private = true" pyproject.toml; then
-                echo "Updating version for $pkg"
-                poetry version $(poetry version -s).dev$(date +%Y%m%d)
+                PKG_NAME=$(poetry version | cut -d' ' -f1)
+                CURRENT_VERSION=$(poetry version -s)
+                
+                if [[ $CURRENT_VERSION == *".dev"* ]]; then
+                  NEXT_VERSION=$(echo $CURRENT_VERSION | sed -E 's/\.dev[0-9]+$//')
+                else
+                  MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+                  MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+                  PATCH=$(echo $CURRENT_VERSION | cut -d. -f3 | cut -d- -f1 | cut -d+ -f1)
+                  NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+                fi
+                
+                TODAY=$(date +%Y%m%d)
+                ALL_VERSIONS=$(curl -s "https://pypi.org/pypi/$PKG_NAME/json" | jq -r '.releases | keys[]')
+                LATEST_NIGHTLY=$(echo "$ALL_VERSIONS" | grep -E "^${NEXT_VERSION}\.dev${TODAY}[0-9]$" | sort -V | tail -n1 || echo "")
+                
+                if [ -z "$LATEST_NIGHTLY" ]; then
+                  poetry version "${NEXT_VERSION}.dev${TODAY}0"
+                else
+                  BUILD_NUM=$(echo $LATEST_NIGHTLY | sed -E "s/.*\.dev${TODAY}([0-9])$/\1/")
+                  NEXT_BUILD=$((BUILD_NUM + 1))
+                  poetry version "${NEXT_VERSION}.dev${TODAY}${NEXT_BUILD}"
+                fi
               fi
               cd - > /dev/null
             fi
-          done <<< "${{ steps.find-python-packages.outputs.packages }}"
+          done
       
       - name: Build and publish
         run: |
-          while IFS= read -r pkg; do
-            if [ -f "$pkg/pyproject.toml" ]; then
+          for pkg in ${{ steps.find-python-packages.outputs.packages }}; do
+            if [ -f "$pkg/pyproject.toml" ] && ! grep -q "private = true" "$pkg/pyproject.toml"; then
               cd $pkg
-              if ! grep -q "private = true" pyproject.toml; then
-                echo "Publishing $pkg"
-                poetry build
-                poetry publish --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
-              fi
+              poetry install --only main
+              poetry build
+              poetry publish --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}
               cd - > /dev/null
             fi
-          done <<< "${{ steps.find-python-packages.outputs.packages }}" 
+          done
 
   create-github-release:
     needs: [prepare-nightly, publish-npm-nightly, publish-pypi-nightly]
@@ -139,34 +173,55 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: nightly
+ 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
       
       - name: Generate Release Notes
         id: release_notes
         run: |
-          TODAY=$(date +%Y-%m-%d)
-          
-          echo "Generating release notes for nightly build $TODAY"
+          TODAY=$(date +%Y%m%d)
+          TODAY_FORMATTED=$(date +%Y-%m-%d)
+          echo "TODAY=$TODAY" >> $GITHUB_OUTPUT
+          echo "TODAY_FORMATTED=$TODAY_FORMATTED" >> $GITHUB_OUTPUT
           
           {
-            echo "# 🌙 Nightly Build $TODAY"
-            echo ""
-            
             extract_unreleased() {
-              local file=$1
-              local package=$2
+              local file=$1 package=$2 version=$3
               if [ -f "$file" ]; then
-                echo "## 📦 $package"
+                if [[ $package == @* ]]; then
+                  local url="https://www.npmjs.com/package/$package"
+                  [[ $version != "latest" ]] && url="$url/v/$version"
+                else
+                  local url="https://pypi.org/project/$package"
+                  [[ $version != "latest" ]] && url="$url/$version"
+                fi
+                echo "## [📦 $package]($url)"
                 echo ""
-                # Extract everything between "## Unreleased" and the next "##" or end of file
                 awk '/^## Unreleased$/{p=1;next}/^## /{p=0}p' "$file" | grep -v '^$' || echo "No unreleased changes"
                 echo ""
               fi
             }
             
-            extract_unreleased "typescript/agentkit/CHANGELOG.md" "@coinbase/agentkit"
-            extract_unreleased "typescript/framework-extensions/langchain/CHANGELOG.md" "@coinbase/agentkit-langchain"
-            extract_unreleased "python/coinbase-agentkit/CHANGELOG.md" "coinbase-agentkit"
-            extract_unreleased "python/framework-extensions/langchain/CHANGELOG.md" "coinbase-agentkit-langchain"
+            for pkg in $(find . -name "package.json" -not -path "*/node_modules/*" -not -path "./package.json" -not -path "*/examples/*" -exec dirname {} \;); do
+              if [ -f "$pkg/package.json" ] && ! grep -q '"private": true' "$pkg/package.json"; then
+                PKG_NAME=$(node -p "require('$pkg/package.json').name")
+                CHANGELOG="$pkg/CHANGELOG.md"
+                extract_unreleased "$CHANGELOG" "$PKG_NAME" \
+                  $(npm view "$PKG_NAME" versions --json | jq -r '.[]' | grep -E "nightly\.${TODAY}\.[0-9]$" | sort -V | tail -n1 || echo "latest")
+              fi
+            done
+            
+            for pkg in $(find . -name "pyproject.toml" -not -path "*/examples/*" -exec dirname {} \;); do
+              if [ -f "$pkg/pyproject.toml" ] && ! grep -q "private = true" "$pkg/pyproject.toml"; then
+                cd $pkg
+                PKG_NAME=$(poetry version | cut -d' ' -f1)
+                cd - > /dev/null
+                CHANGELOG="$pkg/CHANGELOG.md"
+                extract_unreleased "$CHANGELOG" "$PKG_NAME" \
+                  $(curl -s "https://pypi.org/pypi/$PKG_NAME/json" | jq -r '.releases | keys[]' | grep -E "\.dev${TODAY}[0-9]$" | sort -V | tail -n1 || echo "latest")
+              fi
+            done
             
           } > release_notes.md
           
@@ -179,9 +234,10 @@ jobs:
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TODAY: ${{ steps.release_notes.outputs.TODAY }}
         with:
-          tag_name: nightly-${{ github.sha }}
-          release_name: 🌙 Nightly Build $(date +%Y-%m-%d)
+          tag_name: nightly-${{ env.TODAY }}
+          release_name: "🌙 Nightly Build ${{ steps.release_notes.outputs.TODAY_FORMATTED }}"
           body: ${{ steps.release_notes.outputs.RELEASE_NOTES }}
           draft: false
           prerelease: true

--- a/README.md
+++ b/README.md
@@ -191,13 +191,15 @@ To access the bleeding edge version of AgentKit, you can install the nightly bui
 You can install the latest nightly build with the following command:
 
 ```bash
-npm install @coinbase/agentkit@nightly
+npm install @coinbase/agentkit@nightly @coinbase/agentkit-langchain@nightly
 ```
+
+If you're using an AI framework other than Langchain, make sure to install the corresponding package instead of `@coinbase/agentkit-langchain`.
 
 To install a specific version of the nightly build, you can specify the exact version. For example, if you want to install the nightly build from February 20th, 2025, you can run the following:
 
 ```bash
-npm install @coinbase/agentkit@0.2.3-nightly.20250220.0
+npm install @coinbase/agentkit@0.2.3-nightly.20250220.0 @coinbase/agentkit-langchain@0.2.3-nightly.20250220.0
 ```
 
 ### Python
@@ -205,19 +207,21 @@ npm install @coinbase/agentkit@0.2.3-nightly.20250220.0
 You can install the latest nightly build with the following command:
 
 ```bash
-pip install --pre coinbase-agentkit
+pip install --pre coinbase-agentkit coinbase-agentkit-langchain
 
 # or, using poetry
-poetry add coinbase-agentkit --preview
+poetry add coinbase-agentkit coinbase-agentkit-langchain --allow-prereleases
 ```
+
+If you're using an AI framework other than Langchain, make sure to install the corresponding package instead of `coinbase-agentkit-langchain`.
 
 To install a specific version of the nightly build, you can specify the exact version. For example, if you want to install the nightly build from February 20th, 2025, you can run the following:
 
 ```bash
-pip install coinbase-agentkit==0.1.2.dev20250220
+pip install coinbase-agentkit==0.1.2.dev20250220 coinbase-agentkit-langchain==0.1.1.dev20250220
 
 # or, using poetry
-poetry add coinbase-agentkit==0.1.2.dev20250220
+poetry add coinbase-agentkit==0.1.2.dev20250220 coinbase-agentkit-langchain==0.1.1.dev20250220 --allow-prereleases
 ```
 
 ## 🚨 Security and Bug Reports


### PR DESCRIPTION
### What changed?
Fixing package publishing, improving release notes with hyperlink to published packages
The action has been updated to handle publishing multiple nightly builds in one day. This likely won't come up much in practice, but has been useful at least in developing this action.

This PR also updates to README.md to correct the poetry install command, and to add some additional info.