### PR TITLE
bump: release 0.1.3 hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10522,7 +10522,7 @@
       }
     },
     "typescript/create-onchain-agent": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",

--- a/typescript/create-onchain-agent/package.json
+++ b/typescript/create-onchain-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-onchain-agent",
   "description": "Instantly create onchain-agent applications with Coinbase AgentKit.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "scripts": {
     "build": "npm run clean && npm run build:esm+types",


### PR DESCRIPTION
Hotfix to `typescript/create-onchain-agent` for #448 requires a bump & republishing