### PR TITLE
feat: Publish create-onchain-agent PyPI GHA

### DIFF
--- a/.github/workflows/publish_pypi_create_onchain_agent.yml
+++ b/.github/workflows/publish_pypi_create_onchain_agent.yml
@@ -1,0 +1,44 @@
+name: Release Create Onchain Agent to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-pypi-create-onchain-agent:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./python/create-onchain-agent
+    environment:
+      name: pypi
+      url: https://pypi.org/p/create-onchain-agent
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Install dependencies
+      run: poetry install --only main
+
+    - name: Build package
+      run: poetry build
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages-dir: python/create-onchain-agent/dist/


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [x] Other
<!-- please specify -->

### Why was this change implemented?
<!-- please provide a summary of the changes -->
Adds GHA for publishing `create-onchain-agent` package to PyPI.

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [ ] Other
<!-- please specify -->

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [ ] Other
<!-- please specify -->

### Checklist
- [ ] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [x] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [ ] Agent tested
- [ ] Unit tests
<!-- please include the agent LLM -->
<!-- please include the agent prompt -->
<!-- please include the agent output -->

### Notes to reviewers
