### PR TITLE
fix: cli tool does not bundle template, but must read them

### DIFF
--- a/python/create-onchain-agent/CHANGELOG.md
+++ b/python/create-onchain-agent/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Coinbase AgentKit Changelog
+
+## [0.1.1] - 2025-02-24
+
+## Fixed
+
+- Fixed the CLI's lack of access to the templates directory
+
+## [0.1.0] - 2024-02-23
+
+### Added
+
+- Initial release of the create-onchain-agent CLI tool

--- a/python/create-onchain-agent/create_onchain_agent/cli.py
+++ b/python/create-onchain-agent/create_onchain_agent/cli.py
@@ -4,13 +4,21 @@ import os
 import click
 import questionary
 import re
-import logging
+import zipfile
+import requests
+import shutil
+import platformdirs
 from rich.console import Console
 from copier import run_copy
 from prompt_toolkit.styles import Style  # Import for custom styling
+from pathlib import Path
+
+# GitHub repo and folder path
+GITHUB_ZIP_URL = "https://github.com/coinbase/agentkit/archive/refs/heads/main.zip"
+TEMPLATE_SUBDIR = "agentkit-main/python/create-onchain-agent/templates/chatbot"
+LOCAL_CACHE_DIR = Path(platformdirs.user_cache_dir("create-onchain-agent"))
 
 console = Console()
-TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "../templates/chatbot")
 
 # Define a custom style for Questionary prompts
 custom_style = Style.from_dict({
@@ -46,6 +54,35 @@ CDP_SUPPORTED_NETWORKS = {
 
 VALID_PACKAGE_NAME_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
+def download_and_extract_template():
+    """Downloads and extracts the chatbot template to a persistent location."""
+    LOCAL_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    zip_path = LOCAL_CACHE_DIR / "repo.zip"
+    extract_path = LOCAL_CACHE_DIR / "templates"
+
+    # If the template is already downloaded, return its path
+    if extract_path.exists():
+        return str(extract_path)
+
+    # Download the zip file
+    response = requests.get(GITHUB_ZIP_URL)
+    response.raise_for_status()
+
+    with open(zip_path, "wb") as f:
+        f.write(response.content)
+
+    # Extract the template
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        zip_ref.extractall(LOCAL_CACHE_DIR)
+
+    template_path = LOCAL_CACHE_DIR / TEMPLATE_SUBDIR
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template path {TEMPLATE_SUBDIR} not found in ZIP.")
+
+    # Move extracted template to a stable path
+    shutil.move(str(template_path), str(extract_path))
+
+    return str(extract_path)
 
 @click.command()
 def create_project():
@@ -63,8 +100,8 @@ def create_project():
 
     console.print(f"[blue]{ascii_art}[/blue]")
 
-    # Prompt for project name (default: "onchain-kit")
-    project_name = questionary.text("Enter your project name:", default="onchain-kit", style=custom_style).ask().strip()
+    # Prompt for project name (default: "onchain-agent")
+    project_name = questionary.text("Enter your project name:", default="onchain-agent", style=custom_style).ask().strip()
 
     project_path = os.path.join(os.getcwd(), project_name)
 
@@ -121,9 +158,11 @@ def create_project():
 
     console.print(f"\n[blue]Creating your onchain agent project: {project_name}[/blue]")
 
+    templatePath = download_and_extract_template()
+
     # Run Copier with collected answers
     run_copy(
-        TEMPLATE_PATH,
+        templatePath,
         project_path,
         data={
             "_project_name": project_name,

--- a/python/create-onchain-agent/create_onchain_agent/cli.py
+++ b/python/create-onchain-agent/create_onchain_agent/cli.py
@@ -158,11 +158,11 @@ def create_project():
 
     console.print(f"\n[blue]Creating your onchain agent project: {project_name}[/blue]")
 
-    templatePath = download_and_extract_template()
+    template_path = download_and_extract_template()
 
     # Run Copier with collected answers
     run_copy(
-        templatePath,
+        template_path,
         project_path,
         data={
             "_project_name": project_name,

--- a/python/create-onchain-agent/pyproject.toml
+++ b/python/create-onchain-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "create-onchain-agent"
-version = "0.1.0"
+version = "0.1.1"
 description = "CLI to create an onchain agent project"
 authors = [
     {name = "Carson Roscoe",email = "carsonroscoe7@gmail.com"}

--- a/python/create-onchain-agent/templates/chatbot/chatbot.py.jinja
+++ b/python/create-onchain-agent/templates/chatbot/chatbot.py.jinja
@@ -13,7 +13,6 @@ from langgraph.prebuilt import create_react_agent
 from coinbase_agentkit import (
     AgentKit,
     AgentKitConfig,
-
     {% if _wallet_provider == "cdp" %}
     CdpWalletProvider,
     CdpWalletProviderConfig,
@@ -22,7 +21,6 @@ from coinbase_agentkit import (
     EthAccountWalletProvider,
     EthAccountWalletProviderConfig,
     {% endif %}
-
     cdp_wallet_action_provider,
     erc20_action_provider,
     pyth_action_provider,


### PR DESCRIPTION
### What changed?
- [x] Bug fix

The `pipx run create-onchain-template` fails because the `TEMPLATE_DIR` the CLI was reading from is not bundled with the cli.

Temp fix is to read from github main directly. Fast follow with either:
1. Sticking to Github, start tagging releases better, and whenever we bump the CLI, we update the github tag we pull from to the one we're about to release.
2. Find a way to include the template in the cli build directly

### Why was this change implemented?
CLI is not building, EthDenver starts today.

### Checklist
- [ ] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [x] Rebased against main
- [ ] Relevant exports added

### How has it been tested?
- [ ] Agent tested
- [ ] Unit tests

Manually tested via deleting the local template directory to ensure it isn't reading that, and then running:
```
poetry install
poetry build
poetry run create-onchain-agent
```

### Notes to reviewers

I want to discuss a better way to do this in a fast-follow. There is two flaws with this approach.
1. The CLI slows down slightly, since we're adding a download->extract->move folder to cache step during the CLI. It's faster than I expected, but still a consideration as the project/repo get bigger.
2. We risk the version of the CLI and the Template getting out of sync, if people are running a older CLI version and pulling newer templates.