### PR TITLE
fix: improve error handling invalid python version

### DIFF
--- a/python/create-onchain-agent/CHANGELOG.md
+++ b/python/create-onchain-agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Coinbase AgentKit Changelog
 
+## [0.1.3] - 2025-02-24
+
+## Added
+
+- Added guard to CLI to ensure it is only called with supported Python versions
+
 ## [0.1.2] - 2025-02-24
 
 ## Fixed

--- a/python/create-onchain-agent/README.md
+++ b/python/create-onchain-agent/README.md
@@ -4,6 +4,12 @@
 
 `create-onchain-agent` is a CLI tool powered by [AgentKit](https://github.com/coinbase/agentkit) that allows developers to quickly scaffold an **onchain agent** project. This tool simplifies the setup process by generating a chatbot with predefined configurations, including blockchain network selection and wallet providers.
 
+## Requirements
+
+To use `create-onchain-agent`, you must first:
+- **Python**: Install Python version 3.10 or 3.11
+- **Pipx**: Install pipx using Python version 3.10 or 3.11
+
 ## Usage
 
 To use `create-onchain-agent`, simply run:

--- a/python/create-onchain-agent/README.md
+++ b/python/create-onchain-agent/README.md
@@ -7,8 +7,16 @@
 ## Requirements
 
 To use `create-onchain-agent`, you must first setup:
-- **Python**: Install Python version 3.10 or 3.11
-- **Pipx**: Install pipx using Python version 3.10 or 3.11
+- **Python**: [Install Python](https://realpython.com/installing-python/) version 3.10 or 3.11
+- **Pipx**: [Install pipx](https://pipx.pypa.io/stable/installation/) using Python version 3.10 or 3.11
+
+**NOTE:** If you have multiple versions of Python installed, you can specify the Python version when installing pipx.
+
+e.g.:
+```sh
+python3.10 -m pip install --user pipx
+python3.10 -m pipx ensurepath
+```
 
 ## Usage
 

--- a/python/create-onchain-agent/README.md
+++ b/python/create-onchain-agent/README.md
@@ -6,7 +6,7 @@
 
 ## Requirements
 
-To use `create-onchain-agent`, you must first:
+To use `create-onchain-agent`, you must first setup:
 - **Python**: Install Python version 3.10 or 3.11
 - **Pipx**: Install pipx using Python version 3.10 or 3.11
 

--- a/python/create-onchain-agent/create_onchain_agent/cli.py
+++ b/python/create-onchain-agent/create_onchain_agent/cli.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
 
+import sys
+
+# Enforce Python version 3.10 or 3.11
+REQUIRED_MAJOR = 3
+ALLOWED_MINORS = {10, 11, 12}  # Only allow 3.10 and 3.11
+
+if sys.version_info.major != REQUIRED_MAJOR or sys.version_info.minor not in ALLOWED_MINORS:
+    print(f"Unsupported Python version: {sys.version}. Please use Python 3.10 or 3.11.")
+    sys.exit(1)
+
 import os
 import click
 import questionary

--- a/python/create-onchain-agent/create_onchain_agent/cli.py
+++ b/python/create-onchain-agent/create_onchain_agent/cli.py
@@ -4,7 +4,7 @@ import sys
 
 # Enforce Python version 3.10 or 3.11
 REQUIRED_MAJOR = 3
-ALLOWED_MINORS = {10, 11, 12}  # Only allow 3.10 and 3.11
+ALLOWED_MINORS = {10, 11}  # Only allow 3.10 and 3.11
 
 if sys.version_info.major != REQUIRED_MAJOR or sys.version_info.minor not in ALLOWED_MINORS:
     print(f"Unsupported Python version: {sys.version}. Please use Python 3.10 or 3.11.")

--- a/python/create-onchain-agent/pyproject.toml
+++ b/python/create-onchain-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "create-onchain-agent"
-version = "0.1.2"
+version = "0.1.3"
 description = "CLI to create an onchain agent project"
 authors = [
     {name = "Carson Roscoe",email = "carsonroscoe7@gmail.com"}


### PR DESCRIPTION
The `pipx run create-onchain-agent` works, as long as your `pipx` is running `python` version `3.10` or `3.11`.

You can verify via `pipx run --verbose create-onchain-agent` what your installation is. 

This PR ensures that, when the CLI is called, version `3.10` or `3.11` are calling it. Otherwise, it exits early with a informative response.

The reason for this restriction is:
> Starting with Python 3.12+, Python enforces a new "externally managed environment" restriction. This prevents tools like pipx from properly resolving and installing dependencies in certain system-managed environments.