### PR TITLE
feat: added gha for npm create-onchain-agent

### DIFF
--- a/.github/workflows/publish_npm_create_onchain_agent.yml
+++ b/.github/workflows/publish_npm_create_onchain_agent.yml
@@ -1,0 +1,26 @@
+name: Release AgentKit to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-npm-create-onchain-agent:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - name: Install, build and publish @coinbase/agentkit
+        working-directory: ./typescript/create-onchain-agent
+        run: |
+          npm ci
+          npm run build
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_npm_create_onchain_agent.yml
+++ b/.github/workflows/publish_npm_create_onchain_agent.yml
@@ -1,4 +1,4 @@
-name: Release AgentKit to NPM
+name: Release Create Onchain Agent to NPM
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish_npm_create_onchain_agent.yml
+++ b/.github/workflows/publish_npm_create_onchain_agent.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
-      - name: Install, build and publish @coinbase/agentkit
+      - name: Install, build and publish create-onchain-agent
         working-directory: ./typescript/create-onchain-agent
         run: |
           npm ci

--- a/.github/workflows/publish_npm_create_onchain_agent.yml
+++ b/.github/workflows/publish_npm_create_onchain_agent.yml
@@ -23,4 +23,4 @@ jobs:
           npm run build
           npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_CREATE_ONCHAIN_AGENT }}

--- a/.github/workflows/publish_npm_create_onchain_agent.yml
+++ b/.github/workflows/publish_npm_create_onchain_agent.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
-      - run: npm ci
       - name: Install, build and publish @coinbase/agentkit
         working-directory: ./typescript/create-onchain-agent
         run: |

--- a/.github/workflows/publish_npm_create_onchain_agent.yml
+++ b/.github/workflows/publish_npm_create_onchain_agent.yml
@@ -22,4 +22,4 @@ jobs:
           npm run build
           npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_CREATE_ONCHAIN_AGENT }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What changed?

New Github Action

### Why was this change implemented?

The new npm module `create-onchain-agent` lacks a github action for CI/CD releases.