### PR TITLE
fix(python/erc20-get-balance-action): Converting contract address to checksum to avoid errors

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/erc20_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/erc20_action_provider.py
@@ -41,7 +41,7 @@ class ERC20ActionProvider(ActionProvider[EvmWalletProvider]):
             validated_args = GetBalanceSchema(**args)
 
             balance = wallet_provider.read_contract(
-                contract_address=validated_args.contract_address,
+                contract_address=Web3.to_checksum_address(validated_args.contract_address),
                 abi=ERC20_ABI,
                 function_name="balanceOf",
                 args=[wallet_provider.get_address()],


### PR DESCRIPTION
Sometimes the address given by explorers/wallets isn't in the right format, if copied from a URL for example.

This leads to the action giving the following response when called:
```
Error getting balance: ('web3.py only accepts checksum addresses. The software that gave you this non-checksum address should be considered unsafe, please file it as a bug on their platform. Try using an ENS name instead. Or, if you must accept lower safety, use Web3.to_checksum_address(lower_case_address).', '0xc0fbc4967259786c743361a5885ef49380473dcf')
```

In the case of a Base mainnet contract here.
This can easily be fixed by (as explained by the error message) wrapping the address with `Web3.to_checksum_address()`

### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other
<!-- please specify -->

### Why was this change implemented?
Issue encountered during ETH Denver

### Network support
- [x] All EVM
- [ ] Base
- [ ] Base Sepolia
- [ ] Other
<!-- please specify -->

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [ ] Other
<!-- please specify -->

### Checklist
- [ ] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [ ] Readme updates
- [ ] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [ ] Unit tests

LLM: Nous Hermes 3 Pro
Prompt: `What's your balance of the token 0xc0fbc4967259786c743361a5885ef49380473dcf ?`
Agent output before:
```
The address you provided for the token is not in checksum format. I recommend using an ENS name or converting the address to checksum format using Web3.to_checksum_address() to ensure safety. Could you please provide the address again in the correct format?
```
Agent output after:
```
The balance of the token 0xc0fbc4967259786c743361a5885ef49380473dcf in your wallet is 0.
```

### Notes to reviewers
