### PR TITLE
chore: fix package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10523,7 +10523,7 @@
     },
     "typescript/create-onchain-agent": {
       "version": "0.1.3",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "cac": "^6.7.14",
         "cross-spawn": "^7.0.3",

--- a/typescript/create-onchain-agent/package.json
+++ b/typescript/create-onchain-agent/package.json
@@ -1,8 +1,10 @@
 {
   "name": "create-onchain-agent",
   "description": "Instantly create onchain-agent applications with Coinbase AgentKit.",
+  "repository": "https://github.com/coinbase/agentkit",
   "version": "0.1.3",
-  "license": "MIT",
+  "author": "Coinbase Inc.",
+  "license": "Apache-2.0",
   "scripts": {
     "build": "npm run clean && npm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types",


### PR DESCRIPTION
### What changed?

Added repository to `create-onchain-agent`'s package.json to reflect back on this github repository. This check is needed for provenance.

Also updated the author and licence of package.json to reflect this repo's defaults.

### Why was this change implemented?

Github action threw this error:
```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/create-onchain-agent - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/coinbase/agentkit" from provenance
```
