### PR TITLE
chore: added changelog to create-onchain-agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10522,7 +10522,7 @@
       }
     },
     "typescript/create-onchain-agent": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "cac": "^6.7.14",

--- a/typescript/create-onchain-agent/CHANGELOG.md
+++ b/typescript/create-onchain-agent/CHANGELOG.md
@@ -1,22 +1,28 @@
 # Coinbase Create Onchain Agent Changelog
 
-## [0.1.3] - 2025-02-24
+## [0.1.4] - 2025-02-24
 
 ## Added
 
-- Added guard to CLI to ensure it is only called with supported Python versions
+- Added CHANGELOG.md
 
-## [0.1.2] - 2025-02-24
+## [0.1.3] - 2025-02-21
 
 ## Fixed
 
 - Fixed the CLI's missing dependencies
 
+## [0.1.2] - 2025-02-24
+
+## Fixed
+
+- Fixed template generation
+
 ## [0.1.1] - 2025-02-24
 
 ## Fixed
 
-- Fixed the CLI's lack of access to the templates directory
+- Fixed package scope
 
 ## [0.1.0] - 2024-02-23
 

--- a/typescript/create-onchain-agent/package.json
+++ b/typescript/create-onchain-agent/package.json
@@ -2,7 +2,7 @@
   "name": "create-onchain-agent",
   "description": "Instantly create onchain-agent applications with Coinbase AgentKit.",
   "repository": "https://github.com/coinbase/agentkit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "Coinbase Inc.",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
### What changed?

Added changelog to `typescript/create-onchain-agent`

### Why was this change implemented?
The changelog is important, and it was missing.
It was also added to test out the github action, as this will bump us to version 0.1.4