### PR TITLE
fix(docs/python): Fix wrong Network import

### DIFF
--- a/python/coinbase-agentkit/README.md
+++ b/python/coinbase-agentkit/README.md
@@ -125,7 +125,8 @@ agent = create_react_agent(
 Action providers define the actions that an agent can take. They are created by subclassing the `ActionProvider` abstract class.
 
 ```python
-from coinbase_agentkit import ActionProvider, WalletProvider, Network
+from coinbase_agentkit import ActionProvider, WalletProvider
+from coinbase_agentkit.network import Network
 
 class MyActionProvider(ActionProvider[WalletProvider]):
     def __init__(self):
@@ -152,7 +153,8 @@ class MyActionSchema(BaseModel):
 2. Define the action:
 
 ```python
-from coinbase_agentkit import ActionProvider, WalletProvider, Network, create_action
+from coinbase_agentkit import ActionProvider, WalletProvider, create_action
+from coinbase_agentkit.network import Network
 
 class MyActionProvider(ActionProvider[WalletProvider]):
     def __init__(self):


### PR DESCRIPTION
### What changed?
- [x] Documentation
- [ ] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other

### Why was this change implemented?
Spotted during ETH Denver, the `Network` import wasn't working

### Network support
- [ ] All EVM
- [ ] Base
- [ ] Base Sepolia
- [ ] Other
<!-- please specify -->

### Wallet support
- [ ] CDP Wallet
- [ ] EVM Wallet
- [ ] Other
<!-- please specify -->

### Checklist
- [ ] Changelog updated
- [ ] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [x] Readme updates
- [ ] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [ ] Agent tested
- [ ] Unit tests
<!-- please include the agent LLM -->
<!-- please include the agent prompt -->
<!-- please include the agent output -->

### Notes to reviewers
