### PR TITLE
fix: format erc20 balance

### DIFF
--- a/python/coinbase-agentkit/CHANGELOG.md
+++ b/python/coinbase-agentkit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed erc20 `get_balance` action to format erc20 balance with correct number of decimals.
+
 ## [0.1.3] - 2025-02-21
 
 - Fixed Morpho `deposit` and `withdraw` function headers to conform to the Action Provider Paradigm.

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/README.md
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/README.md
@@ -1,0 +1,42 @@
+# ERC20 Action Provider
+
+This directory contains the **ERC20ActionProvider** implementation, which provides actions to interact with **ERC20 tokens** on EVM-compatible networks.
+
+## Directory Structure
+
+```
+erc20/
+├── erc20_action_provider.py      # Main provider with ERC20 token functionality
+├── constants.py                  # Constants including ERC20 ABI
+├── schemas.py                    # Pydantic schemas for action inputs
+├── validators.py                 # Input validation utilities
+├── __init__.py                   # Package exports
+└── README.md                     # This file
+```
+
+## Actions
+
+### ERC20 Token Actions
+
+- `get_balance`: Get the balance of an ERC20 token
+  - Returns the **balance** of the token in the wallet
+  - Formats the balance with the correct number of decimals
+  - Takes a contract address as input
+
+- `transfer`: Transfer ERC20 tokens to another address
+  - Takes amount, contract address, and destination as inputs
+  - Constructs and sends the transfer transaction
+  - Returns the **transaction hash** upon success
+  - Handles decimal formatting automatically
+
+## Adding New Actions
+
+To add new ERC20 actions:
+
+1. Define your action schema in `schemas.py`. See [Defining the input schema](https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#defining-the-input-schema) for more information.
+2. Implement the action in `erc20_action_provider.py`
+3. Implement tests in `tests/action_providers/erc20/test_erc20_action_provider.py`
+
+## Notes
+
+For more information on the **ERC20 token standard**, visit [ERC20 Token Standard](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/).

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/constants.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/constants.py
@@ -37,4 +37,15 @@ ERC20_ABI = [
             },
         ],
     },
+    {
+        "type": "function",
+        "name": "decimals",
+        "stateMutability": "view",
+        "inputs": [],
+        "outputs": [
+            {
+                "type": "uint8",
+            },
+        ],
+    },
 ]

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/erc20_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/erc20_action_provider.py
@@ -47,7 +47,14 @@ class ERC20ActionProvider(ActionProvider[EvmWalletProvider]):
                 args=[wallet_provider.get_address()],
             )
 
-            return f"Balance of {validated_args.contract_address} is {balance}"
+            decimals = wallet_provider.read_contract(
+                contract_address=validated_args.contract_address,
+                abi=ERC20_ABI,
+                function_name="decimals",
+                args=[],
+            )
+
+            return f"Balance of {validated_args.contract_address} is {balance / 10 ** decimals}"
         except Exception as e:
             return f"Error getting balance: {e!s}"
 

--- a/python/coinbase-agentkit/tests/action_providers/erc20/conftest.py
+++ b/python/coinbase-agentkit/tests/action_providers/erc20/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from coinbase_agentkit.wallet_providers.evm_wallet_provider import EvmWalletProvider
 
 MOCK_AMOUNT = "1000000000000000000"
+MOCK_DECIMALS = 6
 MOCK_CONTRACT_ADDRESS = "0x1234567890123456789012345678901234567890"
 MOCK_DESTINATION = "0x9876543210987654321098765432109876543210"
 MOCK_ADDRESS = "0x1234567890123456789012345678901234567890"
@@ -17,5 +18,5 @@ def mock_wallet():
     """Create a mock wallet provider."""
     mock = Mock(spec=EvmWalletProvider)
     mock.get_address.return_value = MOCK_ADDRESS
-    mock.read_contract.return_value = MOCK_AMOUNT
+    mock.read_contract.side_effect = [int(MOCK_AMOUNT), MOCK_DECIMALS]
     return mock

--- a/python/coinbase-agentkit/tests/action_providers/erc20/test_erc20_action_provider.py
+++ b/python/coinbase-agentkit/tests/action_providers/erc20/test_erc20_action_provider.py
@@ -1,5 +1,7 @@
 """Tests for the ERC20 action provider."""
 
+from unittest.mock import call
+
 import pytest
 from web3 import Web3
 
@@ -13,6 +15,7 @@ from coinbase_agentkit.network import Network
 from .conftest import (
     MOCK_AMOUNT,
     MOCK_CONTRACT_ADDRESS,
+    MOCK_DECIMALS,
     MOCK_DESTINATION,
 )
 
@@ -37,13 +40,26 @@ def test_get_balance_success(mock_wallet):
 
     response = provider.get_balance(mock_wallet, args)
 
-    mock_wallet.read_contract.assert_called_once_with(
-        contract_address=MOCK_CONTRACT_ADDRESS,
-        abi=ERC20_ABI,
-        function_name="balanceOf",
-        args=[mock_wallet.get_address()],
+    mock_wallet.read_contract.assert_has_calls(
+        [
+            call(
+                contract_address=MOCK_CONTRACT_ADDRESS,
+                abi=ERC20_ABI,
+                function_name="balanceOf",
+                args=[mock_wallet.get_address()],
+            ),
+            call(
+                contract_address=MOCK_CONTRACT_ADDRESS,
+                abi=ERC20_ABI,
+                function_name="decimals",
+                args=[],
+            ),
+        ]
     )
-    assert f"Balance of {MOCK_CONTRACT_ADDRESS} is {MOCK_AMOUNT}" in response
+    assert (
+        f"Balance of {MOCK_CONTRACT_ADDRESS} is {int(MOCK_AMOUNT) / 10 ** MOCK_DECIMALS}"
+        in response
+    )
 
 
 def test_get_balance_error(mock_wallet):


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other
<!-- please specify -->

### Why was this change implemented?
We were not formatting erc20 balances.

### Checklist
- [x] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
- [ ] Doc strings
- [x] Readme updates
- [x] Rebased against master
- [ ] Relevant exports added

### How has it been tested?
- [x] Agent tested
- [x] Unit tests

Setup: Fauceted 1 USDC.

Before
```
Prompt: print USDC balance (token address: 0x036CbD53842c5426634e7929541eC2318f3dCF7e)

-------------------
Balance of 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1000000
-------------------
The USDC balance for the token address `0x036CbD53842c5426634e7929541eC2318f3dCF7e` is 1,000,000.
-------------------
```

After
```
Prompt: print USDC balance (address is 0x036CbD53842c5426634e7929541eC2318f3dCF7e)

-------------------
Balance of 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1
-------------------
The USDC balance for the address 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1 USDC.
-------------------
```
