### PR TITLE
fix: added .gitignore to chatbot template for cli

### DIFF
--- a/python/create-onchain-agent/changelog.d/+0fcb14d9.bugfix.md
+++ b/python/create-onchain-agent/changelog.d/+0fcb14d9.bugfix.md
@@ -1,0 +1,1 @@
+Fixed missing .gitignore in template

--- a/python/create-onchain-agent/templates/chatbot/.gitignore
+++ b/python/create-onchain-agent/templates/chatbot/.gitignore
@@ -1,0 +1,44 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual Environment
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Poetry
+poetry.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Project specific
+wallet_data.txt
+.env.local 


### PR DESCRIPTION
### What changed?
- [ ] Documentation
- [x] Bug fix
- [ ] New Action
- [ ] New Action Provider
- [ ] Other

When you run `pipx run create-onchain-agent`, the python project it would generate lacked a `.gitignore`.

### Why was this change implemented?

Users should not need to create their own .gitignore.

### Checklist
- [x] Changelog updated
- [x] Commits are signed. See [instructions](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)

### How has it been tested?
Tested manually in two ways.

1. Generated using the public cli command, copy-pasted this .gitignore into it, and install/ran it
2. Use the local cli to generate, confirmed .gitignore appears in the generated project, and install/ran it
