### PR TITLE
fix: parse units in erc20 transfer to handle decimals

### DIFF
--- a/python/coinbase-agentkit/changelog.d/+agent-226.bugfix.md
+++ b/python/coinbase-agentkit/changelog.d/+agent-226.bugfix.md
@@ -1,0 +1,1 @@
+Fixed erc20 transfer to handle decimals correctly

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/schemas.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/schemas.py
@@ -1,8 +1,6 @@
 """Schemas for the ERC20 action provider."""
 
-from pydantic import BaseModel, Field, field_validator
-
-from .validators import wei_amount_validator
+from pydantic import BaseModel, Field
 
 
 class GetBalanceSchema(BaseModel):
@@ -17,12 +15,8 @@ class GetBalanceSchema(BaseModel):
 class TransferSchema(BaseModel):
     """Schema for transferring ERC20 tokens."""
 
-    amount: str = Field(description="The amount of the asset to transfer in wei")
+    amount: str = Field(
+        description="The amount of the asset to transfer, in human-readable format (e.g. 1 USDC, 0.01 WETH)"
+    )
     contract_address: str = Field(description="The contract address of the token to transfer")
     destination: str = Field(description="The destination to transfer the funds")
-
-    @field_validator("amount")
-    @classmethod
-    def validate_wei_amount(cls, v: str) -> str:
-        """Validate wei amount."""
-        return wei_amount_validator(v)

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/utils.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/erc20/utils.py
@@ -1,0 +1,43 @@
+import re
+
+
+# Port of viem's parseUnits:
+# https://github.com/wevm/viem/blob/217586d97146db12f4044738f06260fcc2fff0c3/src/utils/unit/parseUnits.ts
+def parse_units(value: str, decimals: int) -> int:
+    """Multiplies a string representation of a number by a given exponent of base 10 (10exponent)."""
+    if not re.match(r"^(-?)([0-9]*)\.?([0-9]*)$", value):
+        raise ValueError(f"Invalid decimal number: {value}")
+
+    parts = value.split(".")
+    integer = parts[0]
+    fraction = parts[1] if len(parts) > 1 else "0"
+
+    negative = integer.startswith("-")
+    if negative:
+        integer = integer[1:]
+
+    fraction = fraction.rstrip("0")
+
+    if decimals == 0:
+        if fraction and round(float(f"0.{fraction}")) == 1:
+            integer = str(int(integer) + 1)
+        fraction = ""
+    elif len(fraction) > decimals:
+        left = fraction[: decimals - 1]
+        unit = fraction[decimals - 1 : decimals]
+        right = fraction[decimals:]
+
+        rounded = round(float(f"{unit}.{right}"))
+
+        fraction = str(int(left) + 1).zfill(len(left) + 1) if rounded > 9 else f"{left}{rounded}"
+
+        if len(fraction) > decimals:
+            fraction = fraction[1:]
+            integer = str(int(integer) + 1)
+
+        fraction = fraction[:decimals]
+    else:
+        fraction = fraction.ljust(decimals, "0")
+
+    result = f"{'-' if negative else ''}{integer}{fraction}"
+    return int(result)

--- a/typescript/.changeset/hungry-gifts-wonder.md
+++ b/typescript/.changeset/hungry-gifts-wonder.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Fix erc20 transfer to handle decimals correctly

--- a/typescript/agentkit/src/action-providers/erc20/schemas.ts
+++ b/typescript/agentkit/src/action-providers/erc20/schemas.ts
@@ -5,7 +5,11 @@ import { z } from "zod";
  */
 export const TransferSchema = z
   .object({
-    amount: z.custom<bigint>().describe("The amount of the asset to transfer"),
+    amount: z
+      .custom<bigint>()
+      .describe(
+        "The amount of the asset to transfer, in human-readable format (e.g. 1 USDC, 0.01 WETH)",
+      ),
     contractAddress: z.string().describe("The contract address of the token to transfer"),
     destination: z.string().describe("The destination to transfer the funds"),
   })


### PR DESCRIPTION
## Description

Fixes an issue with erc20 transfer action in Python and TypeScript where decimals are not handled correctly.

## Tests

### Python

Setup: CDP Langchain Chatbot, Fauceted ETH and USDC

**Before**
```
Prompt: transfer 0.01 of erc20 token 0x036CbD53842c5426634e7929541eC2318f3dCF7e to 0x462660240048930924d6114608D9F057f704cbbf

-------------------
Error transferring the asset: ('execution reverted: ERC20: transfer amount exceeds balance', '0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002645524332303a207472616e7366657220616d6f756e7420657863656564732062616c616e63650000000000000000000000000000000000000000000000000000')
-------------------
The transfer failed because the amount exceeds the available balance of the ERC20 token in your wallet. Please check your balance and ensure you have enough tokens to perform the transfer. If you need assistance with checking your balance, let me know!
-------------------
```

**After**
```
Prompt: transfer 0.01 of erc20 token 0x036CbD53842c5426634e7929541eC2318f3dCF7e to 0x462660240048930924d6114608D9F057f704cbbf

-------------------
Transferred 0.01 of 0x036CbD53842c5426634e7929541eC2318f3dCF7e to 0x462660240048930924d6114608D9F057f704cbbf.
Transaction hash for the transfer: 0x37325361075ee9c950f7e6a2e3841b80d84b81a83badef88a617c8ab56fc0ce6
-------------------
The transfer of 0.01 of the ERC20 token to the specified address was successful.

Here is the transaction hash: `0x37325361075ee9c950f7e6a2e3841b80d84b81a83badef88a617c8ab56fc0ce6`.
-------------------
```

### TypeScript

Setup: CDP Langchain Chatbot, Fauceted ETH and USDC

**Before**
```
Prompt: transfer 0.01 of erc20 token 0x036CbD53842c5426634e7929541eC2318f3dCF7e to 0x6b7E1E26fEd2cFc18ca8C28e64016f1AF8822470

-------------------
Balance of 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1
-------------------

-------------------
Error transferring the asset: SyntaxError: Cannot convert 0.01 to a BigInt
-------------------
It seems that the transfer amount of "0.01" is not valid as ERC20 transfers require whole integer values for the amount in the smallest unit (wei).

ERC20 tokens typically have 18 decimal places, so you need to specify the amount in the smallest unit. For example, if you want to transfer 0.01 tokens and the token has 18 decimals, you would represent it as `10000000000000000` (which is 0.01 times 10^18).

Since your balance is 1 token, please confirm if you would like to proceed with transferring the entire amount or a different whole number?
-------------------
```

**After**
```
Prompt: transfer 0.01 of erc20 token 0x036CbD53842c5426634e7929541eC2318f3dCF7e to 0x6b7E1E26fEd2cFc18ca8C28e64016f1AF8822470

-------------------
Balance of 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1.01
-------------------

-------------------
Transferred 0.01 of 0x036CbD53842c5426634e7929541eC2318f3dCF7e to 0x6b7E1E26fEd2cFc18ca8C28e64016f1AF8822470.
Transaction hash for the transfer: 0x84e6ab283135a719143910e3f282794fc61fb14ad2ff7d56274008e1dd8d8f61
-------------------
Successfully transferred 0.01 of the ERC20 token to the specified address.

Transaction hash: **0x84e6ab283135a719143910e3f282794fc61fb14ad2ff7d56274008e1dd8d8f61**.
-------------------
```

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added a changelog entry