### PR TITLE
fix: cli wallet persistance

### DIFF
--- a/python/create-onchain-agent/changelog.d/+cdfc1615.feature.md
+++ b/python/create-onchain-agent/changelog.d/+cdfc1615.feature.md
@@ -1,0 +1,1 @@
+Added wallet persistance to all templates

--- a/python/create-onchain-agent/templates/chatbot/.env.local.jinja
+++ b/python/create-onchain-agent/templates/chatbot/.env.local.jinja
@@ -1,17 +1,23 @@
 # Get keys from OpenAI Platform: https://platform.openai.com/api-keys
 # Get keys from CDP Portal: https://portal.cdp.coinbase.com/
 
-# Required
-OPENAI_API_KEY= # Place your OpenAI API key here
+## Required
+# Place your OpenAI API key here
+OPENAI_API_KEY=
 {% if _wallet_provider == "cdp" %}
-CDP_API_KEY_NAME= # Place your CDP API key name here
-CDP_API_KEY_PRIVATE_KEY= # Place your CDP API private key here
+# Place your CDP API key name here
+CDP_API_KEY_NAME=
+# Place your CDP API private key here
+CDP_API_KEY_PRIVATE_KEY=
 {% elif _wallet_provider == "eth" %}
-PRIVATE_KEY= # Place your Ethereum private key here
+# Place your Ethereum private key here
+PRIVATE_KEY=
 {% endif %}
-# Optional
+## Optional
 NETWORK={{ _network }}
 {% if _wallet_provider == "eth" %}
-CDP_API_KEY_NAME= # Place your CDP API key name here if you want to use the CDPApiActionProvider
-CDP_API_KEY_PRIVATE_KEY= # Place your CDP API private key here if you want to use the CDPApiActionProvider
+# Place your CDP API key name here if you want to use the CDPApiActionProvider
+CDP_API_KEY_NAME=
+# Place your CDP API private key here if you want to use the CDPApiActionProvider
+CDP_API_KEY_PRIVATE_KEY=
 {% endif %}

--- a/python/create-onchain-agent/templates/chatbot/chatbot.py.jinja
+++ b/python/create-onchain-agent/templates/chatbot/chatbot.py.jinja
@@ -17,12 +17,12 @@ from coinbase_agentkit import (
     {% if _wallet_provider == "cdp" %}
     CdpWalletProvider,
     CdpWalletProviderConfig,
-    cdp_api_action_provider,
+    cdp_wallet_action_provider,
     {% elif _wallet_provider == "eth" %}
     EthAccountWalletProvider,
     EthAccountWalletProviderConfig,
     {% endif %}
-    cdp_wallet_action_provider,
+    cdp_api_action_provider,
     erc20_action_provider,
     pyth_action_provider,
     wallet_action_provider,
@@ -94,7 +94,7 @@ def initialize_agent():
 
     {% elif _wallet_provider == "eth" %}
     # Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
-    private_key = os.getenv("PRIVATE_KEY")
+        private_key = os.getenv("PRIVATE_KEY")
     
     if not private_key:
         if os.path.exists(wallet_data_file):

--- a/python/create-onchain-agent/templates/chatbot/chatbot.py.jinja
+++ b/python/create-onchain-agent/templates/chatbot/chatbot.py.jinja
@@ -2,6 +2,7 @@ import os
 import sys
 import json
 import time
+import secrets
 
 from dotenv import load_dotenv
 
@@ -67,10 +68,9 @@ Join us in shaping AgentKit! Check out the contribution guide:
 - https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING.md
 - https://discord.gg/CDP
 """
-{% if _wallet_provider == "cdp" %}
-# Configure a file to persist the agent's CDP API Wallet Data.
+# Configure a file to persist wallet data
 wallet_data_file = "wallet_data.txt"
-{% endif %}
+
 load_dotenv()
 
 def initialize_agent():
@@ -78,6 +78,7 @@ def initialize_agent():
 
     # Initialize LLM: https://platform.openai.com/docs/models#gpt-4o
     llm = ChatOpenAI(model="gpt-4o-mini")
+
     {% if _wallet_provider == "cdp" %}
     # Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
     wallet_data = None
@@ -90,16 +91,34 @@ def initialize_agent():
         cdp_config = CdpWalletProviderConfig(wallet_data=wallet_data)
 
     wallet_provider = CdpWalletProvider(cdp_config)
-    {% elif _wallet_provider == "eth" %}
-    # Ensure PRIVATE_KEY is set
-    private_key = os.getenv("PRIVATE_KEY")
-    assert private_key, "You must set the PRIVATE_KEY environment variable"
-    assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"
 
+    {% elif _wallet_provider == "eth" %}
+    # Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
+    private_key = os.getenv("PRIVATE_KEY")
+    
+    if not private_key:
+        if os.path.exists(wallet_data_file):
+            try:
+                with open(wallet_data_file) as f:
+                    wallet_data = json.load(f)
+                    private_key = wallet_data.get("private_key")
+                    print("Found private key in wallet_data.txt")
+            except Exception as e:
+                print(f"Error reading wallet data: {e}")
+        
+        if not private_key:
+            # Generate new private key if none exists
+            private_key = "0x" + secrets.token_hex(32)
+            with open(wallet_data_file, "w") as f:
+                json.dump({"private_key": private_key}, f)
+            print("Created new private key and saved to wallet_data.txt")
+            print("We recommend you save this private key to your .env file and delete wallet_data.txt afterwards.")
+
+    assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"
+    
     # Create Ethereum account from private key
     account = Account.from_key(private_key)
 
-    # Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
     wallet_provider = EthAccountWalletProvider(
         config=EthAccountWalletProviderConfig(
             account=account,
@@ -107,6 +126,7 @@ def initialize_agent():
         )
     )
     {% endif %}
+
     # Initialize AgentKit: https://docs.cdp.coinbase.com/agentkit/docs/agent-actions
     agentkit = AgentKit(AgentKitConfig(
         wallet_provider=wallet_provider,
@@ -121,13 +141,14 @@ def initialize_agent():
             weth_action_provider(),
         ]
     ))
+
     {% if _wallet_provider == "cdp" %}
     # Save wallet to file for reuse
     wallet_data_json = json.dumps(wallet_provider.export_wallet().to_dict())
-
     with open(wallet_data_file, "w") as f:
         f.write(wallet_data_json)
     {% endif %}
+
     # Transform agentkit configuration into langchain tools
     tools = get_langchain_tools(agentkit)
     

--- a/typescript/.changeset/dry-doors-rest.md
+++ b/typescript/.changeset/dry-doors-rest.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": minor
+---
+
+Added wallet persistance to all templates

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
@@ -86,10 +86,7 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
     let privateKey = process.env.PRIVATE_KEY as `0x${string}`;
     if (!privateKey) {
       if (fs.existsSync(WALLET_DATA_FILE)) {
-        const walletData = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8"));
-        if (walletData.privateKey) {
-          privateKey = walletData.privateKey;
-        }
+        privateKey = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8")).privateKey;
         console.info("Found private key in wallet_data.txt");
       }
       else {

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
@@ -88,15 +88,16 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
       if (fs.existsSync(WALLET_DATA_FILE)) {
         privateKey = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8")).privateKey;
         console.info("Found private key in wallet_data.txt");
-      }
-      else {
+      } else {
         privateKey = generatePrivateKey();
         fs.writeFileSync(WALLET_DATA_FILE, JSON.stringify({ privateKey }));
         console.log("Created new private key and saved to wallet_data.txt");
-        console.log("We recommend you save this private key to your .env file and delete wallet_data.txt afterwards.");
+        console.log(
+          "We recommend you save this private key to your .env file and delete wallet_data.txt afterwards.",
+        );
       }
     }
-    
+
     const account = privateKeyToAccount(privateKey);
     const networkId = process.env.NETWORK_ID as string;
     const client = createWalletClient({

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
@@ -97,14 +97,14 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
       }
     }
     
-    const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+    const account = privateKeyToAccount(privateKey);
     const networkId = process.env.NETWORK_ID as string;
     const client = createWalletClient({
       account,
       chain: NETWORK_ID_TO_VIEM_CHAIN[networkId],
       transport: http(),
     });
-    const walletProvider = await new ViemWalletProvider(client);
+    const walletProvider = new ViemWalletProvider(client);
 
     // Initialize AgentKit: https://docs.cdp.coinbase.com/agentkit/docs/agent-actions
     const agentkit = await AgentKit.from({

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
@@ -16,7 +16,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { MemorySaver } from "@langchain/langgraph";
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { AgentRequest, AgentResponse } from "@/app/types/api";
-import { createWalletClient, http } from "viem";
+import { createWalletClient, Hex, http } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import fs from "fs";
 
@@ -83,7 +83,7 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
     const llm = new ChatOpenAI({ model: "gpt-4o-mini" });
 
     // Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
-    let privateKey = process.env.PRIVATE_KEY as `0x${string}`;
+    let privateKey = process.env.PRIVATE_KEY as Hex;
     if (!privateKey) {
       if (fs.existsSync(WALLET_DATA_FILE)) {
         privateKey = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8")).privateKey;

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/svm/privy/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/svm/privy/route.ts
@@ -6,7 +6,7 @@ import {
   PrivyWalletConfig,
   PrivyWalletProvider,
   splActionProvider,
-  walletActionProvider
+  walletActionProvider,
 } from "@coinbase/agentkit";
 import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { MemorySaver } from "@langchain/langgraph";
@@ -86,7 +86,7 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
       authorizationKeyId: process.env.PRIVY_WALLET_AUTHORIZATION_KEY_ID,
       chainType: "solana",
       networkId: process.env.NETWORK_ID,
-    }
+    };
     // Try to load saved wallet data
     if (fs.existsSync(WALLET_DATA_FILE)) {
       const savedWallet = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8"));

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/svm/privy/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/svm/privy/route.ts
@@ -2,18 +2,17 @@ import { AgentRequest, AgentResponse } from "@/app/types/api";
 import {
   AgentKit,
   cdpApiActionProvider,
-  erc20ActionProvider,
   jupiterActionProvider,
+  PrivyWalletConfig,
   PrivyWalletProvider,
-  pythActionProvider,
   splActionProvider,
-  walletActionProvider,
-  wethActionProvider,
+  walletActionProvider
 } from "@coinbase/agentkit";
 import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { MemorySaver } from "@langchain/langgraph";
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { ChatOpenAI } from "@langchain/openai";
+import fs from "fs";
 import { NextResponse } from "next/server";
 
 /**
@@ -54,6 +53,9 @@ import { NextResponse } from "next/server";
 // The agent
 let agent: ReturnType<typeof createReactAgent>;
 
+// Configure a file to persist the agent's Prviy Wallet Data
+const WALLET_DATA_FILE = "wallet_data.txt";
+
 /**
  * Initializes and returns an instance of the AI agent.
  * If an agent instance already exists, it returns the existing one.
@@ -76,7 +78,7 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
     const llm = new ChatOpenAI({ model: "gpt-4o-mini" });
 
     // Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
-    const walletProvider = await PrivyWalletProvider.configureWithWallet({
+    const config: PrivyWalletConfig = {
       appId: process.env.PRIVY_APP_ID as string,
       appSecret: process.env.PRIVY_APP_SECRET as string,
       walletId: process.env.PRIVY_WALLET_ID as string,
@@ -84,7 +86,15 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
       authorizationKeyId: process.env.PRIVY_WALLET_AUTHORIZATION_KEY_ID,
       chainType: "solana",
       networkId: process.env.NETWORK_ID,
-    });
+    }
+    // Try to load saved wallet data
+    if (fs.existsSync(WALLET_DATA_FILE)) {
+      const savedWallet = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8"));
+      config.walletId = savedWallet.walletId;
+      config.authorizationPrivateKey = savedWallet.authorizationPrivateKey;
+      config.networkId = savedWallet.networkId;
+    }
+    const walletProvider = await PrivyWalletProvider.configureWithWallet(config);
 
     // Initialize AgentKit: https://docs.cdp.coinbase.com/agentkit/docs/agent-actions
     const agentkit = await AgentKit.from({
@@ -122,6 +132,10 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
         restating your tools' descriptions unless it is explicitly requested.
         `,
     });
+
+    // Save wallet data
+    const exportedWallet = walletProvider.exportWallet();
+    fs.writeFileSync(WALLET_DATA_FILE, JSON.stringify(exportedWallet));
 
     return agent;
   } catch (error) {

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/svm/solanaKeypair/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/svm/solanaKeypair/route.ts
@@ -84,13 +84,14 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
       if (fs.existsSync(WALLET_DATA_FILE)) {
         privateKey = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8")).privateKey;
         console.info("Found private key in wallet_data.txt");
-      }
-      else {
+      } else {
         const keypair = Keypair.generate();
         privateKey = bs58.encode(keypair.secretKey);
         fs.writeFileSync(WALLET_DATA_FILE, JSON.stringify({ privateKey }));
         console.log("Created new private key and saved to wallet_data.txt");
-        console.log("We recommend you save this private key to your .env file and delete wallet_data.txt afterwards.");
+        console.log(
+          "We recommend you save this private key to your .env file and delete wallet_data.txt afterwards.",
+        );
       }
     }
 

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/svm/solanaKeypair/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/svm/solanaKeypair/route.ts
@@ -15,7 +15,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { Keypair } from "@solana/web3.js";
 import bs58 from "bs58";
 import { NextResponse } from "next/server";
-
+import fs from "fs";
 /**
  * AgentKit Integration Route
  *
@@ -54,6 +54,9 @@ import { NextResponse } from "next/server";
 // The agent
 let agent: ReturnType<typeof createReactAgent>;
 
+// Configure a file to persist a user's private key if none provided
+const WALLET_DATA_FILE = "wallet_data.txt";
+
 /**
  * Initializes and returns an instance of the AI agent.
  * If an agent instance already exists, it returns the existing one.
@@ -76,13 +79,19 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
     const llm = new ChatOpenAI({ model: "gpt-4o-mini" });
 
     // Setup Private Key
-    let solanaPrivateKey = process.env.SOLANA_PRIVATE_KEY as string;
-    if (!solanaPrivateKey) {
-      console.log(`No Solana account detected. Generating a wallet...`);
-      const keypair = Keypair.generate();
-      solanaPrivateKey = bs58.encode(keypair.secretKey);
-      console.log(`Created Solana wallet: ${keypair.publicKey.toBase58()}`);
-      console.log(`Store the private key in your .env for future reuse: ${solanaPrivateKey}`);
+    let privateKey = process.env.SOLANA_PRIVATE_KEY as string;
+    if (!privateKey) {
+      if (fs.existsSync(WALLET_DATA_FILE)) {
+        privateKey = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8")).privateKey;
+        console.info("Found private key in wallet_data.txt");
+      }
+      else {
+        const keypair = Keypair.generate();
+        privateKey = bs58.encode(keypair.secretKey);
+        fs.writeFileSync(WALLET_DATA_FILE, JSON.stringify({ privateKey }));
+        console.log("Created new private key and saved to wallet_data.txt");
+        console.log("We recommend you save this private key to your .env file and delete wallet_data.txt afterwards.");
+      }
     }
 
     // Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
@@ -90,10 +99,10 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
     const rpcUrl = process.env.SOLANA_RPC_URL;
     let walletProvider: SolanaKeypairWalletProvider;
     if (rpcUrl) {
-      walletProvider = await SolanaKeypairWalletProvider.fromRpcUrl(rpcUrl, solanaPrivateKey);
+      walletProvider = await SolanaKeypairWalletProvider.fromRpcUrl(rpcUrl, privateKey);
     } else {
       const network = (process.env.NETWORK_ID ?? "solana-devnet") as SOLANA_NETWORK_ID;
-      walletProvider = await SolanaKeypairWalletProvider.fromNetwork(network, solanaPrivateKey);
+      walletProvider = await SolanaKeypairWalletProvider.fromNetwork(network, privateKey);
     }
 
     // Initialize AgentKit: https://docs.cdp.coinbase.com/agentkit/docs/agent-actions


### PR DESCRIPTION
## Description

The CLI tools only included wallet persistence for the CDP wallet provider case in Typescript and Python.
However, we want the best devx experience.

* If a user runs it without a wallet, one should be created and saved
* If the app is re-run, that saved wallet data should be persisted.


## Tests

Manually tested by generating every scenario via CLI, and testing them one by one.

- [x] - Typescript - evm/cdp
- [x] - Typescript - evm/viem
- [x] - Typescript - evm/privy
- [x] - Typescript - svm/privy
- [x] - Typescript - svm/solanaKeypair
- [x] - Python - cdp
- [x] - Python - eth
