### PR TITLE
feat: improved network selection in typescript/create-onchain-agent

### DIFF
--- a/typescript/.changeset/small-cloths-swim.md
+++ b/typescript/.changeset/small-cloths-swim.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": minor
+---
+
+Improved network selection & custom chainId/rpc selection

--- a/typescript/create-onchain-agent/src/cli.ts
+++ b/typescript/create-onchain-agent/src/cli.ts
@@ -4,7 +4,7 @@ import ora from "ora";
 import path from "path";
 import pc from "picocolors";
 import prompts from "prompts";
-import { EVM_NETWORKS, Networks, NetworkToWalletProviders, SVM_NETWORKS } from "./constants.js";
+import { EVM_NETWORKS, NetworkToWalletProviders, SVM_NETWORKS } from "./constants.js";
 import { Network, WalletProviderChoice } from "./types.js";
 import { copyTemplate } from "./fileSystem.js";
 import {

--- a/typescript/create-onchain-agent/src/cli.ts
+++ b/typescript/create-onchain-agent/src/cli.ts
@@ -122,12 +122,6 @@ async function init() {
               }));
             }
           },
-          initial: (prev, { networkFamily, networkType }) => {
-            if (networkFamily === "EVM" && networkType === "testnet") {
-              return Networks.indexOf("base-sepolia");
-            }
-            return 0;
-          },
         },
         {
           type: (prev, { networkFamily, networkType }) =>

--- a/typescript/create-onchain-agent/src/cli.ts
+++ b/typescript/create-onchain-agent/src/cli.ts
@@ -4,7 +4,7 @@ import ora from "ora";
 import path from "path";
 import pc from "picocolors";
 import prompts from "prompts";
-import { Networks, NetworkToWalletProviders } from "./constants.js";
+import { EVM_NETWORKS, Networks, NetworkToWalletProviders, SVM_NETWORKS } from "./constants.js";
 import { Network, WalletProviderChoice } from "./types.js";
 import { copyTemplate } from "./fileSystem.js";
 import {
@@ -107,17 +107,16 @@ async function init() {
           choices: (prev, { networkFamily, networkType }) => {
             if (networkFamily === "SVM") {
               // Show all Solana networks
-              return Networks.filter(n => n.startsWith("solana")).map(network => ({
+              return SVM_NETWORKS.map(network => ({
                 title: network,
                 value: network as Network,
               }));
             } else {
               // Filter EVM networks by mainnet/testnet
-              const networks = Networks.filter(n => {
+              return EVM_NETWORKS.filter(n => {
                 const isMainnet = n.includes("mainnet");
                 return networkType === "mainnet" ? isMainnet : !isMainnet;
-              });
-              return networks.map(network => ({
+              }).map(network => ({
                 title: network === "base-sepolia" ? `${network} (default)` : network,
                 value: network as Network,
               }));

--- a/typescript/create-onchain-agent/src/cli.ts
+++ b/typescript/create-onchain-agent/src/cli.ts
@@ -155,12 +155,12 @@ async function init() {
               : "RPC URL cannot be empty.",
         },
         {
-          type: (prev, { networkFamily, networkType, network }) => {
+          type: (prev, { networkFamily, networkType }) => {
             // For custom EVM networks, auto-select Viem by returning null
             if (networkFamily === "EVM" && networkType === "custom") {
               return null;
             }
-            // For all other cases (regular EVM networks and SVM networks with multiple providers), show selection
+            // For all other cases (regular EVM networks and SVM networks), show selection
             return "select";
           },
           name: "walletProvider",
@@ -213,10 +213,9 @@ async function init() {
     }
     process.exit(1);
   }
-  let { projectName, packageName, network, chainId, walletProvider, rpcUrl } = result;
-
-  packageName ||= toValidPackageName(projectName);
-  walletProvider ||= "Viem";
+  const { projectName, network, chainId, rpcUrl } = result;
+  const packageName = result.packageName || toValidPackageName(projectName);
+  const walletProvider = result.walletProvider || "Viem";
 
   const spinner = ora(`Creating ${projectName}...`).start();
 

--- a/typescript/create-onchain-agent/src/constants.ts
+++ b/typescript/create-onchain-agent/src/constants.ts
@@ -52,7 +52,7 @@ export const WalletProviderChoices: WalletProviderChoice[] = [
 ];
 
 export const WalletProviderRouteConfigurations: Record<
-  "EVM" | "SVM",
+  "EVM" | "CUSTOM_EVM" | "SVM",
   Partial<Record<WalletProviderChoice, WalletProviderRouteConfiguration>>
 > = {
   EVM: {
@@ -95,6 +95,19 @@ export const WalletProviderRouteConfigurations: Record<
         ],
       },
       apiRoute: "evm/privy/route.ts",
+    },
+  },
+  CUSTOM_EVM: {
+    Viem: {
+      env: {
+        topComments: [
+          "Export private key from your Ethereum wallet and save",
+          "Get keys from CDP Portal: https://portal.cdp.coinbase.com/",
+        ],
+        required: ["PRIVATE_KEY="],
+        optional: ["CDP_API_KEY_NAME=", "CDP_API_KEY_PRIVATE_KEY="],
+      },
+      apiRoute: "custom-evm/viem/route.ts",
     },
   },
   SVM: {

--- a/typescript/create-onchain-agent/src/constants.ts
+++ b/typescript/create-onchain-agent/src/constants.ts
@@ -6,24 +6,20 @@ import {
   WalletProviderRouteConfiguration,
 } from "./types";
 
-export const EVM_NETWORKS: Set<EVMNetwork> = new Set([
-  "ethereum-mainnet",
-  "ethereum-sepolia",
-  "polygon-mainnet",
-  "polygon-mumbai",
+export const EVM_NETWORKS: EVMNetwork[] = [
   "base-mainnet",
   "base-sepolia",
+  "ethereum-mainnet",
+  "ethereum-sepolia",
   "arbitrum-mainnet",
   "arbitrum-sepolia",
   "optimism-mainnet",
   "optimism-sepolia",
-]);
+  "polygon-mainnet",
+  "polygon-mumbai",
+];
 
-export const SVM_NETWORKS: Set<SVMNetwork> = new Set([
-  "solana-mainnet",
-  "solana-devnet",
-  "solana-testnet",
-]);
+export const SVM_NETWORKS: SVMNetwork[] = ["solana-mainnet", "solana-devnet", "solana-testnet"];
 
 const CDP_SUPPORTED_EVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["CDP", "Viem", "Privy"];
 const SVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["SolanaKeypair", "Privy"];

--- a/typescript/create-onchain-agent/src/fileSystem.ts
+++ b/typescript/create-onchain-agent/src/fileSystem.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { optimizedCopy, toValidPackageName } from "./utils.js";
+import { optimizedCopy } from "./utils.js";
 
 const sourceDir = path.resolve(fileURLToPath(import.meta.url), "../../../templates/next");
 

--- a/typescript/create-onchain-agent/src/fileSystem.ts
+++ b/typescript/create-onchain-agent/src/fileSystem.ts
@@ -70,7 +70,7 @@ export async function copyTemplate(projectName: string, packageName: string): Pr
 
   const pkgPath = path.join(root, "package.json");
   const pkg = JSON.parse(await fs.promises.readFile(pkgPath, "utf-8"));
-  pkg.name = packageName || toValidPackageName(projectName);
+  pkg.name = packageName;
 
   await fs.promises.writeFile(pkgPath, JSON.stringify(pkg, null, 2));
 

--- a/typescript/create-onchain-agent/src/types.ts
+++ b/typescript/create-onchain-agent/src/types.ts
@@ -24,3 +24,11 @@ export type WalletProviderRouteConfiguration = {
   };
   apiRoute: string;
 };
+
+export type NetworkSelection = {
+  networkFamily: "EVM" | "SVM";
+  networkType: "mainnet" | "testnet" | "custom";
+  network?: Network;
+  chainId?: string;
+  rpcUrl?: string;
+};

--- a/typescript/create-onchain-agent/src/utils.ts
+++ b/typescript/create-onchain-agent/src/utils.ts
@@ -253,4 +253,5 @@ export async function handleSelection(
   }
   await fs.rm(path.join(agentDir, "evm"), { recursive: true, force: true });
   await fs.rm(path.join(agentDir, "svm"), { recursive: true, force: true });
+  await fs.rm(path.join(agentDir, "custom-evm"), { recursive: true, force: true });
 }

--- a/typescript/create-onchain-agent/src/utils.ts
+++ b/typescript/create-onchain-agent/src/utils.ts
@@ -210,7 +210,7 @@ export async function handleSelection(
     // Finish with # Optional section
     "\n\n# Optional\n",
     ...[
-      `NETWORK_ID=${network ?? ''}`,
+      `NETWORK_ID=${network ?? ""}`,
       rpcUrl ? `RPC_URL=${rpcUrl}` : null,
       chainId ? `CHAIN_ID=${chainId}` : null,
       ...selectedRouteConfig.env.optional,

--- a/typescript/create-onchain-agent/src/utils.ts
+++ b/typescript/create-onchain-agent/src/utils.ts
@@ -13,9 +13,13 @@ import {
  * Determines the network family based on the provided network.
  *
  * @param {EVMNetwork | SVMNetwork} network - The network to check.
+ * @param {string} chainId - The chain ID to check.
  * @returns {"EVM" | "SVM" | undefined} The network family, or `undefined` if not recognized.
  */
-export function getNetworkType(network?: EVMNetwork | SVMNetwork, chainId?: string): "EVM" | "SVM" | 'CUSTOM_EVM' | null {
+export function getNetworkType(
+  network?: EVMNetwork | SVMNetwork,
+  chainId?: string,
+): "EVM" | "SVM" | "CUSTOM_EVM" | null {
   if (network) {
     if (EVM_NETWORKS.includes(network as EVMNetwork)) {
       return "EVM";

--- a/typescript/create-onchain-agent/src/utils.ts
+++ b/typescript/create-onchain-agent/src/utils.ts
@@ -210,8 +210,9 @@ export async function handleSelection(
     // Finish with # Optional section
     "\n\n# Optional\n",
     ...[
-      `NETWORK_ID=${network}`,
+      `NETWORK_ID=${network ?? ''}`,
       rpcUrl ? `RPC_URL=${rpcUrl}` : null,
+      chainId ? `CHAIN_ID=${chainId}` : null,
       ...selectedRouteConfig.env.optional,
     ]
       .filter(Boolean)

--- a/typescript/create-onchain-agent/src/utils.ts
+++ b/typescript/create-onchain-agent/src/utils.ts
@@ -16,9 +16,9 @@ import {
  * @returns {"EVM" | "SVM" | undefined} The network family, or `undefined` if not recognized.
  */
 export function getNetworkFamily(network: EVMNetwork | SVMNetwork): "EVM" | "SVM" | undefined {
-  return EVM_NETWORKS.has(network as EVMNetwork)
+  return EVM_NETWORKS.includes(network as EVMNetwork)
     ? "EVM"
-    : SVM_NETWORKS.has(network as SVMNetwork)
+    : SVM_NETWORKS.includes(network as SVMNetwork)
       ? "SVM"
       : undefined;
 }
@@ -166,6 +166,7 @@ export const getWalletProviders = (network?: Network): WalletProviderChoice[] =>
  * @param {WalletProviderChoice} walletProvider - The selected wallet provider.
  * @param {Network} [network] - The optional blockchain network.
  * @param {string} [chainId] - The optional chain ID for the network.
+ * @param {string} [rpcUrl] - The optional RPC URL for the network.
  * @throws {Error} If neither `network` nor `chainId` are provided, or if the selected combination is invalid.
  * @returns {Promise<void>} A promise that resolves when the selection process is complete.
  */
@@ -174,6 +175,7 @@ export async function handleSelection(
   walletProvider: WalletProviderChoice,
   network?: Network,
   chainId?: string,
+  rpcUrl?: string,
 ) {
   const agentDir = path.join(root, "app", "api", "agent");
 
@@ -207,7 +209,13 @@ export async function handleSelection(
     ...["OPENAI_API_KEY=", ...selectedRouteConfig.env.required].join("\n"),
     // Finish with # Optional section
     "\n\n# Optional\n",
-    ...[`NETWORK_ID=${network}`, ...selectedRouteConfig.env.optional].join("\n"),
+    ...[
+      `NETWORK_ID=${network}`,
+      rpcUrl ? `RPC_URL=${rpcUrl}` : null,
+      ...selectedRouteConfig.env.optional,
+    ]
+      .filter(Boolean)
+      .join("\n"),
   ];
   await fs.writeFile(envPath, envLines);
 

--- a/typescript/create-onchain-agent/src/utils.ts
+++ b/typescript/create-onchain-agent/src/utils.ts
@@ -15,12 +15,21 @@ import {
  * @param {EVMNetwork | SVMNetwork} network - The network to check.
  * @returns {"EVM" | "SVM" | undefined} The network family, or `undefined` if not recognized.
  */
-export function getNetworkFamily(network: EVMNetwork | SVMNetwork): "EVM" | "SVM" | undefined {
-  return EVM_NETWORKS.includes(network as EVMNetwork)
-    ? "EVM"
-    : SVM_NETWORKS.includes(network as SVMNetwork)
-      ? "SVM"
-      : undefined;
+export function getNetworkType(network?: EVMNetwork | SVMNetwork, chainId?: string): "EVM" | "SVM" | 'CUSTOM_EVM' | null {
+  if (network) {
+    if (EVM_NETWORKS.includes(network as EVMNetwork)) {
+      return "EVM";
+    }
+    if (SVM_NETWORKS.includes(network as SVMNetwork)) {
+      return "SVM";
+    }
+  }
+
+  if (chainId) {
+    return "CUSTOM_EVM";
+  }
+
+  return null;
 }
 
 /**
@@ -179,16 +188,12 @@ export async function handleSelection(
 ) {
   const agentDir = path.join(root, "app", "api", "agent");
 
-  let networkFamily: ReturnType<typeof getNetworkFamily>;
-  if (network) {
-    networkFamily = getNetworkFamily(network);
-  } else if (chainId) {
-    networkFamily = "EVM";
-  } else {
+  const networkFamily = getNetworkType(network, chainId);
+  if (!networkFamily) {
     throw new Error("Unsupported network and chainId selected");
   }
 
-  const selectedRouteConfig = WalletProviderRouteConfigurations[networkFamily!][walletProvider];
+  const selectedRouteConfig = WalletProviderRouteConfigurations[networkFamily][walletProvider];
 
   if (!selectedRouteConfig) {
     throw new Error("Selected invalid network & wallet provider combination");

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/custom-evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/custom-evm/viem/route.ts
@@ -7,7 +7,7 @@ import {
   pythActionProvider,
   ViemWalletProvider,
   walletActionProvider,
-  wethActionProvider
+  wethActionProvider,
 } from "@coinbase/agentkit";
 import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { MemorySaver } from "@langchain/langgraph";

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
@@ -100,9 +100,26 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
 
     const account = privateKeyToAccount(privateKey);
     const networkId = process.env.NETWORK_ID as string;
+
+    // If custom chain is provided, use it, otherwise use the networkId
+    const chain: Chain = customChainId && customRpcUrl ? { 
+      id: parseInt(customChainId), 
+      rpcUrls: { 
+        default: { 
+          http: [customRpcUrl] 
+        } 
+      }, 
+      name: "Custom Chain", 
+      nativeCurrency: { 
+        name: "Ether", 
+        symbol: "ETH", 
+        decimals: 18 
+      } 
+    } : NETWORK_ID_TO_VIEM_CHAIN[networkId]
+
     const client = createWalletClient({
       account,
-      chain: NETWORK_ID_TO_VIEM_CHAIN[networkId],
+      chain,
       transport: http(),
     });
     const walletProvider = new ViemWalletProvider(client);

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
@@ -102,20 +102,23 @@ async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgen
     const networkId = process.env.NETWORK_ID as string;
 
     // If custom chain is provided, use it, otherwise use the networkId
-    const chain: Chain = customChainId && customRpcUrl ? { 
-      id: parseInt(customChainId), 
-      rpcUrls: { 
-        default: { 
-          http: [customRpcUrl] 
-        } 
-      }, 
-      name: "Custom Chain", 
-      nativeCurrency: { 
-        name: "Ether", 
-        symbol: "ETH", 
-        decimals: 18 
-      } 
-    } : NETWORK_ID_TO_VIEM_CHAIN[networkId]
+    const chain: Chain =
+      customChainId && customRpcUrl
+        ? {
+            id: parseInt(customChainId),
+            rpcUrls: {
+              default: {
+                http: [customRpcUrl],
+              },
+            },
+            name: "Custom Chain",
+            nativeCurrency: {
+              name: "Ether",
+              symbol: "ETH",
+              decimals: 18,
+            },
+          }
+        : NETWORK_ID_TO_VIEM_CHAIN[networkId];
 
     const client = createWalletClient({
       account,

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/viem/route.ts
@@ -2,8 +2,6 @@ import { NextResponse } from "next/server";
 import {
   AgentKit,
   cdpApiActionProvider,
-  cdpWalletActionProvider,
-  CdpWalletProvider,
   erc20ActionProvider,
   NETWORK_ID_TO_VIEM_CHAIN,
   pythActionProvider,


### PR DESCRIPTION
## Description

1.
The old selection put ALL networks (EVM & SVM, mainnets & testnets, even custom chain id) into one big select list.
This PR organizes this select into multiple smaller selections.

2. This fixes the "Custom Chain ID". Previously, a chain_id could be assigned, but no custom rpc was gathered, and you could still choose Privy (which does not expose a convenient way to customize by chainId/rpcUrl).

Now, going into the "Custom Chain ID" takes you through a different route entirely. You have to provide an accompanying rpc url, and a new api route is copied. This new API route is `custom-evm/viem`, which mirrors `evm/viem`, except rather than assigning a preconfigured Viem chain, it creates a new chain and assigns the chainId/rpc.

This new route already has the fixes from #468 and #484 built into it, so no fast follow will be required to bring it to parity after the merges.

## Tests

Tested via manual trial and error down each CLI path and generated the results

<img width="474" alt="Screenshot 2025-02-27 at 11 24 57 PM" src="https://github.com/user-attachments/assets/254abbb0-f836-46d9-b5a8-58e30476cd6d" />
<img width="438" alt="Screenshot 2025-02-27 at 11 25 01 PM" src="https://github.com/user-attachments/assets/21d0b96d-f9d6-4ff5-9f08-4ec1875aa9e7" />
<img width="435" alt="Screenshot 2025-02-27 at 11 25 06 PM" src="https://github.com/user-attachments/assets/ea5863db-f4f6-4be5-99ce-a873f7506fcc" />
<img width="429" alt="Screenshot 2025-02-27 at 11 26 05 PM" src="https://github.com/user-attachments/assets/0fb9eb6c-b8ea-4106-baf5-fc4187bf46f2" />
<img width="428" alt="Screenshot 2025-02-27 at 11 26 16 PM" src="https://github.com/user-attachments/assets/120c91d0-0371-42a7-ae6b-a03afd93761f" />
<img width="440" alt="Screenshot 2025-02-27 at 11 26 21 PM" src="https://github.com/user-attachments/assets/3f466849-eab3-4c77-926c-8cdb9bfd6c9e" />
<img width="421" alt="Screenshot 2025-02-27 at 11 26 30 PM" src="https://github.com/user-attachments/assets/19b6c47a-0dbe-4613-98c9-860e0b5fe77d" />
