### PR TITLE
chore: fix publish agentkit langchain

### DIFF
--- a/.github/workflows/publish_npm_agentkit_langchain.yml
+++ b/.github/workflows/publish_npm_agentkit_langchain.yml
@@ -17,11 +17,14 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
           cache-dependency-path: ./typescript
-      - name: Install, build and publish @coinbase/agentkit-langchain
-        working-directory: ./typescript/framework-extensions/langchain
+      - name: Install and build
+        working-directory: ./typescript
         run: |
           npm ci
           npm run build
+      - name: Publish @coinbase/agentkit-langchain
+        working-directory: ./typescript/framework-extensions/langchain
+        run: |
           npm publish --ignore-scripts --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for contributing to AgentKit!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

`@coinbase/agentkit-langchain` depends on the local `@coinbase/agenkit` in order to be built correctly. This was changed and broken in: https://github.com/coinbase/agentkit/pull/466/files#diff-1aea946a0503fc7de81458f127e5aca1a224400432f9681d179f76db0902f607