### PR TITLE
feat: added smart wallet support to npm create onchain-agent

### DIFF
--- a/typescript/.changeset/chubby-hornets-end.md
+++ b/typescript/.changeset/chubby-hornets-end.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": patch
+---
+
+Added smart wallet support

--- a/typescript/create-onchain-agent/src/cli.ts
+++ b/typescript/create-onchain-agent/src/cli.ts
@@ -171,6 +171,7 @@ async function init() {
           message: (prev, { network }) => {
             const walletDescriptions: Record<WalletProviderChoice, string> = {
               CDP: "Uses Coinbase Developer Platform (CDP)'s managed wallet.",
+              SmartWallet: "Uses Coinbase Developer Platform (CDP)'s Smart Wallet.",
               Viem: "Client-side Ethereum wallet.",
               Privy: "Authentication and wallet infrastructure.",
               SolanaKeypair: "Client-side Solana wallet.",

--- a/typescript/create-onchain-agent/src/constants.ts
+++ b/typescript/create-onchain-agent/src/constants.ts
@@ -21,7 +21,12 @@ export const EVM_NETWORKS: EVMNetwork[] = [
 
 export const SVM_NETWORKS: SVMNetwork[] = ["solana-mainnet", "solana-devnet", "solana-testnet"];
 
-const CDP_SUPPORTED_EVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["CDP", "SmartWallet", "Viem", "Privy"];
+const CDP_SUPPORTED_EVM_WALLET_PROVIDERS: WalletProviderChoice[] = [
+  "CDP",
+  "SmartWallet",
+  "Viem",
+  "Privy",
+];
 const SVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["SolanaKeypair", "Privy"];
 export const NON_CDP_SUPPORTED_EVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["Viem", "Privy"];
 
@@ -99,13 +104,8 @@ export const WalletProviderRouteConfigurations: Record<
           "Get keys from CDP Portal: https://portal.cdp.coinbase.com/",
           "Optionally provide a private key, otherwise one will be generated",
         ],
-        required: [
-          "CDP_API_KEY_NAME=",
-          "CDP_API_KEY_PRIVATE_KEY=",
-        ],
-        optional: [
-          "PRIVATE_KEY=",
-        ],
+        required: ["CDP_API_KEY_NAME=", "CDP_API_KEY_PRIVATE_KEY="],
+        optional: ["PRIVATE_KEY="],
       },
       apiRoute: "evm/smart/route.ts",
     },

--- a/typescript/create-onchain-agent/src/constants.ts
+++ b/typescript/create-onchain-agent/src/constants.ts
@@ -105,7 +105,6 @@ export const WalletProviderRouteConfigurations: Record<
         ],
         optional: [
           "PRIVATE_KEY=",
-          "NETWORK_ID=",
         ],
       },
       apiRoute: "evm/smart/route.ts",

--- a/typescript/create-onchain-agent/src/constants.ts
+++ b/typescript/create-onchain-agent/src/constants.ts
@@ -21,7 +21,7 @@ export const EVM_NETWORKS: EVMNetwork[] = [
 
 export const SVM_NETWORKS: SVMNetwork[] = ["solana-mainnet", "solana-devnet", "solana-testnet"];
 
-const CDP_SUPPORTED_EVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["CDP", "Viem", "Privy"];
+const CDP_SUPPORTED_EVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["CDP", "SmartWallet", "Viem", "Privy"];
 const SVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["SolanaKeypair", "Privy"];
 export const NON_CDP_SUPPORTED_EVM_WALLET_PROVIDERS: WalletProviderChoice[] = ["Viem", "Privy"];
 
@@ -92,6 +92,23 @@ export const WalletProviderRouteConfigurations: Record<
         ],
       },
       apiRoute: "evm/privy/route.ts",
+    },
+    SmartWallet: {
+      env: {
+        topComments: [
+          "Get keys from CDP Portal: https://portal.cdp.coinbase.com/",
+          "Optionally provide a private key, otherwise one will be generated",
+        ],
+        required: [
+          "CDP_API_KEY_NAME=",
+          "CDP_API_KEY_PRIVATE_KEY=",
+        ],
+        optional: [
+          "PRIVATE_KEY=",
+          "NETWORK_ID=",
+        ],
+      },
+      apiRoute: "evm/smart/route.ts",
     },
   },
   CUSTOM_EVM: {

--- a/typescript/create-onchain-agent/src/types.ts
+++ b/typescript/create-onchain-agent/src/types.ts
@@ -14,7 +14,7 @@ export type SVMNetwork = "solana-mainnet" | "solana-devnet" | "solana-testnet";
 
 export type Network = EVMNetwork | SVMNetwork;
 
-export type WalletProviderChoice = "CDP" | "Viem" | "Privy" | "SolanaKeypair";
+export type WalletProviderChoice = "CDP" | "Viem" | "Privy" | "SolanaKeypair" | "SmartWallet";
 
 export type WalletProviderRouteConfiguration = {
   env: {

--- a/typescript/create-onchain-agent/templates/next/.gitignore
+++ b/typescript/create-onchain-agent/templates/next/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log*
 
 # local env files
 .env*
+wallet_data.txt
 
 # vercel
 .vercel

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/smart/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/smart/route.ts
@@ -1,0 +1,226 @@
+import { NextResponse } from "next/server";
+import {
+  AgentKit,
+  cdpApiActionProvider,
+  cdpWalletActionProvider,
+  SmartWalletProvider,
+  erc20ActionProvider,
+  pythActionProvider,
+  walletActionProvider,
+  wethActionProvider,
+} from "@coinbase/agentkit";
+import { getLangChainTools } from "@coinbase/agentkit-langchain";
+import { ChatOpenAI } from "@langchain/openai";
+import { MemorySaver } from "@langchain/langgraph";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { AgentRequest, AgentResponse } from "@/app/types/api";
+import * as fs from "fs";
+import { Address, Hex } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+/**
+ * AgentKit Integration Route
+ *
+ * This file is your gateway to integrating AgentKit with your product.
+ * It defines the interaction between your system and the AI agent,
+ * allowing you to configure the agent to suit your needs.
+ *
+ * # Key Steps to Customize Your Agent:**
+ *
+ * 1. Select your LLM:
+ *    - Modify the `ChatOpenAI` instantiation to choose your preferred LLM.
+ *
+ * 2. Set up your WalletProvider:
+ *    - Learn more: https://github.com/coinbase/agentkit/tree/main/typescript/agentkit#evm-wallet-providers
+ *
+ * 3️. Set up your ActionProviders:
+ *    - ActionProviders define what your agent can do.
+ *    - Choose from built-in providers or create your own:
+ *      - Built-in: https://github.com/coinbase/agentkit/tree/main/typescript/agentkit#action-providers
+ *      - Custom: https://github.com/coinbase/agentkit/tree/main/typescript/agentkit#creating-an-action-provider
+ *
+ * 4. Instantiate your Agent:
+ *    - Pass the LLM, tools, and memory into `createReactAgent()` to bring your agent to life.
+ *
+ * # Next Steps:
+ * - Explore the AgentKit README: https://github.com/coinbase/agentkit
+ * - Learn more about available WalletProviders & ActionProviders.
+ * - Experiment with custom ActionProviders for your unique use case.
+ *
+ * ## Want to contribute?
+ * Join us in shaping AgentKit! Check out the contribution guide:
+ * - https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING.md
+ * - https://discord.gg/CDP
+ */
+
+// The agent
+let agent: ReturnType<typeof createReactAgent>;
+
+// Configure a file to persist the agent's Smart Wallet + Private Key data
+const WALLET_DATA_FILE = "wallet_data.txt";
+
+type WalletData = {
+  privateKey: Hex;
+  smartWalletAddress: Address;
+};
+
+/**
+ * Initializes and returns an instance of the AI agent.
+ * If an agent instance already exists, it returns the existing one.
+ *
+ * @function getOrInitializeAgent
+ * @returns {Promise<ReturnType<typeof createReactAgent>>} The initialized AI agent.
+ *
+ * @description Handles agent setup
+ *
+ * @throws {Error} If the agent initialization fails.
+ */
+async function getOrInitializeAgent(): Promise<ReturnType<typeof createReactAgent>> {
+  // If agent has already been initialized, return it
+  if (agent) {
+    return agent;
+  }
+
+  try {
+    // Initialize LLM: https://platform.openai.com/docs/models#gpt-4o
+    const llm = new ChatOpenAI({ model: "gpt-4o-mini" });
+
+    let walletData: WalletData | null = null;
+    let privateKey: Hex | null = null;
+
+    // Read existing wallet data if available
+    if (fs.existsSync(WALLET_DATA_FILE)) {
+      try {
+        walletData = JSON.parse(fs.readFileSync(WALLET_DATA_FILE, "utf8")) as WalletData;
+        privateKey = walletData.privateKey;
+      } catch (error) {
+        console.error("Error reading wallet data:", error);
+        // Continue without wallet data
+      }
+    }
+
+    if (!privateKey) {
+      if (walletData?.smartWalletAddress) {
+        throw new Error(
+          `Smart wallet found but no private key provided. Either provide the private key, or delete ${WALLET_DATA_FILE} and try again.`,
+        );
+      }
+      privateKey = (process.env.PRIVATE_KEY || generatePrivateKey()) as Hex;
+    }
+
+    const signer = privateKeyToAccount(privateKey);
+
+    // Initialize WalletProvider: https://docs.cdp.coinbase.com/agentkit/docs/wallet-management
+    const walletProvider = await SmartWalletProvider.configureWithWallet({
+      networkId: process.env.NETWORK_ID || "base-sepolia",
+      signer,
+      smartWalletAddress: walletData?.smartWalletAddress,
+      paymasterUrl: undefined, // Sponsor transactions: https://docs.cdp.coinbase.com/paymaster/docs/welcome
+    });
+
+    // Initialize AgentKit: https://docs.cdp.coinbase.com/agentkit/docs/agent-actions
+    const agentkit = await AgentKit.from({
+      walletProvider,
+      actionProviders: [
+        wethActionProvider(),
+        pythActionProvider(),
+        walletActionProvider(),
+        erc20ActionProvider(),
+        cdpApiActionProvider({
+          apiKeyName: process.env.CDP_API_KEY_NAME,
+          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
+        }),
+        cdpWalletActionProvider({
+          apiKeyName: process.env.CDP_API_KEY_NAME,
+          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
+        }),
+      ],
+    });
+    const tools = await getLangChainTools(agentkit);
+    const memory = new MemorySaver();
+
+    // Initialize Agent
+    const canUseFaucet = walletProvider.getNetwork().networkId == "base-sepolia";
+    const faucetMessage = `If you ever need funds, you can request them from the faucet.`;
+    const cantUseFaucetMessage = `If you need funds, you can provide your wallet details and request funds from the user.`;
+    agent = createReactAgent({
+      llm,
+      tools,
+      checkpointSaver: memory,
+      messageModifier: `
+        You are a helpful agent that can interact onchain using the Coinbase Developer Platform AgentKit. You are 
+        empowered to interact onchain using your tools. ${canUseFaucet ? faucetMessage : cantUseFaucetMessage}.
+        Before executing your first action, get the wallet details to see what network 
+        you're on. If there is a 5XX (internal) HTTP error code, ask the user to try again later. If someone 
+        asks you to do something you can't do with your currently available tools, you must say so, and 
+        encourage them to implement it themselves using the CDP SDK + Agentkit, recommend they go to 
+        docs.cdp.coinbase.com for more information. Be concise and helpful with your responses. Refrain from 
+        restating your tools' descriptions unless it is explicitly requested.
+        `,
+    });
+
+    // Save wallet data
+    const smartWalletAddress = await walletProvider.getAddress();
+    fs.writeFileSync(
+      WALLET_DATA_FILE,
+      JSON.stringify({
+        privateKey,
+        smartWalletAddress,
+      } as WalletData),
+    );
+
+    return agent;
+  } catch (error) {
+    console.error("Error initializing agent:", error);
+    throw new Error("Failed to initialize agent");
+  }
+}
+
+/**
+ * Handles incoming POST requests to interact with the AgentKit-powered AI agent.
+ * This function processes user messages and streams responses from the agent.
+ *
+ * @function POST
+ * @param {Request & { json: () => Promise<AgentRequest> }} req - The incoming request object containing the user message.
+ * @returns {Promise<NextResponse<AgentResponse>>} JSON response containing the AI-generated reply or an error message.
+ *
+ * @description Sends a single message to the agent and returns the agents' final response.
+ *
+ * @example
+ * const response = await fetch("/api/agent", {
+ *     method: "POST",
+ *     headers: { "Content-Type": "application/json" },
+ *     body: JSON.stringify({ userMessage: input }),
+ * });
+ */
+export async function POST(
+  req: Request & { json: () => Promise<AgentRequest> },
+): Promise<NextResponse<AgentResponse>> {
+  try {
+    // 1️. Extract user message from the request body
+    const { userMessage } = await req.json();
+
+    // 2. Get the agent
+    const agent = await getOrInitializeAgent();
+
+    // 3.Start streaming the agent's response
+    const stream = await agent.stream(
+      { messages: [{ content: userMessage, role: "user" }] }, // The new message to send to the agent
+      { configurable: { thread_id: "AgentKit Discussion" } }, // Customizable thread ID for tracking conversations
+    );
+
+    // 4️. Process the streamed response chunks into a single message
+    let agentResponse = "";
+    for await (const chunk of stream) {
+      if ("agent" in chunk) {
+        agentResponse += chunk.agent.messages[0].content;
+      }
+    }
+
+    // 5️. Return the final response
+    return NextResponse.json({ response: agentResponse });
+  } catch (error) {
+    console.error("Error processing request:", error);
+    return NextResponse.json({ error: "Failed to process message" });
+  }
+}

--- a/typescript/create-onchain-agent/templates/next/package.json
+++ b/typescript/create-onchain-agent/templates/next/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@coinbase/agentkit": "^0.2.2",
-    "@coinbase/agentkit-langchain": "^0.2.2",
+    "@coinbase/agentkit": "^0.2.3",
+    "@coinbase/agentkit-langchain": "^0.2.3",
     "@langchain/langgraph": "^0.2.21",
     "@langchain/openai": "^0.3.14",
     "@langchain/core": "^0.3.19",


### PR DESCRIPTION
## Description

With the release of `@coinbase/agentkit` 0.2.3,`SmartWalletProvider` have been added.

This PR adds support to `npm create onchain-agent` to create a API endpoint that uses the SmartWalletProvider when selected.

## Tests

### Success Case

When using the CLI for a EVM mainnet/testnet, `SmartWallet` is an option:
![Screenshot 2025-03-03 at 11 40 30 AM](https://github.com/user-attachments/assets/b7e60f3d-4445-4ab1-bb0b-5cca7c236e05)

The .env.local generated will require CDP keys + OpenAI key, and optionally require a private key/network id
![Screenshot 2025-03-03 at 11 54 58 AM](https://github.com/user-attachments/assets/9329e03a-e25d-44ce-bc30-e3f032787bb7)

Putting the required env vars into .env (CDP keys + OpenAI Keys) is sufficient to get the bot running. The optional values are unnecessary to run, even private key
<img width="1725" alt="Screenshot 2025-03-03 at 11 51 20 AM" src="https://github.com/user-attachments/assets/8537e752-ab5d-4eae-9865-08e252038bbb" />

Killing the process and restarting it will load the private key/smart wallet address from the saved file, reconstituting state:
<img width="1723" alt="Screenshot 2025-03-03 at 11 53 25 AM" src="https://github.com/user-attachments/assets/be031474-e1cd-4c37-9509-b4b127d7497a" />


## Ensure SmartWallet is not an option in invalid cases

When using the CLI, picking a custom chain ID does NOT prompt for SmartWallet and instead defaults to Viem:
![Screenshot 2025-03-03 at 11 45 02 AM](https://github.com/user-attachments/assets/fb1491f6-797b-4ff7-82c0-3fd91d40ef07)

When using the CLI, Solana does NOT have the option:
![Screenshot 2025-03-03 at 11 45 39 AM](https://github.com/user-attachments/assets/2908374b-8c1e-44e9-ac33-ec7b67654cdc)

## Note

Added the generated `wallet_data.txt` file to the templates `.gitignore`
