### PR TITLE
chore: rm label sync

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   labeler:
@@ -9,4 +9,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+      - uses: actions/labeler@v5

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,5 +10,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5
-      with:
-        sync-labels: true


### PR DESCRIPTION
## Description

This is causing noise – every update to a PR causes the "needs triage" label to be re-applied. Initial PRs usually have every relevant piece of info, so there's little to no value in having the sync anyway.