### PR TITLE
fix: linter error in ts cli's generated project

### DIFF
--- a/typescript/.changeset/ripe-buttons-dress.md
+++ b/typescript/.changeset/ripe-buttons-dress.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": patch
+---
+
+Fixed linter error in generated project

--- a/typescript/create-onchain-agent/templates/next/app/page.tsx
+++ b/typescript/create-onchain-agent/templates/next/app/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
                 }`}
               >
                 <ReactMarkdown components={{
-                  a: ({ node, ...props }) => (
+                  a: (props) => (
                     <a
                       {...props}
                       className="text-blue-600 dark:text-blue-400 underline hover:text-blue-800 dark:hover:text-blue-300"


### PR DESCRIPTION
## Description

A inconsistent linter error can occur on the Next project generated.

Upon further inspection, the error can be ignored by passing along the full props.

## Tests

My colleague who ran into the error tested this fix manually