### PR TITLE
chore(vercel-ai-sdk): improve dependency management

### DIFF
--- a/typescript/.changeset/all-nails-cry.md
+++ b/typescript/.changeset/all-nails-cry.md
@@ -1,5 +1,5 @@
 ---
-"@coinbase/agentkit-vercel-ai-sdk": patch
+"@coinbase/agentkit-vercel-ai-sdk": minor
 ---
 
 add vercel ai sdk framework support

--- a/typescript/.changeset/config.json
+++ b/typescript/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@coinbase/*-example"]
+  "ignore": ["@coinbase/*-example"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/typescript/framework-extensions/vercel-ai-sdk/package.json
+++ b/typescript/framework-extensions/vercel-ai-sdk/package.json
@@ -41,8 +41,13 @@
     "ai-sdk"
   ],
   "dependencies": {
-    "@coinbase/agentkit": "^0.2.3",
-    "ai": "^4.1.16",
     "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@coinbase/agentkit": "0.2.3"
+  },
+  "peerDependencies": {
+    "@coinbase/agentkit": ">=0.1.0",
+    "ai": "^4.1.16"
   }
 }

--- a/typescript/framework-extensions/vercel-ai-sdk/tsconfig.json
+++ b/typescript/framework-extensions/vercel-ai-sdk/tsconfig.json
@@ -6,5 +6,5 @@
     "module": "Node16"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/tests"]
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -452,9 +452,14 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coinbase/agentkit": "^0.2.3",
-        "ai": "^4.1.16",
         "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@coinbase/agentkit": "0.2.3"
+      },
+      "peerDependencies": {
+        "@coinbase/agentkit": ">=0.1.0",
+        "ai": "^4.1.16"
       }
     },
     "framework-extensions/vercel-ai-sdk/node_modules/@coinbase/agentkit/node_modules/@coinbase/coinbase-sdk": {
@@ -13940,8 +13945,7 @@
     "@coinbase/agentkit-vercel-ai-sdk": {
       "version": "file:framework-extensions/vercel-ai-sdk",
       "requires": {
-        "@coinbase/agentkit": "^0.2.3",
-        "ai": "^4.1.16",
+        "@coinbase/agentkit": "0.2.3",
         "zod": "^3.22.4"
       }
     },


### PR DESCRIPTION
## Description

This PR introduces changes to the `@coinbase/agentkit-vercel-ai-sdk` packaging setup to bring it more in line with a true "extension" or "plugin" style package. This means that it no longer directly depends on `@coinbase/agentkit` or Vercel's `ai` package, freeing up consumers to manage the versions of these packages themselves.

Along with the changes to the `changesets` config, this has the added benefit of not having to bump `@coinbase/agentkit-vercel-ai-sdk` whenever changes are added to `@coinbase/agentkit`.

## Tests

This was tested locally by packaging up `@coinbase/agentkit` and `@coinbase/agentkit-vercel-ai-sdk`, and installing them locally in a standalone project, which can be seen here: https://github.com/0xRAG/peer-playground

Steps taken:
1. In `typescript/`, run `npm i && npm run build`
2. Run `cd framework-extensions/vercel-ai-sdk/dist && npm pack && cd -`
3. Run `cd agentkit/dist && npm pack && cd -`
4. From the `peer-playground` app, run `pnpm install`
5. In `peer-playground`, add a `.env` with your `OPENAI_API_KEY`
6. From the `peer-playground` app, run `pnpm add ../../agentkit/typescript/agentkit/dist/coinbase-agentkit-0.2.3.tgz` (The path is dependent on your filesystem, of course)
7. From the `peer-playground` app, run `pnpm add ../../agentkit/typescript/framework-extensions/vercel-ai-sdk/dist/coinbase-agentkit-vercel-ai-sdk-0.0.1.tgz` (The path is dependent on your filesystem, of course)
8. From the `peer-playground` app, run `pnpm tsx index.ts`. This will boot up the chatbot
9. Ask the chatbot `print wallet details`. It will take a second to think, and then output its response

These steps validate that the package will continue to work with the changes in this PR.

To demonstrate the benefits to the consumer, reset `peer-playground` to a clean state, without the changes from above. Then, switch to `npm` with the following commands. At the end, you'll see that you have two installations of `@coinbase/agentkit`, which can lead to unexpected bugs.
1. Run `rm -rf node_modules`
2. Run `npm i`
3. In the `package.json`, update `"@coinbase/agentkit"` to `^0.1.0`
4. Run `npm i`
5. Run `npm ls @coinbase/agentkit`

Notice in the output, you have two copies of `@coinbase/agentkit` at different versions!
```
peer-playground@1.0.0 /Users/ryan/code/public/playground/peer
├─┬ @coinbase/agentkit-vercel-ai-sdk@0.0.1
│ └── @coinbase/agentkit@0.2.3
└── @coinbase/agentkit@0.1.2
```

Now, if you install the local build of `@coinbase/agentkit-vercel-ai-sdk` and check `@coinbase/agentkit`, you'll see that it is de-duped:
1. `npm i ../../agentkit/typescript/framework-extensions/vercel-ai-sdk/dist/coinbase-agentkit-vercel-ai-sdk-0.0.1.tgz` (Update for you local path)
2. Run `npm ls @coinbase/agentkit`

Now the output is:
```
peer-playground@1.0.0 /Users/ryan/code/public/playground/peer
├─┬ @coinbase/agentkit-vercel-ai-sdk@0.0.1
│ └── @coinbase/agentkit@0.1.2 deduped
└── @coinbase/agentkit@0.1.2
```

### How does this work with `changesets`?

Currently, `changesets` will bump `@coinbase/agentkit-vercel-ai-sdk` when there are any changes in `@coinbase/agentkit`. This can be observed by:
1. On main, in `typescript/`, run `rm .changeset/all-nails-cry.md`. This is to simulate a scenario where there are no changes to the extension.
2. Run `npx @changesets/cli version` (In order for the command to work, you will have to create a GitHub Personal Access Token with scopes `read:user` and `repo:status`. Or update [this line](https://github.com/coinbase/agentkit/blob/main/typescript/.changeset/config.json#L3) to `"changelog": "@changesets/cli/changelog",`)

Notice the version in `@coinbase/agentkit-vercel-ai-sdk` was bumped.

Now if you switch over to this branch (`chore/vercel-pkg`) and follow the same steps, you'll see the version was not bumped.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [ ] Added a changelog entry
