### PR TITLE
chore: fix typo in wallet data configuration variable name

### DIFF
--- a/typescript/create-onchain-agent/templates/next/app/api/agent/evm/privy/route.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/evm/privy/route.ts
@@ -55,7 +55,7 @@ import fs from "fs";
 // The agent
 let agent: ReturnType<typeof createReactAgent>;
 
-// Configure a file to persist the agent's Prviy Wallet Data
+// Configure a file to persist the agent's Privy Wallet Data
 const WALLET_DATA_FILE = "wallet_data.txt";
 
 /**


### PR DESCRIPTION
## Description

I corrected a typo in the variable name used for wallet data configuration. It was previously written as `PrviyWalletData`, which is clearly a mistake. The correct name should be `PrivyWalletData`.

## Tests

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [ ] Added a changelog entry

