### PR TITLE
chore: remove noisy label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,3 @@ documentation:
 example:
 - changed-files:
   - any-glob-to-any-file: '**/examples/**'
-
-'needs triage':
-- changed-files:
-  - any-glob-to-any-file: '**'


### PR DESCRIPTION
<!--
Thanks for contributing to AgentKit!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

This label gets re-added on every push to a PR. I think this label can be implied by whether or not a maintainer has given an initial acknowledgement on an open PR.
