### PR TITLE
chore: python bump cdp sdk version

### DIFF
--- a/python/coinbase-agentkit/CHANGELOG.md
+++ b/python/coinbase-agentkit/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## [0.1.6] - 2025-03-11
+
+### Added
+
+- Added edwards key support via updating cdp-sdk version
+
+
 ## [0.1.5] - 2025-03-07
 
 ### Fixed

--- a/python/coinbase-agentkit/changelog.d/+14ef2776.feature.md
+++ b/python/coinbase-agentkit/changelog.d/+14ef2776.feature.md
@@ -1,0 +1,1 @@
+Added edwards key support via updating cdp-sdk version

--- a/python/coinbase-agentkit/changelog.d/+14ef2776.feature.md
+++ b/python/coinbase-agentkit/changelog.d/+14ef2776.feature.md
@@ -1,1 +1,0 @@
-Added edwards key support via updating cdp-sdk version

--- a/python/coinbase-agentkit/poetry.lock
+++ b/python/coinbase-agentkit/poetry.lock
@@ -490,13 +490,13 @@ test = ["coverage (>=7)", "hypothesis", "pytest"]
 
 [[package]]
 name = "cdp-sdk"
-version = "0.19.0"
+version = "0.21.0"
 description = "CDP Python SDK"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "cdp_sdk-0.19.0-py3-none-any.whl", hash = "sha256:fbb1176e4ff44df233598e71f80f5bccc5c53cc322eb670d35258b67ee2937e1"},
-    {file = "cdp_sdk-0.19.0.tar.gz", hash = "sha256:e2f55668f16dfd3329353ddd2fe5bd9c0bd22b2ab0f66b1efa72007e13a71e29"},
+    {file = "cdp_sdk-0.21.0-py3-none-any.whl", hash = "sha256:36a2ec372c79354133f142566674f6f5a21f474d31f378154a3b4e0e0089818a"},
+    {file = "cdp_sdk-0.21.0.tar.gz", hash = "sha256:6d832189e84cec76c3353f52835ddf06789630325ca5f0ea1a48ad663b698e7d"},
 ]
 
 [package.dependencies]
@@ -3785,4 +3785,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3f1083a7b1ac442d625386e110eaa5abd818d4a602839ea4728f1c4696bc7d4f"
+content-hash = "26c1811879439ad652d0f9b0124e1b86e1f74f2cf351d258b83b2b2048750b86"

--- a/python/coinbase-agentkit/pyproject.toml
+++ b/python/coinbase-agentkit/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-cdp-sdk = "0.19.0"
+cdp-sdk = "0.21.0"
 pydantic = "^2.0"
 web3 = "^7.6.0"
 python-dotenv = "^1.0.1"

--- a/python/coinbase-agentkit/pyproject.toml
+++ b/python/coinbase-agentkit/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coinbase-agentkit"
-version = "0.1.5"
+version = "0.1.6"
 description = "Coinbase AgentKit"
 authors = ["John Peterson <john.peterson@coinbase.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Description

Edwards key support was added to `cdp-sdk` 0.20.0. We are updating from `0.19.0` to `0.21.0` to inherit this feature.

## Tests

```
Starting Agent...

Available modes:
1. chat    - Interactive chat mode
2. auto    - Autonomous action mode

Choose a mode (enter number or name): 1
Starting chat mode... Type 'exit' to end.

Prompt: What is your wallet and address?

-------------------
Wallet Details:
- Provider: cdp_wallet_provider
- Address: 0x33503a7E9243f837b85F6E8CAb1ee914B1BddE0c
- Network:
  * Protocol Family: evm
  * Network ID: base-sepolia
  * Chain ID: 84532
- Native Balance: 0
-------------------
My wallet address is **0x33503a7E9243f837b85F6E8CAb1ee914B1BddE0c** on the **base-sepolia** network.
-------------------
```

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [x] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
