### PR TITLE
fix: readded missing .env.local file

### DIFF
--- a/python/create-onchain-agent/templates/beginner/.env.local.jinja
+++ b/python/create-onchain-agent/templates/beginner/.env.local.jinja
@@ -1,0 +1,13 @@
+# Get keys from OpenAI Platform: https://platform.openai.com/api-keys
+# Get keys from CDP Portal: https://portal.cdp.coinbase.com/
+
+## Required
+# Place your OpenAI API key here
+OPENAI_API_KEY=
+# Place your CDP API key name here
+CDP_API_KEY_NAME=
+# Place your CDP API private key here
+CDP_API_KEY_PRIVATE_KEY=
+
+## Optional
+NETWORK_ID=base-sepolia


### PR DESCRIPTION
## Description

With the beginner template, I made the mistake of removing .jinja from the file extension, because templating the .env file was not required for this template. However, `.env.local` being the newly named file got ignored, as pushing up .env files is unsafe.

This PR reintroduced the env file