### PR TITLE
fix(py/weth): Replace deprecated pydantic @validator and class configs

### DIFF
--- a/python/coinbase-agentkit/changelog.d/579.bugfix.md
+++ b/python/coinbase-agentkit/changelog.d/579.bugfix.md
@@ -1,0 +1,1 @@
+Replace deprecated pydantic @validator and class config

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/weth/schemas.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/weth/schemas.py
@@ -2,7 +2,7 @@
 
 import re
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 from .constants import MIN_WRAP_AMOUNT
 
@@ -12,7 +12,7 @@ class WrapEthSchema(BaseModel):
 
     amount_to_wrap: str = Field(..., description="Amount of ETH to wrap in wei")
 
-    @validator("amount_to_wrap")
+    @field_validator("amount_to_wrap")
     @classmethod
     def validate_amount(cls, v: str) -> str:
         """Validate that amount is a valid wei value (whole number as string)."""

--- a/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/wallet_providers/eth_account_wallet_provider.py
@@ -7,7 +7,7 @@ from typing import Any
 from eth_account.account import LocalAccount
 from eth_account.datastructures import SignedTransaction
 from eth_account.messages import encode_defunct
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from web3 import Web3
 from web3.middleware import SignAndSendRawMiddlewareBuilder
 from web3.types import BlockIdentifier, ChecksumAddress, HexStr, TxParams
@@ -24,10 +24,7 @@ class EthAccountWalletProviderConfig(BaseModel):
     gas: EvmGasConfig | None = Field(None, description="Gas configuration settings")
     rpc_url: str | None = Field(None, description="Optional RPC URL to override default chain RPC")
 
-    class Config:
-        """Configuration for EthAccountWalletProvider."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class EthAccountWalletProvider(EvmWalletProvider):


### PR DESCRIPTION
## Description

Replaced a pydantic `@validator` by `@field_validator`, as `@validator` is deprecated and will be removed in future versions.

Other parts are already using `@field_validator`, this was the last usage of it.
Discovered it while integrating AgentKit into an AI Agent framework and writing tests, which where raising warnings:

```sh
venv/lib/python3.11/site-packages/coinbase_agentkit/action_providers/weth/schemas.py:15
  /libertai-agents/libertai_agents/venv/lib/python3.11/site-packages/coinbase_agentkit/action_providers/weth/schemas.py:15: 
  PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. 
 You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details.
 Deprecated in Pydantic V2.0 to be removed in V3.0. 
 See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    @validator("amount_to_wrap")
```

Also fixed this warning in 2 places:
```sh
venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295
 /libertai-agents/libertai_agents/venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:295: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)
```

By switching to `ConfigDict`

## Tests

Straightforward change of a `@validator` / `@field_validator` and `ConfigDict`, that are all using default / basic options

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [ ] Added a changelog entry