### PR TITLE
Add transaction queue to cdp wallet provider

### DIFF
--- a/typescript/.changeset/cold-cougars-hug.md
+++ b/typescript/.changeset/cold-cougars-hug.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added transaction queue to the cdp wallet provider to avoid nonce collisions.

--- a/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
@@ -298,7 +298,9 @@ export class CdpWalletProvider extends EvmWalletProvider {
 
       return tx.transactionHash as `0x${string}`;
     })();
-    this.#transactionQueue = sendPromise.then(txHash => this.waitForTransactionReceipt(txHash));
+    this.#transactionQueue = sendPromise
+      .then(txHash => this.waitForTransactionReceipt(txHash))
+      .catch(() => {});
     return await sendPromise;
   }
 

--- a/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpWalletProvider.ts
@@ -114,6 +114,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
   #publicClient: PublicClient;
   #gasLimitMultiplier: number;
   #feePerGasMultiplier: number;
+  #transactionQueue: Promise<void> | undefined;
 
   /**
    * Constructs a new CdpWalletProvider.
@@ -276,23 +277,29 @@ export class CdpWalletProvider extends EvmWalletProvider {
       throw new Error("Wallet not initialized");
     }
 
-    const preparedTransaction = await this.prepareTransaction(
-      transaction.to!,
-      transaction.value!,
-      transaction.data!,
-    );
+    const sendPromise = (async () => {
+      if (this.#transactionQueue) await this.#transactionQueue;
 
-    const signature = await this.signTransaction({
-      ...preparedTransaction,
-    } as TransactionRequest);
+      const preparedTransaction = await this.prepareTransaction(
+        transaction.to!,
+        transaction.value!,
+        transaction.data!,
+      );
 
-    const signedPayload = await this.addSignatureAndSerialize(preparedTransaction, signature);
+      const signature = await this.signTransaction({
+        ...preparedTransaction,
+      } as TransactionRequest);
 
-    const externalAddress = new ExternalAddress(this.#cdpWallet.getNetworkId(), this.#address!);
+      const signedPayload = await this.addSignatureAndSerialize(preparedTransaction, signature);
 
-    const tx = await externalAddress.broadcastExternalTransaction(signedPayload.slice(2));
+      const externalAddress = new ExternalAddress(this.#cdpWallet!.getNetworkId(), this.#address!);
 
-    return tx.transactionHash as `0x${string}`;
+      const tx = await externalAddress.broadcastExternalTransaction(signedPayload.slice(2));
+
+      return tx.transactionHash as `0x${string}`;
+    })();
+    this.#transactionQueue = sendPromise.then(txHash => this.waitForTransactionReceipt(txHash));
+    return await sendPromise;
   }
 
   /**
@@ -314,6 +321,7 @@ export class CdpWalletProvider extends EvmWalletProvider {
 
     const nonce = await this.#publicClient!.getTransactionCount({
       address: this.#address! as `0x${string}`,
+      blockTag: "pending",
     });
 
     const feeData = await this.#publicClient.estimateFeesPerGas();


### PR DESCRIPTION
<!--
Thanks for contributing to AgentKit!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

When an agent uses multiple actions that send transactions at once, the cdp wallet provider might send them all at once with the same nonce. This PR implements a transaction queue so the wallet provider will await previous transactions before sending a new one to avoid nonce collisions.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
chatbots in the examples directory.

Please provide samples of the prompts you tested with, the Agent outputs for each prompt,
which chatbot you used, and any other relevant context, like which network was used.

Use the following format if helpful:

```
Chatbot: <name of chatbot used>
Network: <network used>
Setup: <any other relevant context>

Prompt: <prompt>

<agent output>
```

For example:

```
Chatbot: typescript/examples/langchain-smart-wallet-chatbot/chatbot.ts
Network: Base Sepolia
Setup: Fauceted with 1 USDC

Prompt: print USDC balance (token address: 0x036CbD53842c5426634e7929541eC2318f3dCF7e)

-------------------
Balance of 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1
-------------------
The USDC balance for the token address `0x036CbD53842c5426634e7929541eC2318f3dCF7e` is 1.
-------------------
```
 -->

Example:
Chatbot: langchain-cdp-chatbot
Network: base
Setup: relevant assets topped up

Prompt: "supply 5 usdc and 0.001 weth into compound"
Response: 
```
You have successfully supplied **5 USDC** to Compound:

- **Transaction Hash:** [0x6d451e11557fdd1ae207ec8d418a4a7d13214fa614b7ae35104b503cdae0813c](https://etherscan.io/tx/0x6d451e11557fdd1ae207ec8d418a4a7d13214fa614b7ae35104b503cdae0813c)

However, there was an error when trying to supply **0.001 WETH** due to a "Replacement transaction underpriced" error.

Would you like to retry supplying WETH or take any other action?
```


I also added a unit test for the queue.

## Checklist

A couple of things to include in your PR for completeness:

- [X] Added documentation to all relevant README.md files
- [x] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
