### PR TITLE
fix: removed CdpWalletActionProvider from smart wallet action provider lists

### DIFF
--- a/typescript/.changeset/sad-windows-divide.md
+++ b/typescript/.changeset/sad-windows-divide.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": patch
+---
+
+Removed CdpWalletActionProvider from smart wallet action provider lists

--- a/typescript/create-onchain-agent/templates/mcp/src/agentkit/evm/smart/getAgentKit.ts
+++ b/typescript/create-onchain-agent/templates/mcp/src/agentkit/evm/smart/getAgentKit.ts
@@ -1,7 +1,6 @@
 import {
   AgentKit,
   cdpApiActionProvider,
-  cdpWalletActionProvider,
   erc20ActionProvider,
   pythActionProvider,
   SmartWalletProvider,
@@ -42,10 +41,6 @@ export async function getAgentKit(): Promise<AgentKit> {
         walletActionProvider(),
         erc20ActionProvider(),
         cdpApiActionProvider({
-          apiKeyName: process.env.CDP_API_KEY_NAME,
-          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
-        }),
-        cdpWalletActionProvider({
           apiKeyName: process.env.CDP_API_KEY_NAME,
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/agentkit/evm/smart/prepare-agentkit.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/agentkit/evm/smart/prepare-agentkit.ts
@@ -1,7 +1,6 @@
 import {
   AgentKit,
   cdpApiActionProvider,
-  cdpWalletActionProvider,
   erc20ActionProvider,
   pythActionProvider,
   SmartWalletProvider,
@@ -107,10 +106,6 @@ export async function prepareAgentkitAndWalletProvider(): Promise<{
         walletActionProvider(),
         erc20ActionProvider(),
         cdpApiActionProvider({
-          apiKeyName: process.env.CDP_API_KEY_NAME,
-          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
-        }),
-        cdpWalletActionProvider({
           apiKeyName: process.env.CDP_API_KEY_NAME,
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),

--- a/typescript/create-onchain-agent/templates/prepareAgentkit/agentkit/evm/smart/prepareAgentkit.ts
+++ b/typescript/create-onchain-agent/templates/prepareAgentkit/agentkit/evm/smart/prepareAgentkit.ts
@@ -1,7 +1,6 @@
 import {
   AgentKit,
   cdpApiActionProvider,
-  cdpWalletActionProvider,
   erc20ActionProvider,
   pythActionProvider,
   SmartWalletProvider,
@@ -107,10 +106,6 @@ export async function prepareAgentkitAndWalletProvider(): Promise<{
         walletActionProvider(),
         erc20ActionProvider(),
         cdpApiActionProvider({
-          apiKeyName: process.env.CDP_API_KEY_NAME,
-          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
-        }),
-        cdpWalletActionProvider({
           apiKeyName: process.env.CDP_API_KEY_NAME,
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),

--- a/typescript/examples/langchain-smart-wallet-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-smart-wallet-chatbot/chatbot.ts
@@ -1,7 +1,6 @@
 import {
   AgentKit,
   cdpApiActionProvider,
-  cdpWalletActionProvider,
   erc20ActionProvider,
   pythActionProvider,
   SmartWalletProvider,
@@ -114,10 +113,6 @@ async function initializeAgent() {
         walletActionProvider(),
         erc20ActionProvider(),
         cdpApiActionProvider({
-          apiKeyName: process.env.CDP_API_KEY_NAME,
-          apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
-        }),
-        cdpWalletActionProvider({
           apiKeyName: process.env.CDP_API_KEY_NAME,
           apiKeyPrivateKey: process.env.CDP_API_KEY_PRIVATE_KEY,
         }),


### PR DESCRIPTION
## Description

There is a bug where smart wallet code generated from the npm cli would include `CdpWalletActionProvider` included in the list of action providers. These actions cannot be used by any wallet provider other than the `CdpWalletProvider`.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [x] Added a changelog entry