### PR TITLE
fix: changesets bump versions with workspace protocol only

### DIFF
--- a/typescript/.changeset/config.json
+++ b/typescript/.changeset/config.json
@@ -7,6 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": ["@coinbase/*-example", "mcp", "next-template"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true


### PR DESCRIPTION
fix: changesets bump versions with workspace protocol only