### PR TITLE
Fixed privy dependency bug

### DIFF
--- a/typescript/.changeset/giant-impalas-relate.md
+++ b/typescript/.changeset/giant-impalas-relate.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Fixed Privy dependency on @privy-io/public-api

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -43,6 +43,7 @@
     "@alloralabs/allora-sdk": "^0.1.0",
     "@coinbase/coinbase-sdk": "^0.20.0",
     "@jup-ag/api": "^6.0.39",
+    "@privy-io/public-api": "^2.18.5",
     "@privy-io/server-auth": "^1.18.4",
     "@solana/spl-token": "^0.4.12",
     "@solana/web3.js": "^1.98.0",

--- a/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.test.ts
@@ -137,6 +137,7 @@ describe("PrivyEvmDelegatedEmbeddedWalletProvider", () => {
     authorizationPrivateKey: "wallet-auth:test-auth-key",
     walletId: MOCK_WALLET_ID,
     networkId: "base-sepolia",
+    walletType: "embedded" as const,
   };
 
   beforeEach(() => {

--- a/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.ts
@@ -37,6 +37,9 @@ export interface PrivyEvmDelegatedEmbeddedWalletConfig extends PrivyWalletConfig
 
   /** The chain ID to connect to */
   chainId?: string;
+
+  /** The wallet type to use */
+  walletType: "embedded";
 }
 
 /**

--- a/typescript/agentkit/src/wallet-providers/privyShared.ts
+++ b/typescript/agentkit/src/wallet-providers/privyShared.ts
@@ -16,10 +16,6 @@ export interface PrivyWalletConfig {
   authorizationPrivateKey?: string;
   /** Optional authorization key ID for creating new wallets */
   authorizationKeyId?: string;
-  /** The chain type to create the wallet on */
-  chainType?: "ethereum" | "solana";
-  /** The type of wallet to use */
-  walletType?: "server" | "embedded";
 }
 
 export type PrivyWalletExport = {
@@ -57,7 +53,7 @@ export const createPrivyClient = (config: PrivyWalletConfig) => {
  * @returns The created Privy wallet
  */
 export async function createPrivyWallet(
-  config: PrivyWalletConfig,
+  config: PrivyWalletConfig & { chainType: "ethereum" | "solana" },
 ): Promise<CreatePrivyWalletReturnType> {
   const privy = createPrivyClient(config);
 

--- a/typescript/agentkit/src/wallet-providers/privySvmWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/privySvmWalletProvider.test.ts
@@ -124,6 +124,7 @@ describe("PrivySvmWalletProvider", () => {
   const MOCK_CONFIG = {
     appId: "test-app-id",
     appSecret: "test-app-secret",
+    walletType: "server" as const,
   };
 
   const MOCK_CONFIG_WITH_WALLET_ID = {

--- a/typescript/agentkit/src/wallet-providers/privySvmWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privySvmWalletProvider.ts
@@ -1,4 +1,4 @@
-import { PrivyClient } from "@privy-io/server-auth";
+import { PrivyClient, SolanaCaip2ChainId } from "@privy-io/server-auth";
 import { SvmWalletProvider } from "./svmWalletProvider";
 import {
   RpcResponseAndContext,
@@ -21,6 +21,8 @@ export interface PrivySvmWalletConfig extends PrivyWalletConfig {
   networkId?: string;
   /** The connection to use for the wallet */
   connection?: Connection;
+  /** The wallet type to use */
+  walletType: "server";
 }
 
 /**
@@ -78,7 +80,10 @@ export class PrivySvmWalletProvider extends SvmWalletProvider {
   public static async configureWithWallet<T extends PrivySvmWalletProvider>(
     config: PrivySvmWalletConfig,
   ): Promise<T> {
-    const { wallet, privy } = await createPrivyWallet(config);
+    const { wallet, privy } = await createPrivyWallet({
+      ...config,
+      chainType: "solana",
+    });
 
     const connection =
       config.connection ??
@@ -119,7 +124,7 @@ export class PrivySvmWalletProvider extends SvmWalletProvider {
     try {
       const { hash } = await this.#privyClient.walletApi.solana.signAndSendTransaction({
         walletId: this.#walletId,
-        caip2: `solana:${this.#genesisHash.substring(0, 32)}`,
+        caip2: `solana:${this.#genesisHash.substring(0, 32)}` as SolanaCaip2ChainId,
         transaction,
       });
 

--- a/typescript/agentkit/src/wallet-providers/privyWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/privyWalletProvider.test.ts
@@ -1,6 +1,7 @@
 import { PrivyWalletProvider } from "./privyWalletProvider";
 import { PrivyEvmWalletProvider } from "./privyEvmWalletProvider";
 import { PrivySvmWalletProvider } from "./privySvmWalletProvider";
+import { PrivyEvmDelegatedEmbeddedWalletProvider } from "./privyEvmDelegatedEmbeddedWalletProvider";
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
@@ -39,6 +40,19 @@ jest.mock("./privySvmWalletProvider", () => ({
   },
 }));
 
+jest.mock("./privyEvmDelegatedEmbeddedWalletProvider", () => ({
+  PrivyEvmDelegatedEmbeddedWalletProvider: {
+    configureWithWallet: jest.fn().mockResolvedValue({
+      getAddress: jest.fn().mockReturnValue("0x324335Cc6634C0532925a3b844Bc454e4438d22g"),
+      getNetwork: jest.fn().mockReturnValue({
+        protocolFamily: "evm",
+        chainId: "1",
+        networkId: "mainnet",
+      }),
+    }),
+  },
+}));
+
 describe("PrivyWalletProvider", () => {
   const MOCK_EVM_CONFIG = {
     appId: "test-app-id",
@@ -51,6 +65,13 @@ describe("PrivyWalletProvider", () => {
     chainType: "solana" as const,
   };
 
+  const MOCK_EVM_EMBEDDED_WALLET_CONFIG = {
+    ...MOCK_EVM_CONFIG,
+    authorizationPrivateKey: "test-auth-key",
+    walletId: "test-wallet-id",
+    walletType: "embedded" as const,
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -60,7 +81,8 @@ describe("PrivyWalletProvider", () => {
 
     expect(PrivyEvmWalletProvider.configureWithWallet).toHaveBeenCalledWith(MOCK_EVM_CONFIG);
     expect(PrivySvmWalletProvider.configureWithWallet).not.toHaveBeenCalled();
-
+    expect(PrivyEvmDelegatedEmbeddedWalletProvider.configureWithWallet).not.toHaveBeenCalled();
+    
     expect(provider.getAddress()).toBe("0x742d35Cc6634C0532925a3b844Bc454e4438f44e");
     expect(provider.getNetwork().protocolFamily).toBe("evm");
   });
@@ -75,6 +97,7 @@ describe("PrivyWalletProvider", () => {
 
     expect(PrivyEvmWalletProvider.configureWithWallet).toHaveBeenCalledWith(config);
     expect(PrivySvmWalletProvider.configureWithWallet).not.toHaveBeenCalled();
+    expect(PrivyEvmDelegatedEmbeddedWalletProvider.configureWithWallet).not.toHaveBeenCalled();
 
     expect(provider.getAddress()).toBe("0x742d35Cc6634C0532925a3b844Bc454e4438f44e");
     expect(provider.getNetwork().protocolFamily).toBe("evm");
@@ -85,9 +108,23 @@ describe("PrivyWalletProvider", () => {
 
     expect(PrivySvmWalletProvider.configureWithWallet).toHaveBeenCalledWith(MOCK_SVM_CONFIG);
     expect(PrivyEvmWalletProvider.configureWithWallet).not.toHaveBeenCalled();
+    expect(PrivyEvmDelegatedEmbeddedWalletProvider.configureWithWallet).not.toHaveBeenCalled();
 
     expect(provider.getAddress()).toBe("AQoKYV7tYpTrFZN6P5oUufbQKAUr9mNYGe1TTJC9wajM");
     expect(provider.getNetwork().protocolFamily).toBe("solana");
+  });
+
+  it("should create an EVM embedded wallet provider when embedded is specified", async () => {
+    const provider = await PrivyWalletProvider.configureWithWallet(MOCK_EVM_EMBEDDED_WALLET_CONFIG);
+
+    expect(PrivyEvmDelegatedEmbeddedWalletProvider.configureWithWallet).toHaveBeenCalledWith(
+      MOCK_EVM_EMBEDDED_WALLET_CONFIG,
+    );
+    expect(PrivyEvmWalletProvider.configureWithWallet).not.toHaveBeenCalled();
+    expect(PrivySvmWalletProvider.configureWithWallet).not.toHaveBeenCalled();
+
+    expect(provider.getAddress()).toBe("0x324335Cc6634C0532925a3b844Bc454e4438d22g");
+    expect(provider.getNetwork().protocolFamily).toBe("evm");
   });
 
   it("should pass through all config properties", async () => {

--- a/typescript/agentkit/src/wallet-providers/privyWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/privyWalletProvider.test.ts
@@ -82,7 +82,7 @@ describe("PrivyWalletProvider", () => {
     expect(PrivyEvmWalletProvider.configureWithWallet).toHaveBeenCalledWith(MOCK_EVM_CONFIG);
     expect(PrivySvmWalletProvider.configureWithWallet).not.toHaveBeenCalled();
     expect(PrivyEvmDelegatedEmbeddedWalletProvider.configureWithWallet).not.toHaveBeenCalled();
-    
+
     expect(provider.getAddress()).toBe("0x742d35Cc6634C0532925a3b844Bc454e4438f44e");
     expect(provider.getNetwork().protocolFamily).toBe("evm");
   });

--- a/typescript/agentkit/src/wallet-providers/privyWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyWalletProvider.ts
@@ -5,10 +5,13 @@ import {
   PrivyEvmDelegatedEmbeddedWalletConfig,
 } from "./privyEvmDelegatedEmbeddedWalletProvider";
 
-export type PrivyWalletConfig =
-  | PrivyEvmWalletConfig
+type PrivyWalletConfig =
+  (PrivyEvmWalletConfig
   | PrivySvmWalletConfig
-  | PrivyEvmDelegatedEmbeddedWalletConfig;
+  | PrivyEvmDelegatedEmbeddedWalletConfig) & {
+  chainType?: "ethereum" | "solana";
+  walletType?: "server" | "embedded";
+};
 
 export type PrivyWalletProviderVariant<T> = T extends { walletType: "embedded" }
   ? PrivyEvmDelegatedEmbeddedWalletProvider
@@ -51,10 +54,7 @@ export class PrivyWalletProvider {
    * ```
    */
   static async configureWithWallet<T extends PrivyWalletConfig>(
-    config: T & {
-      chainType?: "ethereum" | "solana";
-      walletType?: "server" | "embedded";
-    },
+    config: T,
   ): Promise<PrivyWalletProviderVariant<T>> {
     const chainType = config.chainType || "ethereum";
     const walletType = config.walletType || "server";

--- a/typescript/agentkit/src/wallet-providers/privyWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyWalletProvider.ts
@@ -5,10 +5,11 @@ import {
   PrivyEvmDelegatedEmbeddedWalletConfig,
 } from "./privyEvmDelegatedEmbeddedWalletProvider";
 
-type PrivyWalletConfig =
-  (PrivyEvmWalletConfig
+type PrivyWalletConfig = (
+  | PrivyEvmWalletConfig
   | PrivySvmWalletConfig
-  | PrivyEvmDelegatedEmbeddedWalletConfig) & {
+  | PrivyEvmDelegatedEmbeddedWalletConfig
+) & {
   chainType?: "ethereum" | "solana";
   walletType?: "server" | "embedded";
 };

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@jup-ag/api':
         specifier: ^6.0.39
         version: 6.0.40
+      '@privy-io/public-api':
+        specifier: ^2.18.5
+        version: 2.20.5(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
       '@privy-io/server-auth':
         specifier: ^1.18.4
         version: 1.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(viem@2.23.15(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))
@@ -1583,6 +1586,14 @@ packages:
     resolution: {integrity: sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@privy-io/api-base@1.4.5':
+    resolution: {integrity: sha512-DN34lc4mlRC/BOE75JOyrFuCCJLA9ljxfzC0RGCFQQ4usShWG7O5fqlmZ4CMmKsbGfgwOOqkkfiICBz1eIWarQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+
+  '@privy-io/public-api@2.20.5':
+    resolution: {integrity: sha512-gyW6YPholimAEMuXZjJrCMVuQm0ox++Zxk5o2v0090X2DSewVnCTIXNHCyQe/nfV1M4v8wdB7bpRXqqi76iJjA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+
   '@privy-io/server-auth@1.19.0':
     resolution: {integrity: sha512-kpKwuM6BzpYTJMRwPrOWSRyQsPvAxrtfRVRD5ODkyUkdJZALjdXcr7kMwi41XJhc738OwDzXFSTJJq6WwEW3DA==}
     peerDependencies:
@@ -2413,6 +2424,9 @@ packages:
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
+  base-x@4.0.1:
+    resolution: {integrity: sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==}
+
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
@@ -2491,6 +2505,9 @@ packages:
 
   bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
+  bs58@5.0.0:
+    resolution: {integrity: sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==}
 
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
@@ -4227,6 +4244,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.12.6:
+    resolution: {integrity: sha512-PJiS4ETaUfCOFLpmtKzAbqZQjCCKVu2OhTV4SVNNE7c2nu/dACvtCqj4L0i/KWNnIgRv7yrILvBj5Lonv5Ncxw==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -7670,6 +7690,22 @@ snapshots:
 
   '@pkgr/core@0.2.0': {}
 
+  '@privy-io/api-base@1.4.5':
+    dependencies:
+      zod: 3.24.2
+
+  '@privy-io/public-api@2.20.5(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@privy-io/api-base': 1.4.5
+      bs58: 5.0.0
+      libphonenumber-js: 1.12.6
+      viem: 2.24.1(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   '@privy-io/server-auth@1.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)(viem@2.23.15(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))':
     dependencies:
       '@noble/curves': 1.8.1
@@ -8973,6 +9009,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  base-x@4.0.1: {}
+
   base-x@5.0.1: {}
 
   base64-js@1.5.1: {}
@@ -9069,6 +9107,10 @@ snapshots:
   bs58@4.0.1:
     dependencies:
       base-x: 3.0.11
+
+  bs58@5.0.0:
+    dependencies:
+      base-x: 4.0.1
 
   bs58@6.0.0:
     dependencies:
@@ -11321,6 +11363,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.12.6: {}
 
   lilconfig@3.1.3: {}
 


### PR DESCRIPTION
## Description

The `@privy-io/server-auth` package has a dev dependency on `@privy-io/public-api` that needs to be explicit.

The version of `@privy-io/public-api` chosen was selected by looking up the `package.json` from our `@privy-io/server-auth` version and adding the same version in our codebase.

https://www.npmjs.com/package/@privy-io/server-auth/v/1.18.4?activeTab=code

After adding this install, my environment unveiled a problem that my cjs/esm r&d venture also showcased - `createPrivyClient` cannot have a undefined `chainType`. At runtime we were ensuring this was never the case, but at build time, our types are incompatible with that.

To fix this properly, 
1. I adjusted the base `PrivyWalletConfig` and removed the `chainType` completely
2. I moved it to a `&` on the `createPrivyWallet`'s config parameter, ensuring that despite not all configs needing it by default, it still must be passed in.
3. In the `PrivySvmWalletProvider`, the one place that actually calls `createPrivyWallet`, now passes in `solana` as the chainType. Since this is the `SVM` file, it having that domain knowledge is appropriate.
4. I updated `PrivyWalletConfig` in `PrivyWalletProvider` to include the optional `chainType` and `walletType` args directly, since they are no longer inherited from the base config

I then updated the tests accordingly to the new types, and and updated the `PrivyWalletProvider` tests to account for the `PrivyEvmDelegatedEmbeddedWalletConfig` case to ensure that it is still properly resolving all providers in all cases, including default.

## Tests

Updated the unit tests. Also manually tested the privy chatbot.

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added a changelog entry