### PR TITLE
chore: removed tagging from gha in python

### DIFF
--- a/.github/workflows/publish_pypi_coinbase_agentkit.yml
+++ b/.github/workflows/publish_pypi_coinbase_agentkit.yml
@@ -46,10 +46,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/coinbase-agentkit/dist/
-
-      - name: Tag package
-        run: |
-          TAG="coinbase-agentkit@v${{ steps.build.outputs.version }}"
-          MESSAGE="Release coinbase-agentkit version ${{ steps.build.outputs.version }}"
-          git tag -a $TAG -m "$MESSAGE"
-          git push origin $TAG

--- a/.github/workflows/publish_pypi_coinbase_agentkit_langchain.yml
+++ b/.github/workflows/publish_pypi_coinbase_agentkit_langchain.yml
@@ -46,10 +46,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/framework-extensions/langchain/dist/
-
-      - name: Tag package
-        run: |
-          TAG="coinbase-agentkit-langchain@v${{ steps.build.outputs.version }}"
-          MESSAGE="Release coinbase-agentkit-langchain version ${{ steps.build.outputs.version }}"
-          git tag -a $TAG -m "$MESSAGE"
-          git push origin $TAG

--- a/.github/workflows/publish_pypi_coinbase_agentkit_openai_agents_sdk.yml
+++ b/.github/workflows/publish_pypi_coinbase_agentkit_openai_agents_sdk.yml
@@ -46,10 +46,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/framework-extensions/openai-agents-sdk/dist/
-
-      - name: Tag package
-        run: |
-          TAG="coinbase-agentkit-openai-agents-sdk@v${{ steps.build.outputs.version }}"
-          MESSAGE="Release coinbase-agentkit-openai-agents-sdk version ${{ steps.build.outputs.version }}"
-          git tag -a $TAG -m "$MESSAGE"
-          git push origin $TAG

--- a/.github/workflows/publish_pypi_create_onchain_agent.yml
+++ b/.github/workflows/publish_pypi_create_onchain_agent.yml
@@ -46,10 +46,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/create-onchain-agent/dist/
-
-      - name: Tag package
-        run: |
-          TAG="create-onchain-agent-python@v${{ steps.build.outputs.version }}"
-          MESSAGE="Release create-onchain-agent-python version ${{ steps.build.outputs.version }}"
-          git tag -a $TAG -m "$MESSAGE"
-          git push origin $TAG


### PR DESCRIPTION
After #657, tagging is a manual step of phase 3, instead of something we rely on Github Actions for. 

The "Why" is I decided to make it a developer-managed step rather than over-rely on workflows. This decision is in an effort to make releases less brittle (hard to test workflows, especially with the new branch protection rules), more testable (can be partially tested when written as code run on a developers machine) and easier to review (as code, we have more control, such as letting developers run drafts before jumping straight into pushing up tags).

The "Why now?" is because we removed `tag.sh` in favor of having the Github Actions tag in the release workflow, however a [bug was uncovered](https://github.com/coinbase/agentkit/actions/runs/14273038306/job/40010380759) because the bot cannot tag without explicit permissions, so a change had to be made in time for the next release - either granting more permissions to the bot, or bringing back a `tag.sh` equivalent.

