### PR TITLE
feat:post embeds on Farcaster and media on Twitter (ts)

### DIFF
--- a/typescript/.changeset/nice-ducks-search.md
+++ b/typescript/.changeset/nice-ducks-search.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Added media upload support for Twitter and embeds support for Farcaster

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -261,7 +261,7 @@ const agent = createReactAgent({
 </tr>
 <tr>
     <td width="200"><code>post_cast</code></td>
-    <td width="768">Creates a new cast (message) on Farcaster with up to 280 characters.</td>
+    <td width="768">Creates a new cast (message) on Farcaster with up to 280 characters and support for up to 2 embedded URLs.</td>
 </tr>
 </table>
 </details>
@@ -361,6 +361,10 @@ const agent = createReactAgent({
 <tr>
     <td width="200"><code>post_tweet_reply</code></td>
     <td width="768">Creates a reply to an existing tweet using the tweet's unique identifier.</td>
+</tr>
+<tr>
+    <td width="200"><code>upload_media</code></td>
+    <td width="768">Uploads media (images, videos) to Twitter that can be attached to tweets.</td>
 </tr>
 </table>
 </details>

--- a/typescript/agentkit/src/action-providers/farcaster/README.md
+++ b/typescript/agentkit/src/action-providers/farcaster/README.md
@@ -21,6 +21,9 @@ farcaster/
 
 - `post_cast`: Create a new Farcaster post
 
+  - Supports text content up to 280 characters
+  - Supports up to 2 embedded URLs via the optional `embeds` parameter
+
 ## Adding New Actions
 
 To add new Farcaster actions:
@@ -36,5 +39,6 @@ The Farcaster provider supports all EVM-compatible networks.
 ## Notes
 
 - Requires a Neynar API key. Visit the [Neynar Dashboard](https://dev.neynar.com/) to get your key.
+- Embeds allow you to attach URLs to casts that will render as rich previews in the Farcaster client
 
 For more information on the **Farcaster Protocol**, visit [Farcaster Documentation](https://docs.farcaster.xyz/).

--- a/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.ts
@@ -133,6 +133,7 @@ A failure response will return a message with the Farcaster API request error:
         body: JSON.stringify({
           signer_uuid: this.signerUuid,
           text: args.castText,
+          embeds: args.embeds,
         }),
       });
       const data = await response.json();

--- a/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/farcaster/farcasterActionProvider.ts
@@ -111,6 +111,7 @@ A failure response will return a message with the Farcaster API request error:
     name: "post_cast",
     description: `
 This tool will post a cast to Farcaster. The tool takes the text of the cast as input. Casts can be maximum 280 characters.
+Optionally, up to 2 embeds (links to websites or mini apps) can be attached to the cast by providing an array of URLs in the embeds parameter.
 
 A successful response will return a message with the API response as a JSON payload:
     {}

--- a/typescript/agentkit/src/action-providers/farcaster/schemas.ts
+++ b/typescript/agentkit/src/action-providers/farcaster/schemas.ts
@@ -14,6 +14,14 @@ export const FarcasterAccountDetailsSchema = z
 export const FarcasterPostCastSchema = z
   .object({
     castText: z.string().max(280, "Cast text must be a maximum of 280 characters."),
+    embeds: z
+      .array(
+        z.object({
+          url: z.string().url("Embed URL must be a valid URL"),
+        }),
+      )
+      .max(2, "Maximum of 2 embeds allowed")
+      .optional(),
   })
   .strip()
   .describe("Input schema for posting a text-based cast");

--- a/typescript/agentkit/src/action-providers/twitter/README.md
+++ b/typescript/agentkit/src/action-providers/twitter/README.md
@@ -19,6 +19,7 @@ twitter/
 - `account_mentions`: Get mentions for a specified Twitter (X) user
 - `post_tweet`: Post a new tweet
 - `post_tweet_reply`: Reply to a tweet
+- `upload_media`: Upload media files (images, videos) to Twitter
 
 ## Adding New Actions
 

--- a/typescript/agentkit/src/action-providers/twitter/schemas.ts
+++ b/typescript/agentkit/src/action-providers/twitter/schemas.ts
@@ -27,6 +27,11 @@ export const TwitterAccountMentionsSchema = z
 export const TwitterPostTweetSchema = z
   .object({
     tweet: z.string().max(280, "Tweet must be a maximum of 280 characters."),
+    mediaIds: z
+      .array(z.string())
+      .max(4, "Maximum of 4 media IDs allowed")
+      .optional()
+      .describe("Optional array of 1-4 media IDs to attach to the tweet"),
   })
   .strip()
   .describe("Input schema for posting a tweet");
@@ -40,6 +45,24 @@ export const TwitterPostTweetReplySchema = z
     tweetReply: z
       .string()
       .max(280, "The reply to the tweet which must be a maximum of 280 characters."),
+    mediaIds: z
+      .array(z.string())
+      .max(4, "Maximum of 4 media IDs allowed")
+      .optional()
+      .describe("Optional array of 1-4 media IDs to attach to the tweet"),
   })
   .strip()
   .describe("Input schema for posting a tweet reply");
+
+/**
+ * Input schema for uploading media.
+ */
+export const TwitterUploadMediaSchema = z
+  .object({
+    filePath: z
+      .string()
+      .min(1, "File path is required.")
+      .describe("The path to the media file to upload"),
+  })
+  .strip()
+  .describe("Input schema for uploading media to Twitter");

--- a/typescript/agentkit/src/action-providers/twitter/twitterActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/twitter/twitterActionProvider.ts
@@ -144,6 +144,8 @@ A failure response will return a message with the Twitter API request error:
     name: "post_tweet",
     description: `
 This tool will post a tweet on Twitter. The tool takes the text of the tweet as input. Tweets can be maximum 280 characters.
+Optionally, up to 4 media items (images, videos) can be attached to the tweet by providing their media IDs in the mediaIds array.
+Media IDs are obtained by first uploading the media using the upload_media action.
 
 A successful response will return a message with the API response as a JSON payload:
     {"data": {"text": "hello, world!", "id": "0123456789012345678", "edit_history_tweet_ids": ["0123456789012345678"]}}
@@ -180,7 +182,10 @@ A failure response will return a message with the Twitter API request error:
   @CreateAction({
     name: "post_tweet_reply",
     description: `
-This tool will post a tweet on Twitter. The tool takes the text of the tweet as input. Tweets can be maximum 280 characters.
+This tool will post a reply to a tweet on Twitter. The tool takes the text of the reply and the ID of the tweet to reply to as input.
+Replies can be maximum 280 characters.
+Optionally, up to 4 media items (images, videos) can be attached to the reply by providing their media IDs in the mediaIds array.
+Media IDs can be obtained by first uploading the media using the upload_media action.
 
 A successful response will return a message with the API response as a JSON payload:
     {"data": {"text": "hello, world!", "id": "0123456789012345678", "edit_history_tweet_ids": ["0123456789012345678"]}}


### PR DESCRIPTION
<!--
Thanks for contributing to AgentKit!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Added media upload support for Twitter and embeds support for Farcaster

- FarcasterActionProvider: post_cast actions takes new optional embeds URL as input
- TwitterActionProvider: 
   - new action to upload upload_media returns media_id
   - post_tweet/post_tweet_reply take new optional media_ids as input

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->

## Tests

```
Chatbot: typescript/examples/langchain-cdp-chatbot/chatbot.ts
Network: Base Sepolia
```

```
Prompt: farcaster post with text "Testing in prod" and embeds: "https://true-cast.vercel.app", "https://true-cast.vercel.app/trueCast.png"
-------------------
Successfully posted cast to Farcaster:
{"success":true,"cast":{"hash":"0x4f24e69ed1f51aaeb65e79b9968bd72742bd4899","author":{"object":"user","fid":1046472,"username":"truecastagent","display_name":"TrueCast","pfp_url":"https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw/bd831a9d-dc68-4de3-a4d8-5337e2e43100/rectcrop3","custody_address":"0x1819005a8e32b2ef3d0fec2f8e0d08517b401d29","profile":{"bio":{"text":""}},"follower_count":16,"following_count":8,"verifications":["0x8e59886e4bd8b733df54c035d8fb33a982fb07dd"],"verified_addresses":{"eth_addresses":["0x8e59886e4bd8b733df54c035d8fb33a982fb07dd"],"sol_addresses":["7FwxmJWVQvCTB1hdr4bTXrvMpdLu8Z58xmRybJkCwsJj"],"primary":{"eth_address":"0x8e59886e4bd8b733df54c035d8fb33a982fb07dd","sol_address":"7FwxmJWVQvCTB1hdr4bTXrvMpdLu8Z58xmRybJkCwsJj"}},"verified_accounts":[{"platform":"x","username":"truecastagent"}],"power_badge":false,"experimental":{"neynar_user_score":0.58,"deprecation_notice":"The `neynar_user_score` field under `experimental` will be deprecated after June 1, 2025, as it will be formally promoted to a stable field named `score` within the user object."},"score":0.58},"text":"Testing in prod"}}
-------------------
The cast "Testing in prod" has been successfully posted to Farcaster with the specified embeds. If you need anything else, feel free to ask!
```

Cast: https://farcaster.xyz/truecastagent/0x4f24e69e

```
Prompt: upload file base.png to twitter

-------------------
Successfully uploaded media to Twitter: 1948465451035422720
-------------------
The media has been successfully uploaded to Twitter with the media ID: `1948465451035422720`. Would you like to post a tweet with this media? If so, please provide the text for the tweet.
-------------------

Prompt: Post text "Testing in prod" with this media ID

-------------------
Successfully posted to Twitter:
{"data":{"edit_history_tweet_ids":["1948465523076821024"],"text":"Testing in prod https://t.co/AAYAcCW3gj","id":"1948465523076821024"}}
-------------------
The tweet "Testing in prod" has been successfully posted to Twitter! You can view it [here](https://twitter.com/i/web/status/1948465523076821024). If you need anything else, feel free to ask!
-------------------

Prompt: post again and use this media id twice 

-------------------
Successfully posted to Twitter:
{"data":{"text":"Testing in prod again https://t.co/ue1UiF2dlg","edit_history_tweet_ids":["1948465987025600547"],"id":"1948465987025600547"}}
-------------------
The tweet "Testing in prod again" has been successfully posted to Twitter using the media twice! You can view it [here](https://twitter.com/i/web/status/1948465987025600547). Let me know if you need anything else!
```

Posts: 
- https://x.com/trueCastAgent/status/1948465523076821024
- https://x.com/trueCastAgent/status/1948465987025600547

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
chatbots in the examples directory.

Please provide samples of the prompts you tested with, the Agent outputs for each prompt,
which chatbot you used, and any other relevant context, like which network was used.

Use the following format if helpful:

```
Chatbot: langchain-cdp-chatbot/chatbot.ts

Prompt: <prompt>

<agent output>
```

For example:

```
Chatbot: typescript/examples/langchain-cdp-chatbot/chatbot.ts
Network: Base Sepolia

Prompt: print USDC balance (token address: 0x036CbD53842c5426634e7929541eC2318f3dCF7e)

-------------------
Balance of 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1
-------------------
The USDC balance for the token address `0x036CbD53842c5426634e7929541eC2318f3dCF7e` is 1.
-------------------
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
