### PR TITLE
feat: Add Zerion API

### DIFF
--- a/typescript/.changeset/fluffy-bats-joke.md
+++ b/typescript/.changeset/fluffy-bats-joke.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Add Zerion API for portfolio and DeFi positions

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -29,3 +29,4 @@ export * from "./flaunch";
 export * from "./onramp";
 export * from "./vaultsfyi";
 export * from "./zerodev";
+export * from "./zerion";

--- a/typescript/agentkit/src/action-providers/zerion/README.md
+++ b/typescript/agentkit/src/action-providers/zerion/README.md
@@ -1,0 +1,37 @@
+# Zerion Action Provider
+
+This directory contains the **ZerionActionProvider** implementation, which provides actions for zerion operations.
+
+## Overview
+
+The ZerionActionProvider is designed to work with EvmWalletProvider for blockchain interactions. It provides a set of actions that enable [describe the main purpose/functionality].
+
+## Directory Structure
+
+```
+zerion/
+├── zerionActionProvider.ts       # Main provider implementation
+├── zerionActionProvider.test.ts  # Provider test suite
+├── schemas.ts                    # Action schemas and types
+├── utils.ts                      # Utility functions
+├── constants.ts                  # Constants
+├── index.ts                      # Package exports
+└── README.md                     # Documentation (this file)
+```
+
+## Actions
+
+- `get_portfolio_overview`: Get portfolio overview (include DeFi positions)
+- `get_fungible_positions`: Get fungible positions (include DeFi positions)
+
+## Adding New Actions
+
+To add new Zerion actions:
+
+1. Define your action schema in `schemas.ts`
+2. Implement the action in `zerionActionProvider.ts`
+3. Add tests in `zerionActionProvider.test.ts`
+
+## Notes
+
+- For more details, please visit: [Zerion Documentation](https://developers.zerion.io/reference/wallets/)

--- a/typescript/agentkit/src/action-providers/zerion/constants.ts
+++ b/typescript/agentkit/src/action-providers/zerion/constants.ts
@@ -1,0 +1,1 @@
+export const ZERION_V1_BASE_URL = "https://api.zerion.io/v1";

--- a/typescript/agentkit/src/action-providers/zerion/index.ts
+++ b/typescript/agentkit/src/action-providers/zerion/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Exports for zerion action provider
+ *
+ * @module zerion
+ */
+
+export * from "./zerionActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/zerion/schemas.ts
+++ b/typescript/agentkit/src/action-providers/zerion/schemas.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * Action schemas for the zerion action provider.
+ *
+ * This file contains the Zod schemas that define the shape and validation
+ * rules for action parameters in the zerion action provider.
+ */
+
+/**
+ * Input schema for getting wallet portfolio.
+ */
+export const GetWalletPortfolioSchema = z
+  .object({
+    walletAddress: z
+      .string()
+      .describe(
+        "The wallet address to fetch portfolio for (defaults to connected wallet if not provided)",
+      ),
+  })
+  .strip()
+  .describe("Input schema for fetching wallet portfolio");

--- a/typescript/agentkit/src/action-providers/zerion/types.ts
+++ b/typescript/agentkit/src/action-providers/zerion/types.ts
@@ -1,0 +1,145 @@
+// Zerion API response types
+export interface ZerionFungiblePositionsResponse {
+  links: {
+    self: string;
+  };
+  data: ZerionFungiblePosition[];
+}
+
+export interface ZerionPortfolioResponse {
+  links: {
+    self: string;
+  };
+  data: ZerionPortfolio;
+}
+
+export interface ZerionPortfolio {
+  type: string;
+  id: string;
+  attributes: PortfolioAttributes;
+}
+
+export interface PortfolioAttributes {
+  positions_distribution_by_type: {
+    wallet: number;
+    deposited: number;
+    borrowed: number;
+    locked: number;
+    staked: number;
+  };
+  positions_distribution_by_chain: {
+    [key: string]: number;
+  };
+  total: {
+    positions: number;
+  };
+  changes: {
+    absolute_1d: number;
+    percent_1d: number;
+  };
+}
+
+export interface ZerionFungiblePosition {
+  type: string;
+  id: string;
+  attributes: FungibleAttributes;
+  relationships: Relationships;
+}
+
+export interface FungibleAttributes {
+  parent: null | string;
+  protocol: null | string;
+  pool_address?: string;
+  group_id?: string;
+  name: string;
+  position_type: PositionType;
+  quantity: Quantity;
+  value: number | null;
+  price: number;
+  changes: Changes | null;
+  fungible_info: FungibleInfo;
+  flags: AttributesFlags;
+  updated_at: Date;
+  updated_at_block: number | null;
+  application_metadata?: ApplicationMetadata;
+}
+
+export interface ApplicationMetadata {
+  name: string;
+  icon: Icon;
+  url: string;
+}
+
+export interface Icon {
+  url: string;
+}
+
+export interface Changes {
+  absolute_1d: number;
+  percent_1d: number;
+}
+
+export interface AttributesFlags {
+  displayable: boolean;
+  is_trash: boolean;
+}
+
+export interface FungibleInfo {
+  name: string;
+  symbol: string;
+  icon: Icon | null;
+  flags: FungibleInfoFlags;
+  implementations: Implementation[];
+}
+
+export interface FungibleInfoFlags {
+  verified: boolean;
+}
+
+export interface Implementation {
+  chain_id: string;
+  address: null | string;
+  decimals: number;
+}
+
+export enum PositionType {
+  Deposit = "deposit",
+  Reward = "reward",
+  Staked = "staked",
+  Wallet = "wallet",
+}
+
+export interface Quantity {
+  int: string;
+  decimals: number;
+  float: number;
+  numeric: string;
+}
+
+export interface Relationships {
+  chain: Chain;
+  dapp?: Dapp;
+  fungible: Chain;
+}
+
+export interface Dapp {
+  data: Data;
+}
+
+export interface Chain {
+  links: {
+    related: string;
+  };
+  data: Data;
+}
+
+export interface Data {
+  type: DataType;
+  id: string;
+}
+
+export enum DataType {
+  Chains = "chains",
+  Dapps = "dapps",
+  Fungibles = "fungibles",
+}

--- a/typescript/agentkit/src/action-providers/zerion/utils.ts
+++ b/typescript/agentkit/src/action-providers/zerion/utils.ts
@@ -1,0 +1,61 @@
+import { ZerionFungiblePosition, ZerionPortfolio } from "./types";
+
+export const formatPortfolioData = (data: ZerionPortfolio) => {
+  // Total value
+  const totalValue = data.attributes.total.positions;
+  const totalValueStr = `$${totalValue.toFixed(2)}`;
+
+  // 24h change
+  const changePercent = data.attributes.changes.percent_1d;
+  const changeStr = `${changePercent.toFixed(2)}%`;
+
+  // Positions by type (filter out 0)
+  const types = Object.entries(data.attributes.positions_distribution_by_type)
+    .filter(([_, v]) => v > 0)
+    .map(([type, value]) => `${type}: $${value.toFixed(2)}`)
+    .join(", ");
+
+  // Positions by chain (top 5 by value)
+  const topChains = Object.entries(data.attributes.positions_distribution_by_chain)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 5)
+    .map(([chain, value]) => `${chain}: $${value.toFixed(2)}`)
+    .join(", ");
+
+  // Final summary string
+  return `Wallet Portfolio Overview:
+- Total Value: ${totalValueStr}
+- 24h Change: ${changeStr}
+- Position Types: ${types}
+- Top Chains: ${topChains}`;
+};
+
+export const formatPositionsData = (data: ZerionFungiblePosition[]) => {
+  const filtered = data.filter(pos => pos.attributes.value !== null && pos.attributes.value > 1);
+
+  // Sort by value (descending)
+  const sorted = filtered.sort((a, b) => b.attributes.value! - a.attributes.value!);
+
+  const lines: string[] = [];
+  let totalValue = 0;
+
+  for (const pos of sorted) {
+    const { value, position_type, fungible_info, application_metadata } = pos.attributes;
+
+    const chain = pos.relationships.chain.data.id;
+
+    const protocolLine = application_metadata?.name ? `via ${application_metadata.name}` : "";
+
+    lines.push(
+      `- ${fungible_info.symbol} (${
+        fungible_info.name
+      }) on ${chain} — $${value!.toFixed(2)} [${position_type}${
+        protocolLine ? " " + protocolLine : ""
+      }]`,
+    );
+
+    totalValue += value!;
+  }
+
+  return `Total Value: $${totalValue.toFixed(2)}\n\nToken Positions (>$1):\n${lines.join("\n")}`;
+};

--- a/typescript/agentkit/src/action-providers/zerion/zerionActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/zerion/zerionActionProvider.test.ts
@@ -1,0 +1,239 @@
+/**
+ * ZerionActionProvider Tests
+ */
+
+import { ZerionActionProvider } from "./zerionActionProvider";
+import { Network } from "../../network";
+import { formatPortfolioData, formatPositionsData } from "./utils";
+
+// Mocks for fetch and utils
+global.fetch = jest.fn();
+jest.mock("./utils", () => ({
+  formatPortfolioData: jest.fn(() => "formatted portfolio"),
+  formatPositionsData: jest.fn(() => "formatted positions"),
+}));
+
+describe("ZerionActionProvider", () => {
+  const mockApiKey = "test-api-key";
+  const originalEnv = process.env.ZERION_API_KEY;
+
+  const mockFungiblePositionResponse = {
+    links: {
+      self: "https://api.zerion.io/v1/wallets/0x42b9df65b219b3dd36ff330a4dd8f327a6ada990/positions/",
+    },
+    data: [
+      {
+        type: "positions",
+        id: "0x111c47865ade3b172a928df8f990bc7f2a3b9aaa-polygon-asset-none-",
+        attributes: {
+          parent: "0x111c47865ade3b172a928df8f990bc7f2a3b9aaa-polygon-asset-none-",
+          protocol: null,
+          pool_address: "0x109830a1aaad605bbf02a9dfa7b0b92ec2fb7daa",
+          name: "Asset",
+          group_id: "0a771a0064dad468045899032c7fb01a971f973f7dff0a5cdc3ce199f45e94d7",
+          position_type: "deposit",
+          quantity: {
+            int: "12345678",
+            decimals: 5,
+            float: 123.45678,
+            numeric: "123.45678",
+          },
+          value: 5.384656557642683,
+          price: 0.043615722,
+          changes: {
+            absolute_1d: 0.272309794,
+            percent_1d: 5.326512552079021,
+          },
+          fungible_info: {
+            name: "Bankless BED Index",
+            symbol: "BED",
+            description: "The BED index is meant to track crypto’s top 3 investab...",
+            icon: {
+              url: "https://token-icons.s3.amazonaws.com/0x0391d2021f89dc339f60fff84546ea23e337750f.png",
+            },
+            flags: {
+              verified: true,
+            },
+            implementations: [
+              {
+                chain_id: "ethereum",
+                address: "0x2af1df3ab0ab157e1e2ad8f88a7d04fbea0c7dc6",
+                decimals: 18,
+              },
+            ],
+          },
+          flags: {
+            displayable: true,
+            is_trash: true,
+          },
+          updated_at: "2023-11-10T23:00:00Z",
+          updated_at_block: 0,
+          application_metadata: {
+            name: "AAVE",
+            icon: {
+              url: "https://token-icons.s3.amazonaws.com/0x0391d2021f89dc339f60fff84546ea23e337750f.png",
+            },
+            url: "https://app.aave.com/",
+          },
+        },
+        relationships: {
+          chain: {
+            links: {
+              related: "https://api.zerion.io/v1/chains/polygon",
+            },
+            data: {
+              type: "chains",
+              id: "polygon",
+            },
+          },
+          fungible: {
+            links: {
+              related:
+                "https://api.zerion.io/v1/fungibles/0x111c47865ade3b172a928df8f990bc7f2a3b9aaa",
+            },
+            data: {
+              type: "fungibles",
+              id: "0x111c47865ade3b172a928df8f990bc7f2a3b9aaa",
+            },
+          },
+          dapp: {
+            data: {
+              type: "dapps",
+              id: "aave-v3",
+            },
+          },
+        },
+      },
+    ],
+  };
+
+  const mockPortfolioResponse = {
+    links: {
+      self: "https://api.zerion.io/v1/wallets/0x42b9df65b219b3dd36ff330a4dd8f327a6ada990/portfolio",
+    },
+    data: {
+      type: "portfolio",
+      id: "0x42b9df65b219b3dd36ff330a4dd8f327a6ada990",
+      attributes: {
+        positions_distribution_by_type: {
+          wallet: 1864.774102420957,
+          deposited: 78.04192492782934,
+          borrowed: 0.9751475798305564,
+          locked: 5.780032725068765,
+          staked: 66.13183205505294,
+        },
+        positions_distribution_by_chain: {
+          arbitrum: 458.3555051522226,
+          aurora: 72.01031337463428,
+          avalanche: 17.128850607339444,
+          base: 55.01550749900544,
+          "binance-smart-chain": 5.561075880033699,
+          celo: 31.293849330045006,
+          ethereum: 1214.009900354964,
+          fantom: 84.58514074264951,
+          linea: 8.258227109505139,
+          optimism: 573.032664994399,
+          polygon: 64.31407562634853,
+          xdai: 113.1679493137936,
+          "zksync-era": 9.451002156306377,
+        },
+        total: {
+          positions: 2017.4858230069574,
+        },
+        changes: {
+          absolute_1d: 102.0271468171374,
+          percent_1d: 5.326512552079021,
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ZERION_API_KEY = mockApiKey;
+  });
+
+  afterAll(() => {
+    process.env.ZERION_API_KEY = originalEnv;
+  });
+
+  it("should throw if no API key is provided", () => {
+    delete process.env.ZERION_API_KEY;
+    expect(() => new ZerionActionProvider()).toThrow("ZERION_API_KEY is not configured.");
+  });
+
+  it("should use provided API key from config", () => {
+    const provider = new ZerionActionProvider({ apiKey: "foo" });
+    expect(provider).toBeDefined();
+  });
+
+  // supportsNetwork tests
+  const provider = new ZerionActionProvider({ apiKey: mockApiKey });
+
+  it("should support the protocol family", () => {
+    expect(provider.supportsNetwork({ protocolFamily: "evm" } as Network)).toBe(true);
+  });
+
+  it("should not support other protocol families", () => {
+    expect(provider.supportsNetwork({ protocolFamily: "other-protocol-family" } as Network)).toBe(
+      false,
+    );
+  });
+
+  it("should handle invalid network objects", () => {
+    expect(provider.supportsNetwork({ protocolFamily: "invalid-protocol" } as Network)).toBe(false);
+    expect(provider.supportsNetwork({} as Network)).toBe(false);
+  });
+
+  describe("getPortfolioOverview", () => {
+    const validAddress = "0x42b9df65b219b3dd36ff330a4dd8f327a6ada990";
+    const invalidAddress = "invalid-address";
+    const provider = new ZerionActionProvider({ apiKey: mockApiKey });
+
+    it("returns error for invalid address", async () => {
+      const result = await provider.getPortfolioOverview({ walletAddress: invalidAddress });
+      expect(result).toMatch(/Invalid wallet address/);
+    });
+
+    it("returns formatted data for valid address", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: jest.fn().mockResolvedValue(mockPortfolioResponse),
+      });
+      const result = await provider.getPortfolioOverview({ walletAddress: validAddress });
+      expect(formatPortfolioData).toHaveBeenCalledWith(mockPortfolioResponse.data);
+      expect(result).toBe("formatted portfolio");
+    });
+
+    it("returns error on fetch failure", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("fail"));
+      const result = await provider.getPortfolioOverview({ walletAddress: validAddress });
+      expect(result).toMatch(/Error fetching portfolio overview/);
+    });
+  });
+
+  describe("getFungiblePositions", () => {
+    const validAddress = "0x42b9df65b219b3dd36ff330a4dd8f327a6ada990";
+    const invalidAddress = "invalid-address";
+    const provider = new ZerionActionProvider({ apiKey: mockApiKey });
+
+    it("returns error for invalid address", async () => {
+      const result = await provider.getFungiblePositions({ walletAddress: invalidAddress });
+      expect(result).toMatch(/Invalid wallet address/);
+    });
+
+    it("returns formatted data for valid address", async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: jest.fn().mockResolvedValue(mockFungiblePositionResponse),
+      });
+      const result = await provider.getFungiblePositions({ walletAddress: validAddress });
+      expect(formatPositionsData).toHaveBeenCalledWith(mockFungiblePositionResponse.data);
+      expect(result).toBe("formatted positions");
+    });
+
+    it("returns error on fetch failure", async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("fail"));
+      const result = await provider.getFungiblePositions({ walletAddress: validAddress });
+      expect(result).toMatch(/Error fetching fungible positions/);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/zerion/zerionActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/zerion/zerionActionProvider.ts
@@ -1,0 +1,182 @@
+/**
+ * Zerion Action Provider
+ *
+ * This file contains the implementation of the ZerionActionProvider,
+ * which provides actions for zerion operations.
+ *
+ * @module zerion
+ */
+
+import { isAddress } from "viem";
+import { z } from "zod";
+import { Network } from "../../network";
+import { CreateAction } from "../actionDecorator";
+import { ActionProvider } from "../actionProvider";
+import { ZERION_V1_BASE_URL } from "./constants";
+import { GetWalletPortfolioSchema } from "./schemas";
+import { ZerionFungiblePositionsResponse, ZerionPortfolioResponse } from "./types";
+import { formatPortfolioData, formatPositionsData } from "./utils";
+
+/**
+ * Configuration options for the ZerionActionProvider.
+ */
+export interface ZerionActionProviderConfig {
+  /**
+   * Zerion API Key. Request new at https://zerion.io/api
+   */
+  apiKey?: string;
+}
+
+/**
+ * ZerionActionProvider provides actions for zerion operations.
+ *
+ * @description
+ * This provider is designed to provide blockchain-agnostic operations.
+ * It supports all blockchain networks.
+ */
+export class ZerionActionProvider extends ActionProvider {
+  private readonly apiKey: string;
+
+  /**
+   * Constructor for the ZerionActionProvider.
+   *
+   * @param config - The configuration options for the ZerionActionProvider.
+   */
+  constructor(config: ZerionActionProviderConfig = {}) {
+    super("zerion", []);
+
+    const apiKey = config.apiKey || process.env.ZERION_API_KEY;
+    if (!apiKey) {
+      throw new Error("ZERION_API_KEY is not configured.");
+    }
+    const encodedKey = Buffer.from(`${apiKey}:`).toString("base64");
+    this.apiKey = encodedKey;
+  }
+
+  /**
+   * Example action implementation.
+   * Replace or modify this with your actual action.
+   *
+   * @description
+   * This is a template action that demonstrates the basic structure.
+   * Replace it with your actual implementation.
+   *
+   * @param args - Arguments defined by GetWalletPortfolioSchema
+   * @returns A promise that resolves to a string describing the action result
+   */
+  @CreateAction({
+    name: "get_portfolio_overview",
+    description: `
+    Fetches and summarizes a crypto wallet's portfolio in USD. 
+    The tool returns a human-readable overview of the wallet's total value, value distribution across blockchains, position types (e.g., staked, deposited), and 24-hour performance change. 
+    Useful for providing quick insights into a wallet's DeFi and cross-chain holdings.
+
+    Input:
+    - walletAddress: The wallet address to fetch portfolio overview for.
+
+    Output a structured text summary with:
+    - Total portfolio value in USD
+    - 24h percentage change in value
+    - Breakdown of value by position types (e.g., wallet, deposited, staked, locked, borrowed)
+    - Top 5 chains by value distribution
+  `,
+    schema: GetWalletPortfolioSchema,
+  })
+  async getPortfolioOverview(args: z.infer<typeof GetWalletPortfolioSchema>): Promise<string> {
+    try {
+      const address = args.walletAddress || "";
+      if (!isAddress(address)) {
+        return `Invalid wallet address: ${address}`;
+      }
+      const options = {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          authorization: `Basic ${this.apiKey}`,
+        },
+      };
+
+      const url = `${ZERION_V1_BASE_URL}/wallets/${args.walletAddress}/portfolio?filter[positions]=no_filter&currency=usd`;
+      const response = await fetch(url, options);
+      const { data }: ZerionPortfolioResponse = await response.json();
+
+      return formatPortfolioData(data);
+    } catch (error) {
+      return `Error fetching portfolio overview for wallet ${args.walletAddress}: ${error}`;
+    }
+  }
+
+  /**
+   * Example action implementation.
+   * Replace or modify this with your actual action.
+   *
+   * @description
+   * This is a template action that demonstrates the basic structure.
+   * Replace it with your actual implementation.
+   *
+   * @param args - Arguments defined by GetWalletPortfolioSchema
+   * @returns A promise that resolves to a string describing the action result
+   */
+  @CreateAction({
+    name: "get_fungible_positions",
+    description: `
+    Retrieves and summarizes a wallet's fungible token holdings with values greater than $1. 
+    For each token, it includes metadata such as symbol, name, holding value, associated protocol (if applicable), and the type of position (e.g., deposit, wallet, reward). 
+    The summary also reports the total USD value of all qualifying token positions.
+
+    Input:
+    - walletAddress: The wallet address to fetch fungible positions for.
+
+    Output a readable text summary including:
+    - All token positions worth more than $1
+    - For each: token name, symbol, USD value, chain, position type
+    - If applicable: protocol used and type of action (e.g. staked, deposited via protocol)
+    - A final total value in USD across all included positions
+  `,
+    schema: GetWalletPortfolioSchema,
+  })
+  async getFungiblePositions(args: z.infer<typeof GetWalletPortfolioSchema>): Promise<string> {
+    try {
+      const address = args.walletAddress || "";
+      if (!isAddress(address)) {
+        return `Invalid wallet address: ${address}`;
+      }
+
+      const options = {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          authorization: `Basic ${this.apiKey}`,
+        },
+      };
+
+      const url = `${ZERION_V1_BASE_URL}/wallets/${args.walletAddress}/positions?filter[positions]=no_filter&currency=usd&filter[trash]=only_non_trash&sort=value`;
+      const response = await fetch(url, options);
+      const { data }: ZerionFungiblePositionsResponse = await response.json();
+
+      return formatPositionsData(data);
+    } catch (error) {
+      return `Error fetching fungible positions for wallet ${args.walletAddress}: ${error}`;
+    }
+  }
+
+  /**
+   * Checks if this provider supports the given network.
+   *
+   * @param network - The network to check support for
+   * @returns True if the network is supported
+   */
+  supportsNetwork(network: Network): boolean {
+    // all protocol networks
+    return network.protocolFamily === "evm";
+  }
+}
+
+/**
+ * Factory function to create a new ZerionActionProvider instance.
+ *
+ * @param config - The configuration options for the ZerionActionProvider.
+ * @returns A new ZerionActionProvider instance
+ */
+export const zerionActionProvider = (config?: ZerionActionProviderConfig) =>
+  new ZerionActionProvider(config);


### PR DESCRIPTION
<!--
Thanks for contributing to AgentKit!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
 -->
- Integrate 2 Zerion API endpoints for portfolio fetching
  - `get_portfolio_overview`: Get aggregated USD balance of a wallet address
  - `get_fungible_positions`: Get aggregated token positions (wallet and DeFi) of a wallet address

Requirement: Zerion API key

## Example

- `get_portfolio_overview`
```
Wallet Portfolio Overview:
- Total Value: $3267.53
- 24h Change: -0.63%
- Position Types: wallet: $497.17, deposited: $2138.66, staked: $631.65
- Top Chains: unichain: $2179.59, base: $815.98, ethereum: $270.11, polygon: $0.85, abstract: $0.58
```
- `get_fungible_positions`
```
Total Value: $3762.01

Token Positions (>$1):
- ETH (Ethereum) on unichain — $1134.21 [deposit via Uniswap V4]
- USD₮0 (USD₮0) on unichain — $1004.22 [deposit via Uniswap V4]
- WELL (WELL) on base — $630.55 [staked via Moonwell]
- MORPHO (Morpho Token) on base — $497.49 [deposit via Moonwell]
- ETH (Ethereum) on ethereum — $268.30 [wallet]
- ETH (Ethereum) on base — $182.84 [wallet]
- ETH (Ethereum) on unichain — $40.94 [wallet]
- UNI (Uniswap) on ethereum — $1.92 [wallet]
- ALCH (Alchemist Accelerate) on base — $1.54 [wallet]
```

## Tests
```
 PASS  src/action-providers/zerion/zerionActionProvider.test.ts (8.381 s)
  ZerionActionProvider
    ✓ should throw if no API key is provided (10 ms)
    ✓ should use provided API key from config
    ✓ should support the protocol family
    ✓ should not support other protocol families
    ✓ should handle invalid network objects
    getPortfolioOverview
      ✓ returns error for invalid address
      ✓ returns formatted data for valid address (1 ms)
      ✓ returns error on fetch failure
    getFungiblePositions
      ✓ returns error for invalid address (1 ms)
      ✓ returns formatted data for valid address
      ✓ returns error on fetch failure
```

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry

