### PR TITLE
fix: assigning gas estimations and chainId in sendTransaction

### DIFF
--- a/typescript/agentkit/src/wallet-providers/cdpV2Shared.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpV2Shared.ts
@@ -46,3 +46,20 @@ export interface WalletProviderWithClient {
    */
   getClient(): CdpClient;
 }
+
+/**
+ * Type guard to check if a wallet provider implements WalletProviderWithClient interface.
+ *
+ * @param provider - The provider to check
+ * @returns True if the provider implements WalletProviderWithClient
+ */
+export function isWalletProviderWithClient(
+  provider: unknown,
+): provider is WalletProviderWithClient {
+  return (
+    provider !== null &&
+    typeof provider === "object" &&
+    "getClient" in provider &&
+    typeof (provider as WalletProviderWithClient).getClient === "function"
+  );
+}


### PR DESCRIPTION
Assigning gas estimations and chain id in sendTransaction to ensure they are EIP1559 transactions.

Tested locally via confirming the issue existed leveraging the wrap eth to weth action, and then ensuring it worked locally after the above changes.

Note: I noticed the `CdpV2ApiActionProvider` was finicky about injecting the wallet provider. This is because my custom type was failing the `=== WalletProvider` check in certain environments (worked with vercel ai agents, but was finicky in langchain). I refactor to a type guard.