### PR TITLE
docs: Update agentkit link README.md

### DIFF
--- a/python/framework-extensions/langchain/README.md
+++ b/python/framework-extensions/langchain/README.md
@@ -47,7 +47,7 @@ agent = create_react_agent(
 
 For AgentKit configuration options, see the [Coinbase Agentkit README](https://github.com/coinbase/agentkit/blob/master/python/coinbase-agentkit/README.md).
 
-For a full example, see the [chatbot example](https://github.com/coinbase/agentkit/blob/master/python/examples/langchain-smart-wallet-chatbot/chatbot.py).
+For a full example, see the [chatbot example](https://github.com/coinbase/agentkit/blob/main/python/examples/langchain-cdp-smart-wallet-chatbot/chatbot.py).
 
 ## Contributing
 


### PR DESCRIPTION
Updated the reference URL for the chatbot example to point to the correct location. The previous link was pointing to a non-existent path causing a 404 error. This change ensures users can access the proper example when learning how to implement AgentKit with LangChain.