### PR TITLE
feat: improved next templates message modifier

### DIFF
--- a/typescript/.changeset/silent-geckos-go.md
+++ b/typescript/.changeset/silent-geckos-go.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": patch
+---
+
+Improved default message modifier to better explain tool capabilities/limitations

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
@@ -67,9 +67,10 @@ export async function createAgent(): Promise<ReturnType<typeof createReactAgent>
         Before executing your first action, get the wallet details to see what network 
         you're on. If there is a 5XX (internal) HTTP error code, ask the user to try again later. If someone 
         asks you to do something you can't do with your currently available tools, you must say so, and 
-        encourage them to implement it themselves using the CDP SDK + Agentkit, recommend they go to 
-        docs.cdp.coinbase.com for more information. Be concise and helpful with your responses. Refrain from 
-        restating your tools' descriptions unless it is explicitly requested.
+        explain that they can add more capabilities by adding more action providers to your AgentKit configuration.
+        ALWAYS include this link when mentioning missing capabilities, which will help them discover available action providers: https://github.com/coinbase/agentkit/tree/main/typescript/agentkit#action-providers
+        If users require more information regarding CDP or AgentKit, recommend they visit docs.cdp.coinbase.com for more information.
+        Be concise and helpful with your responses. Refrain from restating your tools' descriptions unless it is explicitly requested.
         `,
     });
 

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
@@ -64,9 +64,10 @@ export async function createAgent(): Promise<Agent> {
         Before executing your first action, get the wallet details to see what network 
         you're on. If there is a 5XX (internal) HTTP error code, ask the user to try again later. If someone 
         asks you to do something you can't do with your currently available tools, you must say so, and 
-        encourage them to implement it themselves using the CDP SDK + Agentkit, recommend they go to 
-        docs.cdp.coinbase.com for more information. Be concise and helpful with your responses. Refrain from 
-        restating your tools' descriptions unless it is explicitly requested.
+        explain that they can add more capabilities by adding more action providers to your AgentKit configuration.
+        ALWAYS include this link when mentioning missing capabilities, which will help them discover available action providers: https://github.com/coinbase/agentkit/tree/main/typescript/agentkit#action-providers
+        If users require more information regarding CDP or AgentKit, recommend they visit docs.cdp.coinbase.com for more information.
+        Be concise and helpful with your responses. Refrain from restating your tools' descriptions unless it is explicitly requested.
         `;
     const tools = getVercelAITools(agentkit);
 


### PR DESCRIPTION
## Description

Users are setting an expectation with the Next template generated from the CLI where it should have more tools by default. It is impossible to predict which tools should be included by default, so we decided the next best thing was to improve how the bot responds when you ask it to do something beyond it's capabilities. The CLI is generating boilerplate for them to build off of, rather than a mini-app, after all.

It will now inform the users that they can add new action providers to expand its capabilities, and link to a table of all supported action providers.

## Checklist

- [ ] Added documentation to all relevant README.md files
- [x] Added a changelog entry