### PR TITLE
Fix broken Solana web3.js documentation link in README

### DIFF
--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -1024,7 +1024,7 @@ The `CdpV2SolanaWalletProvider` supports the following Solana networks:
 
 ### SolanaKeypairWalletProvider
 
-The `SolanaKeypairWalletProvider` is a wallet provider that uses the API [Solana web3.js](https://solana-labs.github.io/solana-web3.js/).
+The `SolanaKeypairWalletProvider` is a wallet provider that uses the API [Solana web3.js](https://solana.com/docs/clients/javascript).
 
 NOTE: It is highly recommended to use a dedicated RPC provider. See [here](https://solana.com/rpc) for more info on Solana RPC infrastructure, and see [here](#rpc-url-configuration) for instructions on configuring `SolanaKeypairWalletProvider` with a custom RPC URL.
 


### PR DESCRIPTION
Replaced the outdated and broken link to the Solana web3.js documentation (https://solana-labs.github.io/solana-web3.js/) with the official and up-to-date Solana JavaScript SDK documentation (https://solana.com/docs/clients/javascript) in the README. This ensures users have access to the latest resources and usage examples for Solana web3.js.

