### PR TITLE
fix: ignore templates

### DIFF
--- a/typescript/.changeset/config.json
+++ b/typescript/.changeset/config.json
@@ -8,7 +8,7 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,
-  "ignore": ["@coinbase/*-example", "mcp", "next-template"],
+  "ignore": ["@coinbase/*-example"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }

--- a/typescript/.changeset/dirty-candies-thank.md
+++ b/typescript/.changeset/dirty-candies-thank.md
@@ -1,5 +1,0 @@
----
-"next-template": patch
----
-
-Add next-template to workspace


### PR DESCRIPTION
We are temporarily ignoring the templates under the create-onchain-agent CLI, until after this release. However, the way we ignored it broke changeset validation's ignore: https://github.com/coinbase/agentkit/actions/runs/15324606781/job/43115854116

This PR temporarily fixes it so that the automated flow can proceed