### PR TITLE
chore: bump python packages

### DIFF
--- a/python/create-onchain-agent/CHANGELOG.md
+++ b/python/create-onchain-agent/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!-- towncrier release notes start -->
 
+## [0.7.0] - 2025-05-30
+
+### Added
+
+- Bump coinbase-agentkit to 0.6.0 in beginner template and chatbot template
+- Bump coinbase-agentkit-langchain to 0.5.0 in beginner template and chatbot template
+- Bump coinbase-agentkit-openai-agents-sdk to 0.5.0 in beginner template and chatbot template
+- Renamed CDP env vars to modern naming convention
+
+
 ## [0.6.1] - 2025-05-15
 
 ### Added

--- a/python/create-onchain-agent/changelog.d/+4cc563fc.feature.md
+++ b/python/create-onchain-agent/changelog.d/+4cc563fc.feature.md
@@ -1,1 +1,0 @@
-Renamed CDP env vars to modern naming convention

--- a/python/create-onchain-agent/pyproject.toml
+++ b/python/create-onchain-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "create-onchain-agent"
-version = "0.6.1"
+version = "0.7.0"
 description = "CLI to create an onchain agent project"
 authors = [{ name = "Carson Roscoe", email = "carsonroscoe7@gmail.com" }]
 requires-python = ">=3.10"

--- a/python/create-onchain-agent/templates/beginner/pyproject.toml.jinja
+++ b/python/create-onchain-agent/templates/beginner/pyproject.toml.jinja
@@ -9,11 +9,11 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = "^1.0.1"
-coinbase-agentkit = "^0.5.1"
+coinbase-agentkit = "^0.6.0"
 {% if _framework == "langchain" %}langchain-openai = "^0.2.4"
 langgraph = "^0.2.39"
-coinbase-agentkit-langchain = "0.4.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
-coinbase-agentkit-openai-agents-sdk = "0.4.0"
+coinbase-agentkit-langchain = "0.5.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
+coinbase-agentkit-openai-agents-sdk = "0.5.0"
 openai = "1.68.0"{% endif %}
 {% if _wallet_provider == "server" or _wallet_provider == "smart"%}cdp-sdk = "1.6.1"{% endif %}
 

--- a/python/create-onchain-agent/templates/chatbot/pyproject.toml.jinja
+++ b/python/create-onchain-agent/templates/chatbot/pyproject.toml.jinja
@@ -9,11 +9,11 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = "^1.0.1"
-coinbase-agentkit = "^0.5.1"
+coinbase-agentkit = "^0.6.0"
 {% if _framework == "langchain" %}langchain-openai = "^0.2.4"
 langgraph = "^0.2.39"
-coinbase-agentkit-langchain = "0.4.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
-coinbase-agentkit-openai-agents-sdk = "0.4.0"
+coinbase-agentkit-langchain = "0.5.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
+coinbase-agentkit-openai-agents-sdk = "0.5.0"
 openai = "1.68.0"{% endif %}
 {% if _wallet_provider == "server" or _wallet_provider == "smart"%}cdp-sdk = "1.6.1"{% endif %}
 

--- a/python/create-onchain-agent/uv.lock
+++ b/python/create-onchain-agent/uv.lock
@@ -128,7 +128,7 @@ wheels = [
 
 [[package]]
 name = "create-onchain-agent"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/python/examples/langchain-cdp-chatbot-with-aws-bedrock/uv.lock
+++ b/python/examples/langchain-cdp-chatbot-with-aws-bedrock/uv.lock
@@ -690,7 +690,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -701,7 +701,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-cdp-server-chatbot/uv.lock
+++ b/python/examples/langchain-cdp-server-chatbot/uv.lock
@@ -658,7 +658,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -669,7 +669,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-cdp-smart-wallet-chatbot/uv.lock
+++ b/python/examples/langchain-cdp-smart-wallet-chatbot/uv.lock
@@ -658,7 +658,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -669,7 +669,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-eth-account-chatbot/uv.lock
+++ b/python/examples/langchain-eth-account-chatbot/uv.lock
@@ -658,7 +658,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -669,7 +669,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-nillion-secretvault-chatbot/uv.lock
+++ b/python/examples/langchain-nillion-secretvault-chatbot/uv.lock
@@ -658,7 +658,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -669,7 +669,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-twitter-chatbot/uv.lock
+++ b/python/examples/langchain-twitter-chatbot/uv.lock
@@ -660,7 +660,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -671,7 +671,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/openai-agents-sdk-cdp-chatbot/uv.lock
+++ b/python/examples/openai-agents-sdk-cdp-chatbot/uv.lock
@@ -625,7 +625,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/openai-agents-sdk" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -638,7 +638,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },

--- a/python/examples/openai-agents-sdk-cdp-voice-chatbot/uv.lock
+++ b/python/examples/openai-agents-sdk-cdp-voice-chatbot/uv.lock
@@ -625,7 +625,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/openai-agents-sdk" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -638,7 +638,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },

--- a/python/examples/openai-agents-sdk-smart-wallet-chatbot/uv.lock
+++ b/python/examples/openai-agents-sdk-smart-wallet-chatbot/uv.lock
@@ -625,7 +625,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "../../framework-extensions/openai-agents-sdk" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -638,7 +638,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },

--- a/python/framework-extensions/langchain/CHANGELOG.md
+++ b/python/framework-extensions/langchain/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## [0.5.0] - 2025-05-30
+
+### Added
+
+- Bump coinbase-agentkit to 0.6.0
+
+
 ## [0.4.0] - 2025-05-14
 
 ### Added

--- a/python/framework-extensions/langchain/docs/conf.py
+++ b/python/framework-extensions/langchain/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = 'Coinbase Agentkit LangChain'
 author = 'Coinbase Developer Platform'
-release = '0.4.0'
+release = '0.5.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/python/framework-extensions/langchain/pyproject.toml
+++ b/python/framework-extensions/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 description = "Coinbase AgentKit LangChain extension"
 authors = [{ name = "John Peterson", email = "john.peterson@coinbase.com" }]
 requires-python = "~=3.10"
@@ -17,7 +17,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit>=0.5.0,<0.7",
+    "coinbase-agentkit>=0.6.0,<0.7",
     "langchain>=0.3.4,<0.4",
     "python-dotenv>=1.0.1,<2",
     "nest-asyncio>=1.5.8,<2",

--- a/python/framework-extensions/langchain/uv.lock
+++ b/python/framework-extensions/langchain/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "coinbase-agentkit"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "allora-sdk" },
@@ -634,14 +634,14 @@ dependencies = [
     { name = "requests" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/ce/1bceddd7002df44c1be1644d294e23ec46ee7669a282f01d9e51fd30ca8a/coinbase_agentkit-0.5.0.tar.gz", hash = "sha256:0a8dc2aafcf64fc6bcfc053e2c4c96b89bff85eb125ea220fc6e35131d9f6556", size = 102628 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e1/6a21afddfffe91b53b6865bae9e6a910b4d595eb05feab25e59a382e6242/coinbase_agentkit-0.6.0.tar.gz", hash = "sha256:b0700af4a3a736254dc1f308d3673e238817067fdee91b5e5d44c9e7fda7052f", size = 102816 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/f3/13ff4e122b42ccff42551dd3d01828c2080a3ad4d3051f4a92bc70a16601/coinbase_agentkit-0.5.0-py3-none-any.whl", hash = "sha256:85fd55803796ba29a3c24b359b5d6e3841aa190eee409ce8b945738678228b84", size = 162806 },
+    { url = "https://files.pythonhosted.org/packages/85/35/76010c76941a8a0f47e1d49ffc0cd1ec0eac5a6746eca9bb7a59c388ccb9/coinbase_agentkit-0.6.0-py3-none-any.whl", hash = "sha256:9847a4037accd0de25743fd8b941ca4666715454db0146a809030f9b80d31535", size = 163009 },
 ]
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -669,7 +669,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/framework-extensions/openai-agents-sdk/CHANGELOG.md
+++ b/python/framework-extensions/openai-agents-sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## [0.5.0] - 2025-05-30
+
+### Added
+
+- Bump coinbase-agentkit to 0.6.0
+
+
 ## [0.4.0] - 2025-05-14
 
 ### Added

--- a/python/framework-extensions/openai-agents-sdk/pyproject.toml
+++ b/python/framework-extensions/openai-agents-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.4.0"
+version = "0.5.0"
 description = "Coinbase AgentKit OpenAI Agents SDK extension"
 authors = [{ name = "John Peterson", email = "john.peterson@coinbase.com" }]
 requires-python = "~=3.10"
@@ -17,7 +17,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit>=0.5.0,<0.7",
+    "coinbase-agentkit>=0.6.0,<0.7",
     "python-dotenv>=1.0.1,<2",
     "pytest-asyncio>=0.25.3,<0.26",
     "openai-agents>=0.0.6,<0.0.7",

--- a/python/framework-extensions/openai-agents-sdk/uv.lock
+++ b/python/framework-extensions/openai-agents-sdk/uv.lock
@@ -618,7 +618,7 @@ wheels = [
 
 [[package]]
 name = "coinbase-agentkit"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "allora-sdk" },
@@ -633,14 +633,14 @@ dependencies = [
     { name = "requests" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/ce/1bceddd7002df44c1be1644d294e23ec46ee7669a282f01d9e51fd30ca8a/coinbase_agentkit-0.5.0.tar.gz", hash = "sha256:0a8dc2aafcf64fc6bcfc053e2c4c96b89bff85eb125ea220fc6e35131d9f6556", size = 102628 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e1/6a21afddfffe91b53b6865bae9e6a910b4d595eb05feab25e59a382e6242/coinbase_agentkit-0.6.0.tar.gz", hash = "sha256:b0700af4a3a736254dc1f308d3673e238817067fdee91b5e5d44c9e7fda7052f", size = 102816 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/f3/13ff4e122b42ccff42551dd3d01828c2080a3ad4d3051f4a92bc70a16601/coinbase_agentkit-0.5.0-py3-none-any.whl", hash = "sha256:85fd55803796ba29a3c24b359b5d6e3841aa190eee409ce8b945738678228b84", size = 162806 },
+    { url = "https://files.pythonhosted.org/packages/85/35/76010c76941a8a0f47e1d49ffc0cd1ec0eac5a6746eca9bb7a59c388ccb9/coinbase_agentkit-0.6.0-py3-none-any.whl", hash = "sha256:9847a4037accd0de25743fd8b941ca4666715454db0146a809030f9b80d31535", size = 163009 },
 ]
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -670,7 +670,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.5.0,<0.7" },
+    { name = "coinbase-agentkit", specifier = ">=0.6.0,<0.7" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },


### PR DESCRIPTION
Now that `coinbase-agentkit` version `0.6.0` is released, we can deploy the dependent packages.

`coinbase-agentkit-langchain` was bumped to `0.5.0`
`coinbase-agentkit-openai-agents-sdk` was bumped to `0.5.0`
`create-onchain-agent` was bumped to `0.7.0`