### PR TITLE
Fix typo: "persistance" → "persistence" in CHANGELOG

### DIFF
--- a/typescript/create-onchain-agent/CHANGELOG.md
+++ b/typescript/create-onchain-agent/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ### Fixed
 
-- [#484](https://github.com/coinbase/agentkit/pull/484) [`a1dcd3f`](https://github.com/coinbase/agentkit/commit/a1dcd3fa32dac78a91eb99938e5608672ca005ee) Thanks [@CarsonRoscoe](https://github.com/CarsonRoscoe)! - Added wallet persistance to all templates
+- [#484](https://github.com/coinbase/agentkit/pull/484) [`a1dcd3f`](https://github.com/coinbase/agentkit/commit/a1dcd3fa32dac78a91eb99938e5608672ca005ee) Thanks [@CarsonRoscoe](https://github.com/CarsonRoscoe)! - Added wallet persistence to all templates
 
 - [#468](https://github.com/coinbase/agentkit/pull/468) [`b13c5e6`](https://github.com/coinbase/agentkit/commit/b13c5e685ebeed1d00963286067da1a106b18d37) Thanks [@CarsonRoscoe](https://github.com/CarsonRoscoe)! - Fixed CDP env vars being required, when some cases are optional
 


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the CHANGELOG file, changing "persistance" to the correct spelling "persistence" in the entry for wallet persistence in all templates. No other changes were made.

