### PR TITLE
fix elizaos-plugins reference

### DIFF
--- a/CONTRIBUTING-TYPESCRIPT.md
+++ b/CONTRIBUTING-TYPESCRIPT.md
@@ -218,7 +218,7 @@ Actions are necessary building blocks powering onchain AI applications, but they
 Integrations into AI Agent frameworks are specific to the framework itself, so we can't go into specific implementation details here, but we can offer up some examples and tips.
 
 - Check out how [AgentKit actions are mapped into LangChain Tools](https://github.com/coinbase/agentkit/blob/master/typescript/framework-extensions/langchain/src/index.ts)
-- Check out how [AgentKit Actions are mapped into Eliza Actions](https://github.com/elizaOS/eliza/blob/develop/packages/plugin-agentkit/src/actions.ts#L31)
+- Check out how [AgentKit Actions are mapped into Eliza Actions](https://github.com/elizaos-plugins/plugin-agentkit/blob/main/src/actions.ts#L25)
 
 ## Testing
 


### PR DESCRIPTION
Hey devs, fixed reference in CONTRIBUTING-TYPESCRIPT.md

https://github.com/elizaOS/eliza/blob/develop/packages/plugin-agentkit/src/actions.ts#L31 - fix dead reference
https://github.com/elizaos-plugins/plugin-agentkit/blob/main/src/actions.ts#L25 - new link