### PR TITLE
fix: bug in configureWithWallet config

### DIFF
--- a/typescript/.changeset/short-carpets-share.md
+++ b/typescript/.changeset/short-carpets-share.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": patch
+---
+
+Fixed a bug in wallet config

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/agentkit/evm/smart/prepare-agentkit.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/agentkit/evm/smart/prepare-agentkit.ts
@@ -102,8 +102,7 @@ export async function prepareAgentkitAndWalletProvider(): Promise<{
       networkId: process.env.NETWORK_ID || "base-sepolia",
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       owner: owner as any,
-      smartWalletAddress: walletData?.smartWalletAddress,
-      paymasterUrl: undefined, // Sponsor transactions: https://docs.cdp.coinbase.com/paymaster/docs/welcome
+      address: walletData?.smartWalletAddress,
     });
 
     // Initialize AgentKit: https://docs.cdp.coinbase.com/agentkit/docs/agent-actions


### PR DESCRIPTION
create-onchain-agent next template (smart wallet) build fails with:
```
./app/api/agent/prepare-agentkit.ts:105:7
Type error: Object literal may only specify known properties, and 'smartWalletAddress' does not exist in type 'CdpSmartWalletProviderConfig'.

  103 |       // eslint-disable-next-line @typescript-eslint/no-explicit-any
  104 |       owner: owner as any,
 105 |       smartWalletAddress: walletData?.smartWalletAddress,
  106 |       paymasterUrl: undefined, // Sponsor transactions: https://docs.cdp.coinbase.com/paymaster/docs/welcome
  107 |     });
  108 |
```

This PR fixes the config following the implementation in the corresponding chatbot example: https://github.com/coinbase/agentkit/blob/main/typescript/examples/langchain-cdp-smart-wallet-chatbot/chatbot.ts
