### PR TITLE
chore: update strands to use deployed agentkit v0.7.1

### DIFF
--- a/python/examples/strands-agents-cdp-server-chatbot/uv.lock
+++ b/python/examples/strands-agents-cdp-server-chatbot/uv.lock
@@ -713,7 +713,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", editable = "../../coinbase-agentkit" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.1,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "strands-agents", specifier = ">=1.0.1" },

--- a/python/framework-extensions/strands-agents/pyproject.toml
+++ b/python/framework-extensions/strands-agents/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit",
+    "coinbase-agentkit>=0.7.1,<0.8",
     "python-dotenv>=1.0.1,<2",
     "nest-asyncio>=1.5.8,<2",
     "strands-agents>=1.0.1", 
@@ -87,9 +87,5 @@ name = "Added"
 
 [tool.towncrier.fragment.bugfix]
 name = "Fixed"
-
-[tool.uv.sources]
-coinbase-agentkit = { path = "../../coinbase-agentkit", editable = true }
-
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/python/framework-extensions/strands-agents/uv.lock
+++ b/python/framework-extensions/strands-agents/uv.lock
@@ -678,7 +678,7 @@ wheels = [
 [[package]]
 name = "coinbase-agentkit"
 version = "0.7.1"
-source = { editable = "../../coinbase-agentkit" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cdp-sdk" },
     { name = "ecdsa" },
@@ -694,45 +694,9 @@ dependencies = [
     { name = "web3" },
     { name = "x402" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "cdp-sdk", specifier = ">=1.22.0,<2" },
-    { name = "ecdsa", specifier = ">=0.19.0,<0.20" },
-    { name = "jsonschema", specifier = ">=4.23.0,<5" },
-    { name = "nilql", specifier = ">=0.0.0a12,<0.0.1" },
-    { name = "paramiko", specifier = ">=3.5.1,<4" },
-    { name = "pydantic", specifier = "~=2.0" },
-    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1,<3" },
-    { name = "python-dotenv", specifier = ">=1.0.1,<2" },
-    { name = "requests", specifier = ">=2.31.0,<3" },
-    { name = "solana", specifier = ">=0.36.6" },
-    { name = "solders", specifier = ">=0.26.0" },
-    { name = "web3", specifier = ">=7.6.0,<8" },
-    { name = "x402", specifier = ">=0.1.4,<2" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "jinja2", specifier = ">=3.1.3,<4" },
-    { name = "mypy", specifier = ">=1.13.0,<2" },
-    { name = "myst-parser", specifier = ">=4.0.0,<5" },
-    { name = "pillow", specifier = ">=11.1.0,<12" },
-    { name = "prompt-toolkit", specifier = ">=3.0.50,<4" },
-    { name = "pytest", specifier = ">=8.3.3,<9" },
-    { name = "pytest-cov", specifier = ">=6.0.0,<7" },
-    { name = "python-lsp-server", specifier = ">=1.12.0,<2" },
-    { name = "questionary", specifier = ">=2.1.0,<3" },
-    { name = "rich", specifier = ">=13.7.1,<14" },
-    { name = "ruff", specifier = ">=0.7.1,<0.8" },
-    { name = "ruff-lsp", specifier = ">=0.0.58,<0.0.59" },
-    { name = "sphinx", specifier = ">=8.0.2,<9" },
-    { name = "sphinx-autobuild", specifier = ">=2024.9.19,<2025" },
-    { name = "sphinx-autodoc-typehints", specifier = ">=2.4.4,<3" },
-    { name = "sphinxcontrib-napoleon", specifier = ">=0.7,<0.8" },
-    { name = "towncrier", specifier = ">=24.8.0,<25" },
-    { name = "tweepy", specifier = ">=4.15.0,<5" },
-    { name = "typer", specifier = ">=0.9.0,<0.13" },
+sdist = { url = "https://files.pythonhosted.org/packages/b7/17/95dd9eaf0090604fd9e419eff11a4347a7692ee34a9d1d6416dc27835fc5/coinbase_agentkit-0.7.1.tar.gz", hash = "sha256:b2a3a482d895a138d292f189f2755e38c55166973a810f728219c62cd8f3d364", size = 109757 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/75/c1eb762d9c9ce53ebf0013592186aef447d61f7da88165770ac1782821fa/coinbase_agentkit-0.7.1-py3-none-any.whl", hash = "sha256:26ee1b49f7495f37127860abe485762549a998c266ab1c41637043a3116e9bb4", size = 170267 },
 ]
 
 [[package]]
@@ -767,7 +731,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", editable = "../../coinbase-agentkit" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.1,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "strands-agents", specifier = ">=1.0.1" },


### PR DESCRIPTION
Updated from using the local build to the published build now that allora-sdk dependency has been removed.

This is the final unblock to run publishing