### PR TITLE
feat(typescript): add ListSpendPermissions and UseSpendPermissions

### DIFF
--- a/typescript/.changeset/twelve-planes-swim.md
+++ b/typescript/.changeset/twelve-planes-swim.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Added ListSpendPermissions and UseSpendPermission actions to new CdpEvmWalletActionProvider and CdpSmartWalletActionProvider

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -172,6 +172,32 @@ const agent = createReactAgent({
 ## Action Providers
 
 <details>
+<summary><strong>CDP EVM Wallet</strong></summary>
+<table width="100%">
+<tr>
+    <td width="200"><code>list_spend_permissions</code></td>
+    <td width="768">Lists spend permissions that have been granted to the current EVM wallet by a smart account.</td>
+</tr>
+<tr>
+    <td width="200"><code>use_spend_permission</code></td>
+    <td width="768">Uses a spend permission to spend tokens on behalf of a smart account that the current EVM wallet has permission to spend.</td>
+</tr>
+</table>
+</details>
+<details>
+<summary><strong>CDP Smart Wallet</strong></summary>
+<table width="100%">
+<tr>
+    <td width="200"><code>list_spend_permissions</code></td>
+    <td width="768">Lists spend permissions that have been granted to the current smart wallet by a smart account.</td>
+</tr>
+<tr>
+    <td width="200"><code>use_spend_permission</code></td>
+    <td width="768">Uses a spend permission to spend tokens on behalf of a smart account that the current smart wallet has permission to spend.</td>
+</tr>
+</table>
+</details>
+<details>
 <summary><strong>Across</strong></summary>
 <table width="100%">
 <tr>

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@across-protocol/app-sdk": "^0.2.0",
     "@alloralabs/allora-sdk": "^0.1.0",
-    "@coinbase/cdp-sdk": "^1.26.0",
+    "@coinbase/cdp-sdk": "^1.34.0",
     "@coinbase/coinbase-sdk": "^0.20.0",
     "@jup-ag/api": "^6.0.39",
     "@privy-io/public-api": "2.18.5",

--- a/typescript/agentkit/src/action-providers/cdp/README.md
+++ b/typescript/agentkit/src/action-providers/cdp/README.md
@@ -6,11 +6,15 @@ This directory contains the **CdpV2ActionProvider** implementation, which provid
 
 ```
 cdp/
-├── cdpApiActionProvider.ts          # Provider for CDP API interactions
-├── cdpApiActionProvider.test.ts     # Tests for CDP API provider
-├── schemas.ts                         # Action schemas for CDP operations
-├── index.ts                           # Main exports
-└── README.md                          # This file
+├── cdpApiActionProvider.ts              # Provider for CDP API interactions
+├── cdpApiActionProvider.test.ts         # Tests for CDP API provider
+├── cdpEvmWalletActionProvider.ts        # Provider for CDP EVM Wallet operations
+├── cdpSmartWalletActionProvider.ts      # Provider for CDP Smart Wallet operations
+├── cdpEvmWalletActionProvider.test.ts   # Tests for CDP EVM Wallet provider
+├── cdpSmartWalletActionProvider.test.ts # Tests for CDP Smart Wallet provider
+├── schemas.ts                           # Action schemas for CDP operations
+├── index.ts                             # Main exports
+└── README.md                            # This file
 ```
 
 ## Actions
@@ -21,6 +25,16 @@ cdp/
 
   - Available only on Base Sepolia, Ethereum Sepolia or Solana Devnet
 
+### CDP EVM Wallet Actions
+
+- `list_spend_permissions`: Lists spend permissions that have been granted to the current EVM wallet by a smart account.
+- `use_spend_permission`: Uses a spend permission to spend tokens on behalf of a smart account that the current EVM wallet has permission to spend.
+
+### CDP Smart Wallet Actions
+
+- `list_spend_permissions`: Lists spend permissions that have been granted to the current smart wallet by a smart account.
+- `use_spend_permission`: Uses a spend permission to spend tokens on behalf of a smart account that the current smart wallet has permission to spend.
+
 ## Adding New Actions
 
 To add new CDP actions:
@@ -28,6 +42,8 @@ To add new CDP actions:
 1. Define your action schema in `schemas.ts`
 2. Implement the action in the appropriate provider file:
    - CDP API actions in `cdpApiActionProvider.ts`
+   - CDP EVM Wallet actions in `cdpEvmWalletActionProvider.ts`
+   - CDP Smart Wallet actions in `cdpSmartWalletActionProvider.ts`
 3. Add corresponding tests
 
 ## Network Support

--- a/typescript/agentkit/src/action-providers/cdp/cdpEvmWalletActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpEvmWalletActionProvider.test.ts
@@ -1,0 +1,290 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { CdpClient, SpendPermissionNetwork } from "@coinbase/cdp-sdk";
+import { CdpEvmWalletProvider } from "../../wallet-providers/cdpEvmWalletProvider";
+import { CdpEvmWalletActionProvider } from "./cdpEvmWalletActionProvider";
+import { ListSpendPermissionsSchema, UseSpendPermissionSchema } from "./schemas";
+import * as spendPermissionUtils from "./spendPermissionUtils";
+
+// Mock the CDP SDK and utility functions
+jest.mock("@coinbase/cdp-sdk");
+jest.mock("./spendPermissionUtils");
+
+describe("CDP EVM Wallet Action Provider", () => {
+  let actionProvider: CdpEvmWalletActionProvider;
+  let mockWalletProvider: jest.Mocked<CdpEvmWalletProvider>;
+  let mockCdpClient: jest.Mocked<CdpClient>;
+  let mockAccount: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockAccount = {
+      useSpendPermission: jest.fn(),
+      address: "0x1234567890123456789012345678901234567890",
+    };
+
+    mockCdpClient = {
+      evm: {
+        listSpendPermissions: jest.fn(),
+        getAccount: jest.fn(),
+      },
+    } as any;
+
+    mockWalletProvider = {
+      getNetwork: jest.fn(),
+      getAddress: jest.fn(),
+      getClient: jest.fn(),
+    } as any;
+
+    actionProvider = new CdpEvmWalletActionProvider();
+  });
+
+  describe("listSpendPermissions", () => {
+    const mockArgs = {
+      smartAccountAddress: "0xabcd1234567890123456789012345678901234567890",
+    };
+
+    beforeEach(() => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      } as any);
+      mockWalletProvider.getAddress.mockReturnValue("0x1234567890123456789012345678901234567890");
+      mockWalletProvider.getClient.mockReturnValue(mockCdpClient);
+    });
+
+    it("should successfully list spend permissions for EVM wallets", async () => {
+      const expectedResult =
+        "Found 2 spend permission(s):\n1. Token: USDC, Allowance: 500, Period: 1800 seconds, Start: 111111, End: 222222\n2. Token: ETH, Allowance: 1000, Period: 3600 seconds, Start: 123456, End: 234567";
+      (spendPermissionUtils.listSpendPermissionsForSpender as jest.Mock).mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await actionProvider.listSpendPermissions(mockWalletProvider, mockArgs);
+
+      expect(spendPermissionUtils.listSpendPermissionsForSpender).toHaveBeenCalledWith(
+        mockCdpClient,
+        mockArgs.smartAccountAddress,
+        "0x1234567890123456789012345678901234567890",
+      );
+      expect(result).toBe(expectedResult);
+    });
+
+    it("should return error message for non-EVM networks", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "svm",
+        networkId: "solana-devnet",
+      } as any);
+
+      const result = await actionProvider.listSpendPermissions(mockWalletProvider, mockArgs);
+
+      expect(result).toBe("Spend permissions are currently only supported on EVM networks.");
+      expect(spendPermissionUtils.listSpendPermissionsForSpender).not.toHaveBeenCalled();
+    });
+
+    it("should handle utility function errors gracefully", async () => {
+      (spendPermissionUtils.listSpendPermissionsForSpender as jest.Mock).mockResolvedValue(
+        "Failed to list spend permissions: Network error",
+      );
+
+      const result = await actionProvider.listSpendPermissions(mockWalletProvider, mockArgs);
+
+      expect(result).toBe("Failed to list spend permissions: Network error");
+    });
+
+    it("should validate input schema", () => {
+      const validInput = { smartAccountAddress: "0xabcd1234567890123456789012345678901234567890" };
+      const invalidInput = { wrongField: "0xabcd1234567890123456789012345678901234567890" };
+
+      expect(() => ListSpendPermissionsSchema.parse(validInput)).not.toThrow();
+      expect(() => ListSpendPermissionsSchema.parse(invalidInput)).toThrow();
+    });
+  });
+
+  describe("useSpendPermission", () => {
+    const mockArgs = {
+      smartAccountAddress: "0xabcd1234567890123456789012345678901234567890",
+      value: "2500",
+    };
+
+    beforeEach(() => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      } as any);
+      mockWalletProvider.getAddress.mockReturnValue("0x1234567890123456789012345678901234567890");
+      mockWalletProvider.getClient.mockReturnValue(mockCdpClient);
+      (mockCdpClient.evm.getAccount as jest.Mock).mockResolvedValue(mockAccount);
+    });
+
+    it("should successfully use spend permission for EVM wallets", async () => {
+      const mockPermission = {
+        spender: "0x1234567890123456789012345678901234567890",
+        token: "USDC",
+        allowance: "5000",
+        period: 7200,
+        start: 111111,
+        end: 333333,
+      };
+
+      const mockSpendResult = {
+        status: "completed",
+        transactionHash: "0xdef456789",
+      };
+
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue(
+        mockPermission,
+      );
+      mockAccount.useSpendPermission.mockResolvedValue(mockSpendResult);
+
+      const result = await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+
+      expect(spendPermissionUtils.findLatestSpendPermission).toHaveBeenCalledWith(
+        mockCdpClient,
+        mockArgs.smartAccountAddress,
+        "0x1234567890123456789012345678901234567890",
+      );
+
+      expect(mockCdpClient.evm.getAccount).toHaveBeenCalledWith({
+        address: "0x1234567890123456789012345678901234567890",
+      });
+
+      expect(mockAccount.useSpendPermission).toHaveBeenCalledWith({
+        spendPermission: mockPermission,
+        value: BigInt(2500),
+        network: "base-sepolia" as SpendPermissionNetwork,
+      });
+
+      expect(result).toBe(
+        "Successfully spent 2500 tokens using spend permission. Transaction hash: 0xdef456789",
+      );
+    });
+
+    it("should handle different network conversions", async () => {
+      const testCases = [
+        { networkId: "base-sepolia", expected: "base-sepolia" },
+        { networkId: "base-mainnet", expected: "base" },
+        { networkId: "ethereum-sepolia", expected: "ethereum-sepolia" },
+        { networkId: "ethereum-mainnet", expected: "ethereum" },
+      ];
+
+      const mockPermission = { spender: "0x1234", token: "ETH" };
+      const mockSpendResult = { status: "completed" };
+
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue(
+        mockPermission,
+      );
+      mockAccount.useSpendPermission.mockResolvedValue(mockSpendResult);
+
+      for (const testCase of testCases) {
+        jest.clearAllMocks();
+        mockWalletProvider.getNetwork.mockReturnValue({
+          protocolFamily: "evm",
+          networkId: testCase.networkId,
+        } as any);
+        mockWalletProvider.getClient.mockReturnValue(mockCdpClient);
+        (mockCdpClient.evm.getAccount as jest.Mock).mockResolvedValue(mockAccount);
+
+        await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+
+        expect(mockAccount.useSpendPermission).toHaveBeenCalledWith({
+          spendPermission: mockPermission,
+          value: BigInt(2500),
+          network: testCase.expected as SpendPermissionNetwork,
+        });
+      }
+    });
+
+    it("should handle unknown networks by passing them as-is", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "polygon-mainnet",
+      } as any);
+
+      const mockPermission = { spender: "0x1234", token: "MATIC" };
+      const mockSpendResult = { status: "completed" };
+
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue(
+        mockPermission,
+      );
+      mockAccount.useSpendPermission.mockResolvedValue(mockSpendResult);
+
+      await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+
+      expect(mockAccount.useSpendPermission).toHaveBeenCalledWith({
+        spendPermission: mockPermission,
+        value: BigInt(2500),
+        network: "polygon-mainnet" as SpendPermissionNetwork,
+      });
+    });
+
+    it("should return error message for non-EVM networks", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "svm",
+        networkId: "solana-devnet",
+      } as any);
+
+      const result = await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+      expect(result).toBe("Spend permissions are currently only supported on EVM networks.");
+    });
+
+    it("should handle spend permission not found error", async () => {
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockRejectedValue(
+        new Error("No spend permissions found for spender"),
+      );
+
+      const result = await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+      expect(result).toBe(
+        "Failed to use spend permission: Error: No spend permissions found for spender",
+      );
+    });
+
+    it("should handle account creation failure", async () => {
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue({
+        spender: "0x1234",
+        token: "ETH",
+      });
+      (mockCdpClient.evm.getAccount as jest.Mock).mockRejectedValue(new Error("Account not found"));
+
+      const result = await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+      expect(result).toBe("Failed to use spend permission: Error: Account not found");
+    });
+
+    it("should handle account use permission failure", async () => {
+      const mockPermission = { spender: "0x1234", token: "ETH" };
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue(
+        mockPermission,
+      );
+      mockAccount.useSpendPermission.mockRejectedValue(new Error("Insufficient allowance"));
+
+      const result = await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+      expect(result).toBe("Failed to use spend permission: Error: Insufficient allowance");
+    });
+
+    it("should validate input schema", () => {
+      const validInput = {
+        smartAccountAddress: "0xabcd1234567890123456789012345678901234567890",
+        value: "1000",
+      };
+      const invalidInput = {
+        smartAccountAddress: "not-an-address",
+        value: -100,
+      };
+
+      expect(() => UseSpendPermissionSchema.parse(validInput)).not.toThrow();
+      expect(() => UseSpendPermissionSchema.parse(invalidInput)).toThrow();
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should return true for EVM networks", () => {
+      const evmNetwork = { protocolFamily: "evm", networkId: "base-sepolia" } as any;
+      expect(actionProvider.supportsNetwork(evmNetwork)).toBe(true);
+    });
+
+    it("should return false for non-EVM networks", () => {
+      const svmNetwork = { protocolFamily: "svm", networkId: "solana-devnet" } as any;
+      expect(actionProvider.supportsNetwork(svmNetwork)).toBe(false);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/cdp/cdpEvmWalletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpEvmWalletActionProvider.ts
@@ -1,0 +1,153 @@
+import { SpendPermissionNetwork } from "@coinbase/cdp-sdk";
+import { z } from "zod";
+import { WalletProvider } from "../../wallet-providers";
+import { isWalletProviderWithClient } from "../../wallet-providers/cdpShared";
+import { CdpEvmWalletProvider } from "../../wallet-providers/cdpEvmWalletProvider";
+import { CreateAction } from "../actionDecorator";
+import { ActionProvider } from "../actionProvider";
+import { UseSpendPermissionSchema, ListSpendPermissionsSchema } from "./schemas";
+import { listSpendPermissionsForSpender, findLatestSpendPermission } from "./spendPermissionUtils";
+
+import type { Network } from "../../network";
+import type { Address } from "viem";
+
+/**
+ * CdpEvmWalletActionProvider is an action provider for CDP EVM Wallet specific actions.
+ *
+ * This provider is scoped specifically to EVM wallets and provides actions
+ * that are optimized for EVM functionality, including spend permission usage.
+ */
+export class CdpEvmWalletActionProvider extends ActionProvider<CdpEvmWalletProvider> {
+  /**
+   * Constructor for the CdpEvmWalletActionProvider class.
+   */
+  constructor() {
+    super("cdp_evm_wallet", []);
+  }
+
+  /**
+   * Lists spend permissions for a smart account.
+   *
+   * @param walletProvider - The server wallet provider to use for listing permissions.
+   * @param args - The input arguments for listing spend permissions.
+   * @returns A list of spend permissions available to the current wallet.
+   */
+  @CreateAction({
+    name: "list_spend_permissions",
+    description: `This tool lists spend permissions that have been granted to the current EVM wallet by a smart account.
+It takes a smart account address and returns spend permissions where the current EVM wallet is the spender.
+This is useful to see what spending allowances have been granted before using them.
+This action is specifically designed for EVM wallets.`,
+    schema: ListSpendPermissionsSchema,
+  })
+  async listSpendPermissions(
+    walletProvider: WalletProvider,
+    args: z.infer<typeof ListSpendPermissionsSchema>,
+  ): Promise<string> {
+    const network = walletProvider.getNetwork();
+
+    if (isWalletProviderWithClient(walletProvider)) {
+      if (network.protocolFamily === "evm") {
+        return await listSpendPermissionsForSpender(
+          walletProvider.getClient(),
+          args.smartAccountAddress as Address,
+          walletProvider.getAddress() as Address,
+        );
+      } else {
+        return "Spend permissions are currently only supported on EVM networks.";
+      }
+    } else {
+      return "Wallet provider is not a CDP Wallet Provider.";
+    }
+  }
+
+  /**
+   * Uses a spend permission to transfer tokens from a smart account to the current EVM wallet.
+   *
+   * @param walletProvider - The EVM wallet provider to use for the spend operation.
+   * @param args - The input arguments for using the spend permission.
+   * @returns A confirmation message with transaction details.
+   */
+  @CreateAction({
+    name: "use_spend_permission",
+    description: `This tool uses a spend permission to spend tokens on behalf of a smart account that the current EVM wallet has permission to spend.
+It automatically finds the latest valid spend permission granted by the smart account to the current EVM wallet and uses it to spend the specified amount.
+The smart account must have previously granted a spend permission to the current EVM wallet using createSpendPermission.
+This action is specifically designed for EVM wallets and uses the EVM wallet for spend permission execution.`,
+    schema: UseSpendPermissionSchema,
+  })
+  async useSpendPermission(
+    walletProvider: WalletProvider,
+    args: z.infer<typeof UseSpendPermissionSchema>,
+  ): Promise<string> {
+    const network = walletProvider.getNetwork();
+    const cdpNetwork = this.#getCdpSdkNetwork(network.networkId!);
+
+    if (isWalletProviderWithClient(walletProvider)) {
+      if (network.protocolFamily === "evm") {
+        try {
+          const spenderAddress = walletProvider.getAddress();
+
+          const permission = await findLatestSpendPermission(
+            walletProvider.getClient(),
+            args.smartAccountAddress as Address,
+            spenderAddress as Address,
+          );
+
+          const account = await walletProvider.getClient().evm.getAccount({
+            address: spenderAddress as Address,
+          });
+
+          const spendResult = await account.useSpendPermission({
+            spendPermission: permission,
+            value: BigInt(args.value),
+            network: cdpNetwork as SpendPermissionNetwork,
+          });
+
+          return `Successfully spent ${args.value} tokens using spend permission. Transaction hash: ${spendResult.transactionHash}`;
+        } catch (error) {
+          return `Failed to use spend permission: ${error}`;
+        }
+      } else {
+        return "Spend permissions are currently only supported on EVM networks.";
+      }
+    } else {
+      return "Wallet provider is not a CDP Wallet Provider.";
+    }
+  }
+
+  /**
+   * Checks if the EVM wallet action provider supports the given network.
+   *
+   * @param network - The network to check.
+   * @returns True if the EVM wallet action provider supports the network, false otherwise.
+   */
+  supportsNetwork = (network: Network) => {
+    // EVM wallets support EVM networks in general
+    return network.protocolFamily === "evm";
+  };
+
+  /**
+   * Converts the internal network ID to the format expected by the CDP SDK.
+   *
+   * @param networkId - The network ID to convert
+   * @returns The network ID in CDP SDK format
+   * @throws Error if the network is not supported
+   */
+  #getCdpSdkNetwork(networkId: string): string {
+    switch (networkId) {
+      case "base-sepolia":
+        return "base-sepolia";
+      case "base-mainnet":
+        return "base";
+      case "ethereum-sepolia":
+        return "ethereum-sepolia";
+      case "ethereum-mainnet":
+        return "ethereum";
+      default:
+        return networkId; // For other networks, use as-is
+    }
+  }
+}
+
+export const cdpEvmWalletActionProvider = () => new CdpEvmWalletActionProvider();

--- a/typescript/agentkit/src/action-providers/cdp/cdpSmartWalletActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpSmartWalletActionProvider.test.ts
@@ -1,0 +1,239 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { CdpClient, SpendPermissionNetwork } from "@coinbase/cdp-sdk";
+import { CdpSmartWalletProvider } from "../../wallet-providers/cdpSmartWalletProvider";
+import { CdpSmartWalletActionProvider } from "./cdpSmartWalletActionProvider";
+import { ListSpendPermissionsSchema, UseSpendPermissionSchema } from "./schemas";
+import * as spendPermissionUtils from "./spendPermissionUtils";
+
+// Mock the CDP SDK and utility functions
+jest.mock("@coinbase/cdp-sdk");
+jest.mock("./spendPermissionUtils");
+
+describe("CDP Smart Wallet Action Provider", () => {
+  let actionProvider: CdpSmartWalletActionProvider;
+  let mockWalletProvider: jest.Mocked<CdpSmartWalletProvider>;
+  let mockCdpClient: jest.Mocked<CdpClient>;
+  let mockSmartAccount: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockSmartAccount = {
+      useSpendPermission: jest.fn(),
+      address: "0x1234567890123456789012345678901234567890",
+    };
+
+    mockCdpClient = {
+      evm: {
+        listSpendPermissions: jest.fn(),
+      },
+    } as any;
+
+    mockWalletProvider = {
+      getNetwork: jest.fn(),
+      getAddress: jest.fn(),
+      getClient: jest.fn(),
+      smartAccount: mockSmartAccount,
+    } as any;
+
+    actionProvider = new CdpSmartWalletActionProvider();
+  });
+
+  describe("listSpendPermissions", () => {
+    const mockArgs = {
+      smartAccountAddress: "0xabcd1234567890123456789012345678901234567890",
+    };
+
+    beforeEach(() => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      } as any);
+      mockWalletProvider.getAddress.mockReturnValue("0x1234567890123456789012345678901234567890");
+      mockWalletProvider.getClient.mockReturnValue(mockCdpClient);
+    });
+
+    it("should successfully list spend permissions for EVM networks", async () => {
+      const expectedResult =
+        "Found 1 spend permission(s):\n1. Token: ETH, Allowance: 1000, Period: 3600 seconds, Start: 123456, End: 234567";
+      (spendPermissionUtils.listSpendPermissionsForSpender as jest.Mock).mockResolvedValue(
+        expectedResult,
+      );
+
+      const result = await actionProvider.listSpendPermissions(mockWalletProvider, mockArgs);
+
+      expect(spendPermissionUtils.listSpendPermissionsForSpender).toHaveBeenCalledWith(
+        mockCdpClient,
+        mockArgs.smartAccountAddress,
+        "0x1234567890123456789012345678901234567890",
+      );
+      expect(result).toBe(expectedResult);
+    });
+
+    it("should return error message for non-EVM networks", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "svm",
+        networkId: "solana-devnet",
+      } as any);
+
+      const result = await actionProvider.listSpendPermissions(mockWalletProvider, mockArgs);
+
+      expect(result).toBe("Spend permissions are currently only supported on EVM networks.");
+      expect(spendPermissionUtils.listSpendPermissionsForSpender).not.toHaveBeenCalled();
+    });
+
+    it("should validate input schema", () => {
+      const validInput = { smartAccountAddress: "0xabcd1234567890123456789012345678901234567890" };
+      const invalidInput = { invalidField: "invalid" };
+
+      expect(() => ListSpendPermissionsSchema.parse(validInput)).not.toThrow();
+      expect(() => ListSpendPermissionsSchema.parse(invalidInput)).toThrow();
+    });
+  });
+
+  describe("useSpendPermission", () => {
+    const mockArgs = {
+      smartAccountAddress: "0xabcd1234567890123456789012345678901234567890",
+      value: "1000",
+    };
+
+    beforeEach(() => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      } as any);
+      mockWalletProvider.getAddress.mockReturnValue("0x1234567890123456789012345678901234567890");
+      mockWalletProvider.getClient.mockReturnValue(mockCdpClient);
+    });
+
+    it("should successfully use spend permission for EVM networks", async () => {
+      const mockPermission = {
+        spender: "0x1234567890123456789012345678901234567890",
+        token: "ETH",
+        allowance: "1000",
+        period: 3600,
+        start: 123456,
+        end: 234567,
+      };
+
+      const mockSpendResult = {
+        status: "completed",
+        transactionHash: "0xabcd1234",
+      };
+
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue(
+        mockPermission,
+      );
+      mockSmartAccount.useSpendPermission.mockResolvedValue(mockSpendResult);
+
+      const result = await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+
+      expect(spendPermissionUtils.findLatestSpendPermission).toHaveBeenCalledWith(
+        mockCdpClient,
+        mockArgs.smartAccountAddress,
+        "0x1234567890123456789012345678901234567890",
+      );
+
+      expect(mockSmartAccount.useSpendPermission).toHaveBeenCalledWith({
+        spendPermission: mockPermission,
+        value: BigInt(1000),
+        network: "base-sepolia" as SpendPermissionNetwork,
+      });
+
+      expect(result).toBe(
+        "Successfully spent 1000 tokens using spend permission. Status: completed",
+      );
+    });
+
+    it("should handle base-mainnet network conversion", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-mainnet",
+      } as any);
+
+      const mockPermission = { spender: "0x1234", token: "ETH" };
+      const mockSpendResult = { status: "completed" };
+
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue(
+        mockPermission,
+      );
+      mockSmartAccount.useSpendPermission.mockResolvedValue(mockSpendResult);
+
+      await actionProvider.useSpendPermission(mockWalletProvider, mockArgs);
+
+      expect(mockSmartAccount.useSpendPermission).toHaveBeenCalledWith({
+        spendPermission: mockPermission,
+        value: BigInt(1000),
+        network: "base" as SpendPermissionNetwork,
+      });
+    });
+
+    it("should throw error for unsupported networks", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "ethereum-mainnet",
+      } as any);
+
+      await expect(actionProvider.useSpendPermission(mockWalletProvider, mockArgs)).rejects.toThrow(
+        "Unsupported network for smart wallets: ethereum-mainnet",
+      );
+    });
+
+    it("should return error message for non-EVM networks", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "svm",
+        networkId: "solana-devnet",
+      } as any);
+
+      await expect(actionProvider.useSpendPermission(mockWalletProvider, mockArgs)).rejects.toThrow(
+        "Unsupported network for smart wallets: solana-devnet",
+      );
+    });
+
+    it("should handle spend permission not found error", async () => {
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockRejectedValue(
+        new Error("No spend permissions found"),
+      );
+
+      await expect(actionProvider.useSpendPermission(mockWalletProvider, mockArgs)).rejects.toThrow(
+        "Failed to use spend permission: Error: No spend permissions found",
+      );
+    });
+
+    it("should handle smart account use permission failure", async () => {
+      const mockPermission = { spender: "0x1234", token: "ETH" };
+      (spendPermissionUtils.findLatestSpendPermission as jest.Mock).mockResolvedValue(
+        mockPermission,
+      );
+      mockSmartAccount.useSpendPermission.mockRejectedValue(new Error("Transaction failed"));
+
+      await expect(actionProvider.useSpendPermission(mockWalletProvider, mockArgs)).rejects.toThrow(
+        "Failed to use spend permission: Error: Transaction failed",
+      );
+    });
+
+    it("should validate input schema", () => {
+      const validInput = {
+        smartAccountAddress: "0xabcd1234567890123456789012345678901234567890",
+        value: "1000",
+      };
+      const invalidInput = {
+        wrongField: "0xabcd1234567890123456789012345678901234567890",
+        // Missing required fields
+      };
+
+      expect(() => UseSpendPermissionSchema.parse(validInput)).not.toThrow();
+      expect(() => UseSpendPermissionSchema.parse(invalidInput)).toThrow();
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should return true for any network", () => {
+      const evmNetwork = { protocolFamily: "evm", networkId: "base-sepolia" } as any;
+      const svmNetwork = { protocolFamily: "svm", networkId: "solana-devnet" } as any;
+
+      expect(actionProvider.supportsNetwork(evmNetwork)).toBe(true);
+      expect(actionProvider.supportsNetwork(svmNetwork)).toBe(true);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/cdp/cdpSmartWalletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpSmartWalletActionProvider.ts
@@ -1,0 +1,133 @@
+import { SpendPermissionNetwork } from "@coinbase/cdp-sdk";
+import { z } from "zod";
+import { CdpSmartWalletProvider } from "../../wallet-providers/cdpSmartWalletProvider";
+import { CreateAction } from "../actionDecorator";
+import { ActionProvider } from "../actionProvider";
+import { UseSpendPermissionSchema, ListSpendPermissionsSchema } from "./schemas";
+import { listSpendPermissionsForSpender, findLatestSpendPermission } from "./spendPermissionUtils";
+
+import type { Network } from "../../network";
+import type { Address } from "viem";
+
+/**
+ * CdpSmartWalletActionProvider is an action provider for CDP Smart Wallet specific actions.
+ *
+ * This provider is scoped specifically to CdpSmartWalletProvider and provides actions
+ * that are optimized for smart wallet functionality.
+ */
+export class CdpSmartWalletActionProvider extends ActionProvider<CdpSmartWalletProvider> {
+  /**
+   * Constructor for the CdpSmartWalletActionProvider class.
+   */
+  constructor() {
+    super("cdp_smart_wallet", []);
+  }
+
+  /**
+   * Lists spend permissions for a smart account.
+   *
+   * @param walletProvider - The smart wallet provider to use for listing permissions.
+   * @param args - The input arguments for listing spend permissions.
+   * @returns A list of spend permissions available to the current wallet.
+   */
+  @CreateAction({
+    name: "list_spend_permissions",
+    description: `This tool lists spend permissions that have been granted to the current smart wallet by another smart account.
+It takes a smart account address and returns spend permissions where the current smart wallet is the spender.
+This is useful to see what spending allowances have been granted before using them.
+This action is specifically designed for smart wallets.`,
+    schema: ListSpendPermissionsSchema,
+  })
+  async listSpendPermissions(
+    walletProvider: CdpSmartWalletProvider,
+    args: z.infer<typeof ListSpendPermissionsSchema>,
+  ): Promise<string> {
+    const network = walletProvider.getNetwork();
+
+    if (network.protocolFamily === "evm") {
+      const spenderAddress = walletProvider.getAddress();
+      return await listSpendPermissionsForSpender(
+        walletProvider.getClient(),
+        args.smartAccountAddress as Address,
+        spenderAddress as Address,
+      );
+    } else {
+      return "Spend permissions are currently only supported on EVM networks.";
+    }
+  }
+
+  /**
+   * Uses a spend permission to transfer tokens from a smart account to the current smart wallet.
+   *
+   * @param walletProvider - The smart wallet provider to use for the spend operation.
+   * @param args - The input arguments for using the spend permission.
+   * @returns A confirmation message with transaction details.
+   */
+  @CreateAction({
+    name: "use_spend_permission",
+    description: `This tool uses a spend permission to spend tokens on behalf of a smart account that the current smart wallet has permission to spend.
+It automatically finds the latest valid spend permission granted by the smart account to the current smart wallet and uses it to spend the specified amount.
+The smart account must have previously granted a spend permission to the current smart wallet using createSpendPermission.
+This action is specifically designed for smart wallets and uses the smart account directly for optimal performance.`,
+    schema: UseSpendPermissionSchema,
+  })
+  async useSpendPermission(
+    walletProvider: CdpSmartWalletProvider,
+    args: z.infer<typeof UseSpendPermissionSchema>,
+  ): Promise<string> {
+    const network = walletProvider.getNetwork();
+    const cdpNetwork = this.#getCdpSdkNetwork(network.networkId!);
+
+    if (network.protocolFamily === "evm") {
+      try {
+        const permission = await findLatestSpendPermission(
+          walletProvider.getClient(),
+          args.smartAccountAddress as Address,
+          walletProvider.getAddress() as Address,
+        );
+
+        const spendResult = await walletProvider.smartAccount.useSpendPermission({
+          spendPermission: permission,
+          value: BigInt(args.value),
+          network: cdpNetwork as SpendPermissionNetwork,
+        });
+
+        return `Successfully spent ${args.value} tokens using spend permission. Status: ${spendResult.status}`;
+      } catch (error) {
+        throw new Error(`Failed to use spend permission: ${error}`);
+      }
+    } else {
+      throw new Error("Spend permissions are currently only supported on EVM networks.");
+    }
+  }
+
+  /**
+   * Checks if the smart wallet action provider supports the given network.
+   *
+   * @param _  - The network to check.
+   * @returns True if the smart wallet action provider supports the network, false otherwise.
+   */
+  supportsNetwork = (_: Network): boolean => {
+    return true;
+  };
+
+  /**
+   * Converts the internal network ID to the format expected by the CDP SDK.
+   *
+   * @param networkId - The network ID to convert
+   * @returns The network ID in CDP SDK format
+   * @throws Error if the network is not supported
+   */
+  #getCdpSdkNetwork(networkId: string): string {
+    switch (networkId) {
+      case "base-sepolia":
+        return "base-sepolia";
+      case "base-mainnet":
+        return "base";
+      default:
+        throw new Error(`Unsupported network for smart wallets: ${networkId}`);
+    }
+  }
+}
+
+export const cdpSmartWalletActionProvider = () => new CdpSmartWalletActionProvider();

--- a/typescript/agentkit/src/action-providers/cdp/index.ts
+++ b/typescript/agentkit/src/action-providers/cdp/index.ts
@@ -1,2 +1,5 @@
 export * from "./schemas";
 export * from "./cdpApiActionProvider";
+export * from "./cdpSmartWalletActionProvider";
+export * from "./cdpEvmWalletActionProvider";
+export * from "./spendPermissionUtils";

--- a/typescript/agentkit/src/action-providers/cdp/schemas.ts
+++ b/typescript/agentkit/src/action-providers/cdp/schemas.ts
@@ -25,3 +25,36 @@ export const SwapSchema = z
   })
   .strip()
   .describe("Instructions for swapping tokens");
+
+/**
+ * Input schema for listing spend permissions action.
+ */
+export const ListSpendPermissionsSchema = z
+  .object({
+    smartAccountAddress: z
+      .string()
+      .describe("The smart account address that has granted spend permissions"),
+    network: z
+      .string()
+      .optional()
+      .describe("The network to list permissions on (defaults to wallet's network)"),
+  })
+  .strip()
+  .describe("Instructions for listing spend permissions for a smart account");
+
+/**
+ * Input schema for using a spend permission action.
+ */
+export const UseSpendPermissionSchema = z
+  .object({
+    smartAccountAddress: z
+      .string()
+      .describe("The smart account address that has granted the spend permission"),
+    value: z.string().describe("The amount to spend (in the token's units)"),
+    network: z
+      .string()
+      .optional()
+      .describe("The network to perform the spend on (defaults to wallet's network)"),
+  })
+  .strip()
+  .describe("Instructions for using a spend permission");

--- a/typescript/agentkit/src/action-providers/cdp/spendPermissionUtils.ts
+++ b/typescript/agentkit/src/action-providers/cdp/spendPermissionUtils.ts
@@ -1,0 +1,87 @@
+import { CdpClient, type SpendPermission } from "@coinbase/cdp-sdk";
+import type { Address } from "viem";
+
+/**
+ * Shared utility functions for spend permission operations.
+ */
+
+/**
+ * Lists and formats spend permissions for a given smart account and spender.
+ *
+ * @param cdpClient - The CDP client to use for API calls
+ * @param smartAccountAddress - The smart account address to check permissions for
+ * @param spenderAddress - The spender address to filter permissions by
+ * @returns A formatted string containing the spend permissions or an error message
+ */
+export async function listSpendPermissionsForSpender(
+  cdpClient: CdpClient,
+  smartAccountAddress: Address,
+  spenderAddress: Address,
+): Promise<string> {
+  try {
+    // List all spend permissions for the smart account
+    const allPermissions = await cdpClient.evm.listSpendPermissions({
+      address: smartAccountAddress,
+    });
+
+    // Filter permissions where current wallet is the spender
+    const relevantPermissions = allPermissions.spendPermissions.filter(
+      p => p.permission?.spender.toLowerCase() === spenderAddress.toLowerCase(),
+    );
+
+    if (relevantPermissions.length === 0) {
+      return `No spend permissions found for spender ${spenderAddress} on smart account ${smartAccountAddress}`;
+    }
+
+    // Format the permissions for display
+    const formattedPermissions = relevantPermissions
+      .map((p, index) => {
+        const perm = p.permission;
+        if (!perm) return `${index + 1}. Invalid permission`;
+        return `${index + 1}. Token: ${perm.token}, Allowance: ${perm.allowance}, Period: ${perm.period} seconds, Start: ${perm.start}, End: ${perm.end}`;
+      })
+      .join("\n");
+
+    return `Found ${relevantPermissions.length} spend permission(s):\n${formattedPermissions}`;
+  } catch (error) {
+    return `Failed to list spend permissions: ${error}`;
+  }
+}
+
+/**
+ * Finds and retrieves the latest valid spend permission for a given spender from a smart account.
+ *
+ * @param cdpClient - The CDP client to use for API calls
+ * @param smartAccountAddress - The smart account address to check permissions for
+ * @param spenderAddress - The spender address to find permissions for
+ * @returns The latest spend permission or throws an error if none found
+ * @throws Error if no permissions found or permission is invalid
+ */
+export async function findLatestSpendPermission(
+  cdpClient: CdpClient,
+  smartAccountAddress: Address,
+  spenderAddress: Address,
+): Promise<SpendPermission> {
+  const allPermissions = await cdpClient.evm.listSpendPermissions({
+    address: smartAccountAddress,
+  });
+
+  // Filter permissions where current wallet is the spender
+  const relevantPermissions = allPermissions.spendPermissions.filter(
+    p => p.permission?.spender.toLowerCase() === spenderAddress.toLowerCase(),
+  );
+
+  if (relevantPermissions.length === 0) {
+    throw new Error(
+      `No spend permissions found for spender ${spenderAddress} on smart account ${smartAccountAddress}`,
+    );
+  }
+
+  // Use the latest permission (last in the array)
+  const latestPermissionWrapper = relevantPermissions.at(-1);
+  if (!latestPermissionWrapper?.permission) {
+    throw new Error("Invalid spend permission found");
+  }
+
+  return latestPermissionWrapper.permission;
+}

--- a/typescript/agentkit/src/wallet-providers/cdpSmartWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSmartWalletProvider.ts
@@ -53,8 +53,9 @@ interface ConfigureCdpSmartWalletProviderWithWalletOptions {
  * A wallet provider that uses the Coinbase CDP SDK smart wallets.
  */
 export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletProviderWithClient {
+  public smartAccount: EvmSmartAccount;
+
   #publicClient: PublicClient;
-  #smartAccount: EvmSmartAccount;
   #ownerAccount: LocalAccount | EvmServerAccount;
   #cdp: CdpClient;
   #network: Network;
@@ -68,7 +69,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
   private constructor(config: ConfigureCdpSmartWalletProviderWithWalletOptions) {
     super();
 
-    this.#smartAccount = config.smartAccount;
+    this.smartAccount = config.smartAccount;
     this.#ownerAccount = config.ownerAccount;
     this.#cdp = config.cdp;
     this.#publicClient = config.publicClient;
@@ -167,8 +168,8 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
     ownerAddress: Address;
   }> {
     return {
-      name: this.#smartAccount.name,
-      address: this.#smartAccount.address as Address,
+      name: this.smartAccount.name,
+      address: this.smartAccount.address as Address,
       ownerAddress: this.#ownerAccount.address as Address,
     };
   }
@@ -194,7 +195,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async signTypedData(typedData: any): Promise<Hex> {
     const { domain, types, primaryType, message } = typedData;
-    return await this.#smartAccount.signTypedData({
+    return await this.smartAccount.signTypedData({
       domain,
       types,
       primaryType,
@@ -231,7 +232,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
     ];
 
     const userOperation = await this.#cdp.evm.sendUserOperation({
-      smartAccount: this.#smartAccount,
+      smartAccount: this.smartAccount,
       network: this.#getCdpSdkNetwork(),
       calls,
       paymasterUrl: this.#paymasterUrl,
@@ -246,7 +247,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
    * @returns The address of the smart wallet.
    */
   getAddress(): string {
-    return this.#smartAccount.address;
+    return this.smartAccount.address;
   }
 
   /**
@@ -291,7 +292,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
    * @returns The balance of the wallet in wei
    */
   async getBalance(): Promise<bigint> {
-    return await this.#publicClient.getBalance({ address: this.#smartAccount.address });
+    return await this.#publicClient.getBalance({ address: this.smartAccount.address });
   }
 
   /**
@@ -306,7 +307,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
     // This is a simplified implementation - in practice you might want to poll
     // the CDP API for user operation status
     return this.#cdp.evm.waitForUserOperation({
-      smartAccountAddress: this.#smartAccount.address,
+      smartAccountAddress: this.smartAccount.address,
       userOpHash,
     });
   }

--- a/typescript/examples/vercel-ai-sdk-smart-wallet-chatbot/chatbot.ts
+++ b/typescript/examples/vercel-ai-sdk-smart-wallet-chatbot/chatbot.ts
@@ -1,7 +1,7 @@
 import {
   AgentKit,
   cdpApiActionProvider,
-  erc721ActionProvider,
+  erc20ActionProvider,
   pythActionProvider,
   walletActionProvider,
   CdpSmartWalletProvider,
@@ -19,6 +19,7 @@ dotenv.config();
 type WalletData = {
   smartAccountName?: string;
   smartWalletAddress: Address;
+  ownerAddress: Address;
 };
 
 /**
@@ -79,12 +80,15 @@ async function initializeAgent() {
 
     let walletData: WalletData | null = null;
     let smartAccountName: string | undefined = undefined;
-
+    let smartWalletAddress: Address | undefined = undefined;
+    let ownerAddress: Address | undefined = undefined;
     // Read existing wallet data if available
     if (fs.existsSync(walletDataFile)) {
       try {
         walletData = JSON.parse(fs.readFileSync(walletDataFile, "utf8")) as WalletData;
         smartAccountName = walletData.smartAccountName;
+        smartWalletAddress = walletData.smartWalletAddress;
+        ownerAddress = walletData.ownerAddress;
       } catch (error) {
         console.error(`Error reading wallet data for ${networkId}:`, error);
         // Continue without wallet data
@@ -95,13 +99,15 @@ async function initializeAgent() {
     const walletProvider = await CdpSmartWalletProvider.configureWithWallet({
       networkId,
       smartAccountName,
+      address: smartWalletAddress,
+      owner: ownerAddress,
     });
 
     const agentKit = await AgentKit.from({
       walletProvider,
       actionProviders: [
         cdpApiActionProvider(),
-        erc721ActionProvider(),
+        erc20ActionProvider(),
         pythActionProvider(),
         walletActionProvider(),
       ],
@@ -115,6 +121,7 @@ async function initializeAgent() {
       JSON.stringify({
         smartAccountName: data.name,
         smartWalletAddress: data.address,
+        ownerAddress: data.ownerAddress,
       } as WalletData),
     );
 

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       '@coinbase/cdp-sdk':
-        specifier: ^1.26.0
-        version: 1.26.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
+        specifier: ^1.34.0
+        version: 1.34.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
       '@coinbase/coinbase-sdk':
         specifier: ^0.20.0
         version: 0.20.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)
@@ -929,8 +929,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@coinbase/cdp-sdk@1.26.0':
-    resolution: {integrity: sha512-vjRItqeqKBr8LbQVQMI6h9YbHMqScj8W/JDsVFE40xygrk1nnw69QmzinBcPuInbeVi0u3i1dhucfHiIUnQjoQ==}
+  '@coinbase/cdp-sdk@1.34.0':
+    resolution: {integrity: sha512-1E7kbTldmoJ46QxqOZrLylhDKsixf0L51N0tHHFORA3xVM6VRoDUKzDAPASkcrh4AMimbZty1+ZqFboak4QGcA==}
 
   '@coinbase/coinbase-sdk@0.20.0':
     resolution: {integrity: sha512-OoMMktKbjmeEwtwQCK3kIIoX5M+hNelxAGX5Llymvw6bmyrMDaEBZ/Myga9kaLJ+7Hi5Y4jPDy4Cy2MGxxXg6w==}
@@ -1391,6 +1391,10 @@ packages:
 
   '@noble/curves@1.9.2':
     resolution: {integrity: sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.6':
+    resolution: {integrity: sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@1.3.2':
@@ -5493,12 +5497,13 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@coinbase/cdp-sdk@1.26.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)':
+  '@coinbase/cdp-sdk@1.34.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/spl-token': 0.4.13(@solana/web3.js@1.98.1(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.8.2)(zod@3.25.56)
       axios: 1.9.0
+      axios-retry: 4.5.0(axios@1.9.0)
       jose: 6.0.10
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -6391,6 +6396,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@noble/curves@1.9.6':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
@@ -7001,7 +7010,7 @@ snapshots:
 
   '@zerodev/webauthn-key@5.4.3(viem@2.23.15(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))':
     dependencies:
-      '@noble/curves': 1.9.2
+      '@noble/curves': 1.9.6
       '@simplewebauthn/browser': 8.3.7
       '@simplewebauthn/types': 12.0.0
       viem: 2.23.15(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)


### PR DESCRIPTION
## Description

This PR implements two [Spend Permissions](https://docs.cdp.coinbase.com/wallet-api/v2/evm-features/spend-permissions) actions in both EvmWallet and SmartWallet:
* `list_spend_permissions`
* `use_spend_permissions`

## Tests

Setup:
1. Used the [createSpendPermission example script](https://github.com/coinbase/cdp-sdk/blob/main/examples/typescript/evm/createSpendPermission.ts) to create a spend permission for my Agent's wallet.

**Transcript of chat with Vercel AI Chatbot**

```
Prompt: print wallet details
print wallet details
Here are your wallet details:

- **Provider:** cdp_smart_wallet_provider
- **Address:** 0xe1D1D37231799d5784b12b0b53bB2866a99e8C18
- **Network:**
  - **Protocol Family:** EVM
  - **Network ID:** base-sepolia
  - **Chain ID:** 84532
- **Native Balance:** 0 WEI

If you need any further assistance, let me know!
-------------------

Prompt: print balance of erc20 token with address 0x036CbD53842c5426634e7929541eC2318f3dCF7e
print balance of erc20 token with address 0x036CbD53842c5426634e7929541eC2318f3dCF7e
The balance of the ERC20 token with address `0x036CbD53842c5426634e7929541eC2318f3dCF7e` is **0.005** tokens. If you need any further assistance, feel free to ask!
-------------------

Prompt: list spend permissions granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
list spend permissions granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
Here are the spend permissions granted by the smart account `0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28`:

1. **Token:** `0x036cbd53842c5426634e7929541ec2318f3dcf7e`
   - **Allowance:** 10,000 tokens
   - **Period:** 2,592,000 seconds (30 days)
   - **Start:** 1754666025 (Unix timestamp)
   - **End:** 281474976710655 (Unix timestamp)

If you need further assistance, let me know!
-------------------

Prompt: use 5000 of the spend permission granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
use 5000 of the spend permission granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
Successfully spent **5000 tokens** using the spend permission granted by the smart account `0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28`. The transaction status is currently broadcast. If you need any further assistance, feel free to ask!
-------------------

Prompt: print balance of erc20 token with address 0x036CbD53842c5426634e7929541eC2318f3dCF7e
print balance of erc20 token with address 0x036CbD53842c5426634e7929541eC2318f3dCF7e
The balance of the ERC20 token with address `0x036CbD53842c5426634e7929541eC2318f3dCF7e` is **0.01 tokens**. If you need any further assistance, let me know!
-------------------
```

**Transcript of chat with Vercel AI Chatbot modified to use EVM Server Wallet**
```
Prompt: print wallet details
print wallet details
Here are your wallet details:

- **Provider:** cdp_evm_wallet_provider
- **Address:** 0x81791fddB6fC4397DcE3E1031A159c2636A487Df
- **Network:**
  - **Protocol Family:** EVM
  - **Network ID:** base-sepolia
  - **Chain ID:** 84532
- **Native Balance:** 0 WEI

If you need any further assistance, let me know!
-------------------

Prompt: list spend permissions granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
list spend permissions granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
Here are the spend permissions granted by the smart account `0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28`:

1. **Token:** `0x036cbd53842c5426634e7929541ec2318f3dcf7e`
   - **Allowance:** 10,000
   - **Period:** 2,592,000 seconds (30 days)
   - **Start Time:** 1754687882
   - **End Time:** 281474976710655

If you need further assistance, feel free to ask!
-------------------

Prompt: print erc20 balance of token 0x036cbd53842c5426634e7929541ec2318f3dcf7e
print erc20 balance of token 0x036cbd53842c5426634e7929541ec2318f3dcf7e
The ERC20 balance of the token `0x036cbd53842c5426634e7929541ec2318f3dcf7e` is **0**. If you need any further assistance, let me know!
-------------------

Prompt: use 5000 of spend permission granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
use 5000 of spend permission granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28

-------------------

Prompt: faucet some eth
faucet some eth
I have successfully received ETH from the faucet. The transaction hash is: **0x390b1ce76cc346dfa5a0fd39ce13d03559567b835e8806eea6ae0b3be956fd09**.

If you need any further assistance, feel free to ask!
-------------------

Prompt: use 5000 of spend permission granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
use 5000 of spend permission granted by 0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28
I have successfully used 5000 tokens from the spend permission granted by `0x2017C472CeB2f9A8Bb3d909B0E2ADD46805dDd28`. The transaction hash is: **0x8262653528f58176910163e21a8dddf94d7b040b42485fba6f052d628af603e4**.

If you need any further assistance, feel free to ask!
-------------------

Prompt: print erc20 balance of token 0x036cbd53842c5426634e7929541ec2318f3dcf7e
print erc20 balance of token 0x036cbd53842c5426634e7929541ec2318f3dcf7e
The ERC20 balance of the token `0x036cbd53842c5426634e7929541ec2318f3dcf7e` is **0.005**. If you need any further assistance, let me know!
-------------------
```

**Note**: There was a slight hiccup where the agent seemed to not respond after the first time requesting to use the spend permission. This is because it didn't have funds to cover gas. The reason it didn't print anything is because the action was throwing an error instead of returning a string – this has since been fixed.

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
