### PR TITLE
feat: added Clanker typescript action support

### DIFF
--- a/typescript/.changeset/tasty-dragons-vanish.md
+++ b/typescript/.changeset/tasty-dragons-vanish.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added Clanker typescript action support

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -220,6 +220,15 @@ const agent = createReactAgent({
 </table>
 </details>
 <details>
+<summary><strong>Clanker</strong></summary>
+<table width="100%">
+<tr>
+    <td width="200"><code>clank_token</code></td>
+    <td width="768">Deploys an ERC20 Clanker token based on the supplied config.</td>
+</tr>
+</table>
+</details>
+<details>
 <summary><strong>Compound</strong></summary>
 <table width="100%">
 <tr>

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -55,6 +55,7 @@
     "axios": "^1.9.0",
     "bs58": "^4.0.1",
     "canonicalize": "^2.1.0",
+    "clanker-sdk": "^4.1.18",
     "decimal.js": "^10.5.0",
     "ethers": "^6.13.5",
     "graphql-request": "^7.2.0",

--- a/typescript/agentkit/src/action-providers/clanker/README.md
+++ b/typescript/agentkit/src/action-providers/clanker/README.md
@@ -17,8 +17,7 @@ clanker/
 ├── exampleAction.test.ts           # Example action test suite
 ├── schemas.ts                      # Action schemas and types
 ├── index.ts                        # Package exports
-├── utils/
-│   ├── clankerBridge.ts            # Helpers to wrap the EVMWalletProvider in the type the Clanker SDK expects
+├── utils.ts                        # Helpers to wrap the EVMWalletProvider in the type the Clanker SDK expects          
 └── README.md                       # Documentation (this file)
 ```
 
@@ -30,10 +29,15 @@ clanker/
   - **Input**:
     - `tokenName` (string): The name of the deployed token
     - `tokenSymbol` (string): The symbol of the deployed token
+    - `description` (string): Description of the token or token project
     - `image` (string): A url pointing to the image of the token
-    - `vestingPercentage` (number): The percentage of token that should be vested for the creator
+    - `vaultPercentage` (number): The percentage of token that should be vaulted for the creator
     - `vestingDuration_Days` (number): The duration (in days) that the token should vest after lockup period
     - `lockDuration_Days` (number): The lock duration of the token (minimum 7 days)
+    - `socialMediaUrls` (array): Socials for the token. These may be displayed on aggregators
+    - `interface` (string): System the token was deployed via. Defaults to "CDP AgentKit"
+    - `id` (string): User id of the poster on the social platform the token was deployed from. Used for provenance and will be verified by aggregators
+
   - **Output**: String describing the action result
   - **Example**:
     ```typescript
@@ -87,23 +91,6 @@ When implementing new actions, ensure to:
 1. Add unit tests for schema validations
 2. Test network support
 
-#### Example
-```
-Prompt: Can you clank a token with name [CDP Clanker], and symbol [CDPC] and image hosted at [https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQF6hcTTU1A8Ymi2VldXqCsPkBu_ltAhIKiRg&s]?  vest 10%, locked for 30 days, and then vested for 30 days.  do this on base-mainnet
-```
-
-```
--------------------
-Internal address: 0xE8D165388b13c460F02f4dC922309450a9bF6f22
-Clanker token deployed at 0x15E91EAF0848c8FEfE8c287923B5A78E254A76eb!  View the transaction at 0xf67befc5da942288a7bb4baee2cbbc1a09853e62552e736aa272b91e09f918fa
--------------------
-The Clanker token has been successfully deployed with the name "CDP Clanker" and symbol "CDPC." You can view the transaction [here](https://etherscan.io/tx/0xf67befc5da942288a7bb4baee2cbbc1a09853e62552e736aa272b91e09f918fa). The token address is 0x15E91EAF0848c8FEfE8c287923B5A78E254A76eb.
--------------------
-```
-
 ## Notes
 
-- Agent can define the description by adding a `description` field to the schema
-  - Currently description defaults to a short message describing who deployed it.
-- Likewise, agent can specify initial quote token.
 - Check the (Clanker docs)[https://github.com/clanker-devco/clanker-sdk] to see other configurable options (fees, admin, etc.).

--- a/typescript/agentkit/src/action-providers/clanker/README.md
+++ b/typescript/agentkit/src/action-providers/clanker/README.md
@@ -18,7 +18,7 @@ clanker/
 ├── schemas.ts                      # Action schemas and types
 ├── index.ts                        # Package exports
 ├── utils/
-│   ├── clankerBridge.ts            # Helprs to wrap the EVMWalletProvider in the type the Clanker SDK expects
+│   ├── clankerBridge.ts            # Helpers to wrap the EVMWalletProvider in the type the Clanker SDK expects
 └── README.md                       # Documentation (this file)
 ```
 

--- a/typescript/agentkit/src/action-providers/clanker/README.md
+++ b/typescript/agentkit/src/action-providers/clanker/README.md
@@ -1,0 +1,109 @@
+# Clanker Action Provider
+
+This directory contains the **ClankerActionProvider** implementation, which provides actions for clanker operations.
+
+## Overview
+
+The ClankerActionProvider is designed to work with EvmWalletProvider on Base Mainnet for blockchain interactions. It provides a set of actions that enable deploying a Clanker token recognized by the Clanker ecosystem.
+
+Although Clanker already has an agent that deploys tokens, their [open library](https://github.com/clanker-devco/clanker-sdk) and protocol allows anyone to launch a "Clank" token and be recognized by their ecosystem.
+
+## Directory Structure
+
+```
+clanker/
+├── clankerActionProvider.ts        # Main provider implementation
+├── clankerActionProvider.test.ts   # Provider test suite
+├── exampleAction.test.ts           # Example action test suite
+├── schemas.ts                      # Action schemas and types
+├── index.ts                        # Package exports
+├── utils/
+│   ├── clankerBridge.ts            # Helprs to wrap the EVMWalletProvider in the type the Clanker SDK expects
+└── README.md                       # Documentation (this file)
+```
+
+## Actions
+
+### Example Action
+- `clank_token`: Clanker action implementation
+  - **Purpose**: Creates a Clanker token from the input information
+  - **Input**:
+    - `tokenName` (string): The name of the deployed token
+    - `tokenSymbol` (string): The symbol of the deployed token
+    - `image` (string): A url pointing to the image of the token
+    - `vestingPercentage` (number): The percentage of token that should be vested for the creator
+    - `vestingDuration_Days` (number): The duration (in days) that the token should vest after lockup period
+    - `lockDuration_Days` (number): The lock duration of the token (minimum 7 days)
+  - **Output**: String describing the action result
+  - **Example**:
+    ```typescript
+    const result = await provider.clankToken(walletProvider, {
+      tokenName: "Test Token",
+      tokenSymbol: "TT",
+      image: "https://test.com/image.png",
+      vestingPercentage: 10,
+      vestingDuration_Days: 30,
+      lockDuration_Days: 30,
+    });
+    ```
+
+## Implementation Details
+
+### Network Support
+This provider supports Base Mainnet.
+
+### Wallet Provider Integration
+This provider is specifically designed to work with EvmWalletProvider. Key integration points:
+- Network compatibility checks
+- Transaction signing and execution
+- Creating and deploying a Clanker token
+
+## Adding New Actions
+
+To add new actions:
+
+1. Define the schema in `schemas.ts`:
+   ```typescript
+   export const NewActionSchema = z.object({
+     // Define your action's parameters
+   });
+   ```
+
+2. Implement the action in `clankerActionProvider.ts`:
+   ```typescript
+   @CreateAction({
+     name: "new_action",
+     description: "Description of what your action does",
+     schema: NewActionSchema,
+   })
+   async newAction(walletProvider: EvmWalletProvider, args: z.infer<typeof NewActionSchema>): Promise<string> {
+     // Implement your action logic
+   }
+   ```
+
+## Testing
+
+When implementing new actions, ensure to:
+1. Add unit tests for schema validations
+2. Test network support
+
+#### Example
+```
+Prompt: Can you clank a token with name [CDP Clanker], and symbol [CDPC] and image hosted at [https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQF6hcTTU1A8Ymi2VldXqCsPkBu_ltAhIKiRg&s]?  vest 10%, locked for 30 days, and then vested for 30 days.  do this on base-mainnet
+```
+
+```
+-------------------
+Internal address: 0xE8D165388b13c460F02f4dC922309450a9bF6f22
+Clanker token deployed at 0x15E91EAF0848c8FEfE8c287923B5A78E254A76eb!  View the transaction at 0xf67befc5da942288a7bb4baee2cbbc1a09853e62552e736aa272b91e09f918fa
+-------------------
+The Clanker token has been successfully deployed with the name "CDP Clanker" and symbol "CDPC." You can view the transaction [here](https://etherscan.io/tx/0xf67befc5da942288a7bb4baee2cbbc1a09853e62552e736aa272b91e09f918fa). The token address is 0x15E91EAF0848c8FEfE8c287923B5A78E254A76eb.
+-------------------
+```
+
+## Notes
+
+- Agent can define the description by adding a `description` field to the schema
+  - Currently description defaults to a short message describing who deployed it.
+- Likewise, agent can specify initial quote token.
+- Check the (Clanker docs)[https://github.com/clanker-devco/clanker-sdk] to see other configurable options (fees, admin, etc.).

--- a/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Clanker Action Provider tests
+ */
+
+import { clankerActionProvider } from "./clankerActionProvider";
+import { ClankTokenSchema } from "./schemas";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { Network } from "../../network";
+
+import { makeClanker } from "./utils/clankerBridge";
+
+jest.mock("./utils/clankerBridge", () => ({
+  makeClanker: jest.fn(),
+}));
+
+type MakeClanker = typeof makeClanker;
+const makeClankerMock = makeClanker as jest.MockedFunction<MakeClanker>;
+
+const DEPLOYED_HASH = "0xdeadbeef";
+const DEPLOYED_TOKEN_ADDRESS = "0xabc123abc123abc123abc123abc123abc123abc1";
+
+describe("Clanker action provider tests", () => {
+  const provider = clankerActionProvider();
+
+  let mockWalletProvider: jest.Mocked<EvmWalletProvider>;
+
+  beforeEach(() => {
+    mockWalletProvider = {
+      getAddress: jest.fn(),
+      getBalance: jest.fn(),
+      getName: jest.fn(),
+      getNetwork: jest.fn().mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "base-mainnet",
+      }),
+      nativeTransfer: jest.fn(),
+    } as unknown as jest.Mocked<EvmWalletProvider>;
+
+    const fakeClanker = {
+      deploy: jest.fn(async _tokenCfg => ({
+        txHash: DEPLOYED_HASH as `0x${string}`,
+        waitForTransaction: async () => ({ address: DEPLOYED_TOKEN_ADDRESS as `0x${string}` }),
+      })),
+    };
+
+    makeClankerMock.mockResolvedValue(fakeClanker as unknown as Awaited<ReturnType<MakeClanker>>);
+  });
+
+  describe("network validation", () => {
+    it("should support the protocol family and network", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "evm",
+          networkId: "base-mainnet",
+        } as Network),
+      ).toBe(true);
+    });
+
+    it("should not support other protocol families", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "other-protocol-family",
+        } as Network),
+      ).toBe(false);
+    });
+
+    it("should handle invalid network objects", () => {
+      expect(provider.supportsNetwork({ protocolFamily: "invalid-protocol" } as Network)).toBe(
+        false,
+      );
+      expect(provider.supportsNetwork({} as Network)).toBe(false);
+    });
+  });
+
+  describe("schema validation", () => {
+    it("should validate example action schema", () => {
+      const validInput = {
+        tokenName: "testTokenName",
+        tokenSymbol: "TTN",
+        image: "https://test.com",
+        vestingPercentage: 10,
+        vestingDuration_Days: 30,
+        lockDuration_Days: 30,
+      };
+      const parseResult = ClankTokenSchema.safeParse(validInput);
+      expect(parseResult.success).toBe(true);
+      if (parseResult.success) {
+        expect(parseResult.data.tokenName).toBe("testTokenName");
+        expect(parseResult.data.tokenSymbol).toBe("TTN");
+        expect(parseResult.data.image).toBe("https://test.com");
+        expect(parseResult.data.vestingPercentage).toBe(10);
+        expect(parseResult.data.vestingDuration_Days).toBe(30);
+        expect(parseResult.data.lockDuration_Days).toBe(30);
+      }
+    });
+
+    it("should reject invalid example action input", () => {
+      const invalidInput = {
+        fieldName: "",
+        amount: "invalid",
+      };
+      const parseResult = ClankTokenSchema.safeParse(invalidInput);
+      expect(parseResult.success).toBe(false);
+    });
+  });
+
+  describe("clanker action execution", () => {
+    it("should execute the clanker action with wallet provider", async () => {
+      const args = {
+        tokenName: "testTokenName",
+        tokenSymbol: "TTN",
+        image: "https://test.com",
+        vestingPercentage: 10,
+        vestingDuration_Days: 30,
+        lockDuration_Days: 30,
+      };
+      const result = await provider.clankToken(mockWalletProvider, args);
+      expect(result).toContain(`Clanker token deployed at ${DEPLOYED_TOKEN_ADDRESS}`);
+      expect(result).toContain(`View the transaction at ${DEPLOYED_HASH}`);
+      expect(mockWalletProvider.getNetwork).toHaveBeenCalled();
+
+      expect(makeClankerMock).toHaveBeenCalledWith(expect.any(Object), expect.any(String));
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.test.ts
@@ -9,7 +9,7 @@ import { Network } from "../../network";
 
 import { createClankerClient } from "./utils";
 
-jest.mock("./utils/clankerBridge", () => ({
+jest.mock("./utils", () => ({
   createClankerClient: jest.fn(),
 }));
 

--- a/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.ts
@@ -1,0 +1,120 @@
+/**
+ * Clanker Action Provider
+ *
+ * This file contains the implementation of the ClankerActionProvider,
+ * which provides actions for clanker operations.
+ *
+ * @module clanker
+ */
+
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { Network } from "../../network";
+import { CreateAction } from "../actionDecorator";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { ClankTokenSchema } from "./schemas";
+import { makeClanker } from "./utils/clankerBridge";
+
+/**
+ * ClankerActionProvider provides actions for clanker operations.
+ *
+ * @description
+ * This provider is designed to work with EvmWalletProvider for blockchain interactions.
+ * It supports all evm networks.
+ */
+export class ClankerActionProvider extends ActionProvider<EvmWalletProvider> {
+  /**
+   * Constructor for the ClankerActionProvider.
+   */
+  constructor() {
+    super("clanker", []);
+  }
+
+  /**
+   * Clanker action provider
+   *
+   * @description
+   * This action deploys a clanker token using the Clanker sdk
+   * It automatically includes the coin in the Clanker ecosystem
+   *
+   * @param walletProvider - The wallet provider instance for blockchain interactions
+   * @param args - Clanker arguments (modify these to fine tune token deployment, like initial quote token and rewards config)
+   * @returns A promise that resolves to a string describing the clanker result
+   */
+  @CreateAction({
+    name: "clank_token",
+    description: `
+This tool will launch a token (called a Clanker, named after the token launch protocol).
+Clanker tokens can only be launched when your network ID is 'base-mainnet'.
+  `,
+    schema: ClankTokenSchema,
+  })
+  async clankToken(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof ClankTokenSchema>,
+  ): Promise<string> {
+    const network = walletProvider.getNetwork();
+    const networkId = network.networkId || "base-mainnet";
+    if (!networkId || networkId !== "base-mainnet") {
+      return `Can't Clank token; network must be Base Mainnet`;
+    }
+
+    const clanker = await makeClanker(walletProvider, networkId);
+
+    const lockDuration = args.lockDuration_Days * 24 * 60 * 60;
+    const vestingDuration = args.vestingDuration_Days * 24 * 60 * 60;
+
+    const tokenConfig = {
+      name: args.tokenName,
+      symbol: args.tokenSymbol,
+      image: args.image,
+      context: {
+        interface: "Clanker SDK",
+        platform: "Clanker",
+        messageId: "Deploy Example",
+        id: "TKN-1",
+      },
+      tokenAdmin: walletProvider.getAddress() as `0x${string}`,
+      vault: {
+        percentage: args.vestingPercentage,
+        lockupDuration: lockDuration,
+        vestingDuration: vestingDuration,
+      },
+    };
+
+    const res = await clanker.deploy(tokenConfig);
+
+    if ("error" in res) {
+      return `There was an error deploying the clanker token: ${res}`;
+    }
+
+    const { txHash } = res;
+
+    const confirmed = await res.waitForTransaction();
+    if ("error" in confirmed) {
+      return `There was an error confirming the clanker token deployment: ${confirmed}`;
+    }
+
+    const { address } = confirmed;
+
+    return `Clanker token deployed at ${address}!  View the transaction at ${txHash}`;
+  }
+
+  /**
+   * Checks if this provider supports the given network.
+   *
+   * @param network - The network to check support for
+   * @returns True if the network is supported
+   */
+  supportsNetwork(network: Network): boolean {
+    // all protocol networks
+    return network.protocolFamily === "evm" && network.networkId == "base-mainnet";
+  }
+}
+
+/**
+ * Factory function to create a new ClankerActionProvider instance.
+ *
+ * @returns A new ClankerActionProvider instance
+ */
+export const clankerActionProvider = () => new ClankerActionProvider();

--- a/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/clanker/clankerActionProvider.ts
@@ -54,8 +54,8 @@ It takes the following inputs:
   ): Promise<string> {
     const network = walletProvider.getNetwork();
     const networkId = network.networkId || "base-mainnet";
-    if (!networkId || networkId !== "base-mainnet") {
-      return `Can't Clank token; network must be Base Mainnet`;
+    if (!this.supportsNetwork(network)) {
+      return `Can't Clank token; network ${networkId} is not supported`;
     }
 
     const clanker = await createClankerClient(walletProvider, networkId);
@@ -67,8 +67,10 @@ It takes the following inputs:
       name: args.tokenName,
       symbol: args.tokenSymbol,
       image: args.image,
-      description: args.description,
-      socialMediaUrls: args.socialMediaUrls,
+      metadata: {
+        socialMediaUrls: args.socialMediaUrls,
+        description: args.description,
+      },
       context: {
         interface: args.interface,
         id: args.id,
@@ -79,6 +81,7 @@ It takes the following inputs:
         lockupDuration: lockDuration,
         vestingDuration: vestingDuration,
       },
+      chainId: Number(network.chainId) as 8453 | 84532 | 42161 | undefined,
     };
 
     try {
@@ -110,7 +113,11 @@ It takes the following inputs:
    * @returns True if the network is supported
    */
   supportsNetwork(network: Network): boolean {
-    return network.protocolFamily === "evm" && network.networkId == "base-mainnet";
+    return (
+      network.networkId === "base-mainnet" ||
+      network.networkId === "base-sepolia" ||
+      network.networkId === "arbitrum-mainnet"
+    );
   }
 }
 

--- a/typescript/agentkit/src/action-providers/clanker/index.ts
+++ b/typescript/agentkit/src/action-providers/clanker/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Exports for clanker action provider
+ *
+ * @module clanker
+ */
+
+export * from "./clankerActionProvider";
+export * from "./schemas";
+
+// depending on usage, you might export the factory like this:
+// export { clankerActionProviderFactory } from "./clankerActionProvider";

--- a/typescript/agentkit/src/action-providers/clanker/index.ts
+++ b/typescript/agentkit/src/action-providers/clanker/index.ts
@@ -1,11 +1,2 @@
-/**
- * Exports for clanker action provider
- *
- * @module clanker
- */
-
 export * from "./clankerActionProvider";
 export * from "./schemas";
-
-// depending on usage, you might export the factory like this:
-// export { clankerActionProviderFactory } from "./clankerActionProvider";

--- a/typescript/agentkit/src/action-providers/clanker/schemas.ts
+++ b/typescript/agentkit/src/action-providers/clanker/schemas.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+/**
+ * Action schemas for the clanker action provider.
+ *
+ * This file contains the Zod schemas that define the shape and validation
+ * rules for action parameters in the clanker action provider.
+ */
+
+export const ClankTokenSchema = z.object({
+  /**
+   * Name of token
+   */
+  tokenName: z.string().min(1).max(100),
+
+  /**
+   * Symbol of token (lets keep it short <= 10)
+   */
+  tokenSymbol: z.string().min(1).max(10),
+
+  /**
+   * String URL pointing to image
+   */
+  image: z.string().url(),
+
+  /**
+   * Percentage of token for deployer initially locked
+   */
+  vestingPercentage: z.number().min(0).max(99),
+
+  /**
+   * Vesting duration of token after lockup has passed (in days)
+   */
+  vestingDuration_Days: z.number().min(0),
+
+  /**
+   * Lockup duration of token (in days), minimum 7 days
+   */
+  lockDuration_Days: z.number().min(7),
+});

--- a/typescript/agentkit/src/action-providers/clanker/schemas.ts
+++ b/typescript/agentkit/src/action-providers/clanker/schemas.ts
@@ -7,34 +7,46 @@ import { z } from "zod";
  * rules for action parameters in the clanker action provider.
  */
 
-export const ClankTokenSchema = z.object({
-  /**
-   * Name of token
-   */
-  tokenName: z.string().min(1).max(100),
-
-  /**
-   * Symbol of token (lets keep it short <= 10)
-   */
-  tokenSymbol: z.string().min(1).max(10),
-
-  /**
-   * String URL pointing to image
-   */
-  image: z.string().url(),
-
-  /**
-   * Percentage of token for deployer initially locked
-   */
-  vestingPercentage: z.number().min(0).max(99),
-
-  /**
-   * Vesting duration of token after lockup has passed (in days)
-   */
-  vestingDuration_Days: z.number().min(0),
-
-  /**
-   * Lockup duration of token (in days), minimum 7 days
-   */
-  lockDuration_Days: z.number().min(7),
-});
+export const ClankTokenSchema = z
+  .object({
+    tokenName: z.string().min(1).max(100).describe("The name of the token (max 100 characters)"),
+    tokenSymbol: z.string().min(1).max(10).describe("The symbol of the token (max 10 characters)"),
+    image: z.string().url().describe("Normal or ipfs URL pointing to the token image"),
+    vaultPercentage: z
+      .number()
+      .min(0)
+      .max(90)
+      .describe(
+        "Percentage of token supply allocated to a vault that can be claimed by deployer after lockup period with optional vesting",
+      ),
+    lockDuration_Days: z
+      .number()
+      .min(7)
+      .describe("Lockup duration of token (in days), minimum 7 days"),
+    vestingDuration_Days: z
+      .number()
+      .min(0)
+      .describe(
+        "Vesting duration of token after lockup has passed (in days). Vesting is linear over the duration",
+      ),
+    description: z
+      .string()
+      .optional()
+      .describe("Description of the token or token project (optional)"),
+    socialMediaUrls: z
+      .array(z.object({ platform: z.string(), url: z.string() }))
+      .optional()
+      .describe("Socials for the token. These may be displayed on aggregators."),
+    interface: z
+      .string()
+      .default("CDP AgentKit")
+      .describe('System the token was deployed via. Defaults to "CDP AgentKit".'),
+    id: z
+      .string()
+      .default("")
+      .describe(
+        "User id of the poster on the social platform the token was deployed from. Used for provenance and will be verified by aggregators.",
+      ),
+  })
+  .strip()
+  .describe("Instructions for deploying a Clanker token");

--- a/typescript/agentkit/src/action-providers/clanker/utils.ts
+++ b/typescript/agentkit/src/action-providers/clanker/utils.ts
@@ -1,15 +1,15 @@
 import { createWalletClient, http } from "viem";
-import { EvmWalletProvider } from "../../../wallet-providers";
-import { NETWORK_ID_TO_VIEM_CHAIN } from "../../../network";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { NETWORK_ID_TO_VIEM_CHAIN } from "../../network";
 
 /**
  * Creates the client Clanker expects from the EvmWalletProvider
  *
  * @param walletProvider - The wallet provider instance for blockchain interactions
- * @param networkId - The network to Clank on (this will most likely be Base, unless the action implementation is extended to include other networks)
+ * @param networkId - The network to Clank on
  * @returns The Clanker implementation
  */
-export async function makeClanker(walletProvider: EvmWalletProvider, networkId: string) {
+export async function createClankerClient(walletProvider: EvmWalletProvider, networkId: string) {
   const { Clanker } = await import("clanker-sdk/v4");
 
   const account = walletProvider.toSigner();
@@ -19,7 +19,7 @@ export async function makeClanker(walletProvider: EvmWalletProvider, networkId: 
   const wallet = createWalletClient({
     account,
     chain: NETWORK_ID_TO_VIEM_CHAIN[networkId],
-    transport: http(),
+    transport: http(publicClient.transport.url),
   });
 
   return new Clanker({ wallet, publicClient });

--- a/typescript/agentkit/src/action-providers/clanker/utils/clankerBridge.ts
+++ b/typescript/agentkit/src/action-providers/clanker/utils/clankerBridge.ts
@@ -1,0 +1,26 @@
+import { createWalletClient, http } from "viem";
+import { EvmWalletProvider } from "../../../wallet-providers";
+import { NETWORK_ID_TO_VIEM_CHAIN } from "../../../network";
+
+/**
+ * Creates the client Clanker expects from the EvmWalletProvider
+ *
+ * @param walletProvider - The wallet provider instance for blockchain interactions
+ * @param networkId - The network to Clank on (this will most likely be Base, unless the action implementation is extended to include other networks)
+ * @returns The Clanker implementation
+ */
+export async function makeClanker(walletProvider: EvmWalletProvider, networkId: string) {
+  const { Clanker } = await import("clanker-sdk/v4");
+
+  const account = walletProvider.toSigner();
+
+  const publicClient = walletProvider.getPublicClient();
+
+  const wallet = createWalletClient({
+    account,
+    chain: NETWORK_ID_TO_VIEM_CHAIN[networkId],
+    transport: http(),
+  });
+
+  return new Clanker({ wallet, publicClient });
+}

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -34,3 +34,4 @@ export * from "./x402";
 export * from "./zerion";
 export * from "./zerodev";
 export * from "./zora";
+export * from "./clanker";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       canonicalize:
         specifier: ^2.1.0
         version: 2.1.0
+      clanker-sdk:
+        specifier: ^4.1.18
+        version: 4.1.19(@types/node@22.13.14)(typescript@5.8.2)(viem@2.23.15(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2))
       decimal.js:
         specifier: ^10.5.0
         version: 10.5.0
@@ -1114,10 +1117,17 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@ethereumjs/common@3.2.0':
+    resolution: {integrity: sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==}
+
   '@ethereumjs/rlp@4.0.1':
     resolution: {integrity: sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  '@ethereumjs/tx@4.2.0':
+    resolution: {integrity: sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==}
+    engines: {node: '>=14'}
 
   '@ethereumjs/util@8.1.0':
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
@@ -1241,6 +1251,15 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@inquirer/external-editor@1.0.1':
+    resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -1383,9 +1402,25 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@metamask/abi-utils@2.0.4':
+    resolution: {integrity: sha512-StnIgUB75x7a7AgUhiaUZDpCsqGp7VkNnZh2XivXkJ6mPkE83U8ARGQj5MbRis7VJY8BC5V1AbB1fjdh0hupPQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@metamask/superstruct@3.2.1':
+    resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
+    engines: {node: '>=16.0.0'}
+
+  '@metamask/utils@9.3.0':
+    resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
+    engines: {node: '>=16.0.0'}
+
   '@modelcontextprotocol/sdk@1.8.0':
     resolution: {integrity: sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==}
     engines: {node: '>=18'}
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
@@ -1395,6 +1430,10 @@ packages:
 
   '@noble/curves@1.8.1':
     resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.0':
+    resolution: {integrity: sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/curves@1.9.2':
@@ -1440,6 +1479,9 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@openzeppelin/merkle-tree@1.0.8':
+    resolution: {integrity: sha512-E2c9/Y3vjZXwVvPZKqCKUn7upnvam1P1ZhowJyZVQSkzZm5WhumtaRr+wkUXrZVfkIc7Gfrl7xzabElqDL09ow==}
 
   '@pkgr/core@0.1.2':
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
@@ -1504,17 +1546,26 @@ packages:
   '@scure/base@1.2.4':
     resolution: {integrity: sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
   '@scure/bip32@1.6.2':
     resolution: {integrity: sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==}
 
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
 
   '@scure/bip39@1.5.4':
     resolution: {integrity: sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@shikijs/engine-oniguruma@1.29.2':
     resolution: {integrity: sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==}
@@ -1678,6 +1729,9 @@ packages:
   '@types/cross-spawn@6.0.6':
     resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
@@ -1713,6 +1767,9 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
@@ -2132,6 +2189,9 @@ packages:
   bip39@3.1.0:
     resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   bl@5.1.0:
     resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
 
@@ -2190,6 +2250,9 @@ packages:
 
   buffer-reverse@1.0.1:
     resolution: {integrity: sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -2256,6 +2319,9 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
+  chardet@2.1.0:
+    resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
+
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
 
@@ -2274,6 +2340,16 @@ packages:
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
+  clanker-sdk@4.1.19:
+    resolution: {integrity: sha512-oyDKnMW+ZZqeKZJnA2BZMoOR3QNOSX/5yf8s61NrmDx/HhEZJpqrxgHexDLQkbUi9pLle1bjAIZ8srQR7ZJEyQ==}
+    hasBin: true
+    peerDependencies:
+      viem: ^2.7.9
+
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2286,9 +2362,17 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
+  cli-width@3.0.0:
+    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
+    engines: {node: '>= 10'}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -2360,6 +2444,11 @@ packages:
   corser@2.0.1:
     resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
     engines: {node: '>= 0.4.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   create-hash@1.2.0:
     resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
@@ -2448,6 +2537,9 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2614,6 +2706,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -2746,6 +2842,10 @@ packages:
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
 
+  ethereum-cryptography@3.2.0:
+    resolution: {integrity: sha512-Urr5YVsalH+Jo0sYkTkv1MyI9bLYZwW8BENZCeE1QYaTHETEYx0Nv/SVsWkSqpYrzweg6d8KMY1wTjH/1m/BIg==}
+    engines: {node: ^14.21.3 || >=16, npm: '>=9'}
+
   ethers@5.8.0:
     resolution: {integrity: sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==}
 
@@ -2838,6 +2938,10 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  figures@3.2.0:
+    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
+    engines: {node: '>=8'}
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -3149,6 +3253,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inquirer@8.2.7:
+    resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
+    engines: {node: '>=12.0.0'}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -3234,6 +3342,10 @@ packages:
   is-hex-prefixed@1.0.0:
     resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
     engines: {node: '>=6.5.0', npm: '>=3'}
+
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
 
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
@@ -3632,6 +3744,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -3812,6 +3927,9 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
+  mute-stream@0.0.8:
+    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3954,6 +4072,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
 
   ora@7.0.1:
     resolution: {integrity: sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==}
@@ -4102,6 +4224,10 @@ packages:
   plur@4.0.0:
     resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==}
     engines: {node: '>=10'}
+
+  pony-cause@2.1.11:
+    resolution: {integrity: sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==}
+    engines: {node: '>=12.0.0'}
 
   portfinder@1.0.35:
     resolution: {integrity: sha512-73JaFg4NwYNAufDtS5FsFu/PdM49ahJrO1i44aCRsDWju1z5wuGDaqyFUQWR6aJoK2JPDWlaYYAGFNIGTSUHSw==}
@@ -4273,6 +4399,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4303,6 +4433,10 @@ packages:
 
   rpc-websockets@9.1.1:
     resolution: {integrity: sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==}
+
+  run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -4935,6 +5069,9 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
@@ -4983,6 +5120,10 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -5665,7 +5806,19 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
+  '@ethereumjs/common@3.2.0':
+    dependencies:
+      '@ethereumjs/util': 8.1.0
+      crc-32: 1.2.2
+
   '@ethereumjs/rlp@4.0.1': {}
+
+  '@ethereumjs/tx@4.2.0':
+    dependencies:
+      '@ethereumjs/common': 3.2.0
+      '@ethereumjs/rlp': 4.0.1
+      '@ethereumjs/util': 8.1.0
+      ethereum-cryptography: 2.2.1
 
   '@ethereumjs/util@8.1.0':
     dependencies:
@@ -5953,6 +6106,13 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@inquirer/external-editor@1.0.1(@types/node@22.13.14)':
+    dependencies:
+      chardet: 2.1.0
+      iconv-lite: 0.6.3
+    optionalDependencies:
+      '@types/node': 22.13.14
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -6421,6 +6581,29 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@metamask/abi-utils@2.0.4':
+    dependencies:
+      '@metamask/superstruct': 3.2.1
+      '@metamask/utils': 9.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@metamask/superstruct@3.2.1': {}
+
+  '@metamask/utils@9.3.0':
+    dependencies:
+      '@ethereumjs/tx': 4.2.0
+      '@metamask/superstruct': 3.2.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.4
+      '@types/debug': 4.1.12
+      debug: 4.4.0(supports-color@5.5.0)
+      pony-cause: 2.1.11
+      semver: 7.7.1
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.8.0':
     dependencies:
       content-type: 1.0.5
@@ -6436,6 +6619,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -6447,6 +6632,10 @@ snapshots:
   '@noble/curves@1.8.1':
     dependencies:
       '@noble/hashes': 1.7.1
+
+  '@noble/curves@1.9.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@noble/curves@1.9.2':
     dependencies:
@@ -6485,6 +6674,13 @@ snapshots:
       - utf-8-validate
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@openzeppelin/merkle-tree@1.0.8':
+    dependencies:
+      '@metamask/abi-utils': 2.0.4
+      ethereum-cryptography: 3.2.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@pkgr/core@0.1.2': {}
 
@@ -6555,6 +6751,8 @@ snapshots:
 
   '@scure/base@1.2.4': {}
 
+  '@scure/base@1.2.6': {}
+
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.2
@@ -6567,6 +6765,12 @@ snapshots:
       '@noble/hashes': 1.7.1
       '@scure/base': 1.2.4
 
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.6
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -6576,6 +6780,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.7.1
       '@scure/base': 1.2.4
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@shikijs/engine-oniguruma@1.29.2':
     dependencies:
@@ -6821,6 +7030,10 @@ snapshots:
     dependencies:
       '@types/node': 20.17.27
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/diff-match-patch@1.0.36': {}
 
   '@types/eslint@7.29.0':
@@ -6858,6 +7071,8 @@ snapshots:
   '@types/json5@0.0.29': {}
 
   '@types/minimist@1.2.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node-fetch@2.6.12':
     dependencies:
@@ -7360,6 +7575,12 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   bl@5.1.0:
     dependencies:
       buffer: 6.0.3
@@ -7440,6 +7661,11 @@ snapshots:
 
   buffer-reverse@1.0.1: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -7498,6 +7724,8 @@ snapshots:
 
   chardet@0.7.0: {}
 
+  chardet@2.1.0: {}
+
   charenc@0.0.2: {}
 
   chokidar@3.6.0:
@@ -7521,6 +7749,23 @@ snapshots:
 
   cjs-module-lexer@1.4.3: {}
 
+  clanker-sdk@4.1.19(@types/node@22.13.14)(typescript@5.8.2)(viem@2.23.15(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)):
+    dependencies:
+      '@openzeppelin/merkle-tree': 1.0.8
+      abitype: 1.0.8(typescript@5.8.2)(zod@3.25.56)
+      dotenv: 16.4.7
+      inquirer: 8.2.7(@types/node@22.13.14)
+      viem: 2.23.15(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)
+      zod: 3.25.56
+    transitivePeerDependencies:
+      - '@types/node'
+      - supports-color
+      - typescript
+
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
   cli-cursor@4.0.0:
     dependencies:
       restore-cursor: 4.0.0
@@ -7531,11 +7776,15 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cli-width@3.0.0: {}
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clone@1.0.4: {}
 
   co@4.6.0: {}
 
@@ -7583,6 +7832,8 @@ snapshots:
       vary: 1.1.2
 
   corser@2.0.1: {}
+
+  crc-32@1.2.2: {}
 
   create-hash@1.2.0:
     dependencies:
@@ -7682,6 +7933,10 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
 
   define-data-property@1.1.4:
     dependencies:
@@ -7899,6 +8154,8 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@1.0.5: {}
+
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -8084,6 +8341,14 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
+  ethereum-cryptography@3.2.0:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.0
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+
   ethers@5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@ethersproject/abi': 5.8.0
@@ -8252,6 +8517,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  figures@3.2.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -8579,6 +8848,26 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inquirer@8.2.7(@types/node@22.13.14):
+    dependencies:
+      '@inquirer/external-editor': 1.0.1(@types/node@22.13.14)
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-width: 3.0.0
+      figures: 3.2.0
+      lodash: 4.17.21
+      mute-stream: 0.0.8
+      ora: 5.4.1
+      run-async: 2.4.1
+      rxjs: 7.8.2
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      through: 2.3.8
+      wrap-ansi: 6.2.0
+    transitivePeerDependencies:
+      - '@types/node'
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -8661,6 +8950,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hex-prefixed@1.0.0: {}
+
+  is-interactive@1.0.0: {}
 
   is-interactive@2.0.0: {}
 
@@ -9356,6 +9647,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash@4.17.21: {}
+
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
@@ -9527,6 +9820,8 @@ snapshots:
   multiformats@13.3.2: {}
 
   mustache@4.2.0: {}
+
+  mute-stream@0.0.8: {}
 
   nanoid@3.3.11: {}
 
@@ -9743,6 +10038,18 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
   ora@7.0.1:
     dependencies:
       chalk: 5.4.1
@@ -9910,6 +10217,8 @@ snapshots:
   plur@4.0.0:
     dependencies:
       irregular-plurals: 3.5.0
+
+  pony-cause@2.1.11: {}
 
   portfinder@1.0.35:
     dependencies:
@@ -10089,6 +10398,11 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   restore-cursor@4.0.0:
     dependencies:
       onetime: 5.1.2
@@ -10130,6 +10444,8 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
+
+  run-async@2.4.1: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -10887,6 +11203,10 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
   web-streams-polyfill@4.0.0-beta.3: {}
 
   web3-utils@1.10.4:
@@ -10963,6 +11283,12 @@ snapshots:
       bs58check: 2.1.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
# Clanker Action Provider

## Description

This action adds Clanker token deployment support to the typescript implementation of AgentKit.

Although Clanker already has an agent that deploys tokens, their open library and protocol allows anyone to launch a "Clank" token and be recognized by their ecosystem.

## Tests

```
Chatbot: langchain-cdp-chatbot
Network: Base Mainnet
Setup: Add ClankerActionProvider to the chatbot
```

```
Prompt: Can you clank a token with name [CDP Clanker], and symbol [CDPC] and image hosted at [https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQF6hcTTU1A8Ymi2VldXqCsPkBu_ltAhIKiRg&s]?  vest 10%, locked for 30 days, and then vested for 30 days.  do this on base-mainnet
```

```
Response:
-------------------
Internal address: 0xE8D165388b13c460F02f4dC922309450a9bF6f22
Clanker token deployed at 0x15E91EAF0848c8FEfE8c287923B5A78E254A76eb!  View the transaction at 0xf67befc5da942288a7bb4baee2cbbc1a09853e62552e736aa272b91e09f918fa
-------------------
The Clanker token has been successfully deployed with the name "CDP Clanker" and symbol "CDPC." You can view the transaction [here](https://etherscan.io/tx/0xf67befc5da942288a7bb4baee2cbbc1a09853e62552e736aa272b91e09f918fa). The token address is 0x15E91EAF0848c8FEfE8c287923B5A78E254A76eb.
-------------------
```

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry
