### PR TITLE
Fix unit issues in balance/transfer actions

### DIFF
--- a/typescript/.changeset/fruity-heads-visit.md
+++ b/typescript/.changeset/fruity-heads-visit.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Fixed unit issues in balance/transfer actions; Added new action to get frequently used token addresses by symbol

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -272,6 +272,10 @@ const agent = createReactAgent({
     <td width="200"><code>transfer</code></td>
     <td width="768">Transfers a specified amount of ERC-20 tokens to a destination address.</td>
 </tr>
+<tr>
+    <td width="200"><code>get_erc20_token_address</code></td>
+    <td width="768">Gets the contract address for frequently used ERC20 tokens on different networks by token symbol.</td>
+</tr>
 </table>
 </details>
 <details>

--- a/typescript/agentkit/src/action-providers/across/acrossActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/across/acrossActionProvider.ts
@@ -7,7 +7,7 @@ import { BridgeTokenSchema, CheckDepositStatusSchema } from "./schemas";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { isAcrossSupportedTestnet } from "./utils";
 import { privateKeyToAccount } from "viem/accounts";
-import { abi as ERC20_ABI } from "../erc20/constants";
+import { erc20Abi as ERC20_ABI } from "viem";
 /**
  * Configuration options for the SafeWalletProvider.
  */

--- a/typescript/agentkit/src/action-providers/cdp/cdpEvmWalletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpEvmWalletActionProvider.ts
@@ -136,7 +136,8 @@ It takes the following inputs:
 - slippageBps: (Optional) Maximum allowed slippage in basis points (100 = 1%)
 Important notes:
 - The contract address for native ETH is "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-- Use fromAmount units exactly as provided, do not convert to wei or any other units.
+- Use fromAmount units exactly as provided, do not convert to wei or any other units
+- Never assume token or address, they have to be provided as inputs. If only token symbol is provided, use the get_token_address tool if available to get the token address first
 `,
     schema: SwapSchema,
   })
@@ -221,6 +222,7 @@ Important notes:
 - The contract address for native ETH is "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 - If needed, it will automatically approve the permit2 contract to spend the fromToken
 - Use fromAmount units exactly as provided, do not convert to wei or any other units.
+- Never assume token or address, they have to be provided as inputs. If only token symbol is provided, use the get_token_address tool if available to get the token address first
 `,
     schema: SwapSchema,
   })

--- a/typescript/agentkit/src/action-providers/cdp/cdpSmartWalletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/cdp/cdpSmartWalletActionProvider.ts
@@ -121,7 +121,8 @@ It takes the following inputs:
 - slippageBps: (Optional) Maximum allowed slippage in basis points (100 = 1%)
 Important notes:
 - The contract address for native ETH is "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-- Use fromAmount units exactly as provided, do not convert to wei or any other units.
+- Use fromAmount units exactly as provided, do not convert to wei or any other units
+- Never assume token or address, they have to be provided as inputs. If only token symbol is provided, use the get_token_address tool if available to get the token address first
 `,
     schema: SwapSchema,
   })
@@ -206,7 +207,8 @@ It takes the following inputs:
 Important notes:
 - The contract address for native ETH is "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 - If needed, it will automatically approve the permit2 contract to spend the fromToken
-- Use fromAmount units exactly as provided, do not convert to wei or any other units.
+- Use fromAmount units exactly as provided, do not convert to wei or any other units
+- Never assume token or address, they have to be provided as inputs. If only token symbol is provided, use the get_token_address tool if available to get the token address first
 `,
     schema: SwapSchema,
   })

--- a/typescript/agentkit/src/action-providers/compound/constants.ts
+++ b/typescript/agentkit/src/action-providers/compound/constants.ts
@@ -1,5 +1,5 @@
 import { Address } from "viem";
-import { abi as ERC20_ABI } from "../erc20/constants";
+import { erc20Abi as ERC20_ABI } from "viem";
 
 export const SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"];
 

--- a/typescript/agentkit/src/action-providers/erc20/README.md
+++ b/typescript/agentkit/src/action-providers/erc20/README.md
@@ -11,6 +11,7 @@ erc20/
 ├── constants.ts                   # Constants for ERC20 provider
 ├── schemas.ts                     # Token action schemas
 ├── index.ts                       # Main exports
+├── utils.ts                       # Utility functions
 └── README.md                      # This file
 ```
 
@@ -25,6 +26,12 @@ erc20/
 
   - Constructs and sends the transfer transaction
   - Returns the **transaction hash** upon success
+
+- `get_erc20_token_address`: Get the contract address for a token symbol
+
+  - Takes a token symbol (e.g. USDC, EURC, CBBTC) as input
+  - Returns the **contract address** for the token on the current network
+  - Provides available token symbols if the requested symbol is not found
 
 ## Adding New Actions
 

--- a/typescript/agentkit/src/action-providers/erc20/constants.ts
+++ b/typescript/agentkit/src/action-providers/erc20/constants.ts
@@ -16,14 +16,14 @@ export const BaseSepoliaTokenToAssetId = new Map([
 export const TOKEN_ADDRESSES_BY_SYMBOLS = {
   "base-mainnet": {
     USDC: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-    EURC: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42", 
+    EURC: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
     CBBTC: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
     CBETH: "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
     WETH: "0x4200000000000000000000000000000000000006",
     ZORA: "0x1111111111166b7FE7bd91427724B487980aFc69",
     AERO: "0x940181a94a35a4569e4529a3cdfb74e38fd98631",
     BNKR: "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b",
-    CLANKER: "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb"
+    CLANKER: "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb",
   },
   "base-sepolia": {
     USDC: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
@@ -31,20 +31,20 @@ export const TOKEN_ADDRESSES_BY_SYMBOLS = {
     CBBTC: "0xcbB7C0006F23900c38EB856149F799620fcb8A4a",
     WETH: "0x4200000000000000000000000000000000000006",
   },
-  "ethereum-mainnet":{
+  "ethereum-mainnet": {
     USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     EURC: "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
     CBBTC: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
     WETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     CBETH: "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
   },
-  "polygon-mainnet":{
+  "polygon-mainnet": {
     USDC: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
   },
-  "arbitrum-mainnet":{
+  "arbitrum-mainnet": {
     USDC: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
   },
-  "optimism-mainnet":{
+  "optimism-mainnet": {
     USDC: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
-  }
+  },
 } as const;

--- a/typescript/agentkit/src/action-providers/erc20/constants.ts
+++ b/typescript/agentkit/src/action-providers/erc20/constants.ts
@@ -1,194 +1,5 @@
 import { Coinbase } from "@coinbase/coinbase-sdk";
 
-export const abi = [
-  {
-    type: "event",
-    name: "Approval",
-    inputs: [
-      {
-        indexed: true,
-        name: "owner",
-        type: "address",
-      },
-      {
-        indexed: true,
-        name: "spender",
-        type: "address",
-      },
-      {
-        indexed: false,
-        name: "value",
-        type: "uint256",
-      },
-    ],
-  },
-  {
-    type: "event",
-    name: "Transfer",
-    inputs: [
-      {
-        indexed: true,
-        name: "from",
-        type: "address",
-      },
-      {
-        indexed: true,
-        name: "to",
-        type: "address",
-      },
-      {
-        indexed: false,
-        name: "value",
-        type: "uint256",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "allowance",
-    stateMutability: "view",
-    inputs: [
-      {
-        name: "owner",
-        type: "address",
-      },
-      {
-        name: "spender",
-        type: "address",
-      },
-    ],
-    outputs: [
-      {
-        type: "uint256",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "approve",
-    stateMutability: "nonpayable",
-    inputs: [
-      {
-        name: "spender",
-        type: "address",
-      },
-      {
-        name: "amount",
-        type: "uint256",
-      },
-    ],
-    outputs: [
-      {
-        type: "bool",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "balanceOf",
-    stateMutability: "view",
-    inputs: [
-      {
-        name: "account",
-        type: "address",
-      },
-    ],
-    outputs: [
-      {
-        type: "uint256",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "decimals",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      {
-        type: "uint8",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "name",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      {
-        type: "string",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "symbol",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      {
-        type: "string",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "totalSupply",
-    stateMutability: "view",
-    inputs: [],
-    outputs: [
-      {
-        type: "uint256",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "transfer",
-    stateMutability: "nonpayable",
-    inputs: [
-      {
-        name: "recipient",
-        type: "address",
-      },
-      {
-        name: "amount",
-        type: "uint256",
-      },
-    ],
-    outputs: [
-      {
-        type: "bool",
-      },
-    ],
-  },
-  {
-    type: "function",
-    name: "transferFrom",
-    stateMutability: "nonpayable",
-    inputs: [
-      {
-        name: "sender",
-        type: "address",
-      },
-      {
-        name: "recipient",
-        type: "address",
-      },
-      {
-        name: "amount",
-        type: "uint256",
-      },
-    ],
-    outputs: [
-      {
-        type: "bool",
-      },
-    ],
-  },
-] as const;
-
 export const BaseTokenToAssetId = new Map([
   ["0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf", Coinbase.assets.Cbbtc],
   ["0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", Coinbase.assets.Usdc],
@@ -200,3 +11,17 @@ export const BaseSepoliaTokenToAssetId = new Map([
   ["0x036CbD53842c5426634e7929541eC2318f3dCF7e", Coinbase.assets.Usdc],
   ["0x808456652fdb597867f38412077A9182bf77359F", Coinbase.assets.Eurc],
 ]);
+
+// Compact token symbol mappings using existing addresses only
+export const TOKEN_SYMBOLS = {
+  "base-mainnet": {
+    USDC: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    EURC: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42", 
+    CBBTC: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+  },
+  "base-sepolia": {
+    USDC: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    EURC: "0x808456652fdb597867f38412077A9182bf77359F",
+    CBBTC: "0xcbB7C0006F23900c38EB856149F799620fcb8A4a"
+  }
+} as const;

--- a/typescript/agentkit/src/action-providers/erc20/constants.ts
+++ b/typescript/agentkit/src/action-providers/erc20/constants.ts
@@ -12,16 +12,39 @@ export const BaseSepoliaTokenToAssetId = new Map([
   ["0x808456652fdb597867f38412077A9182bf77359F", Coinbase.assets.Eurc],
 ]);
 
-// Compact token symbol mappings using existing addresses only
-export const TOKEN_SYMBOLS = {
+// Token symbol to address mappings for frequently used tokens
+export const TOKEN_ADDRESSES_BY_SYMBOLS = {
   "base-mainnet": {
     USDC: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     EURC: "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42", 
-    CBBTC: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    CBBTC: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    CBETH: "0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
+    WETH: "0x4200000000000000000000000000000000000006",
+    ZORA: "0x1111111111166b7FE7bd91427724B487980aFc69",
+    AERO: "0x940181a94a35a4569e4529a3cdfb74e38fd98631",
+    BNKR: "0x22af33fe49fd1fa80c7149773dde5890d3c76f3b",
+    CLANKER: "0x1bc0c42215582d5a085795f4badbac3ff36d1bcb"
   },
   "base-sepolia": {
     USDC: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
     EURC: "0x808456652fdb597867f38412077A9182bf77359F",
-    CBBTC: "0xcbB7C0006F23900c38EB856149F799620fcb8A4a"
+    CBBTC: "0xcbB7C0006F23900c38EB856149F799620fcb8A4a",
+    WETH: "0x4200000000000000000000000000000000000006",
+  },
+  "ethereum-mainnet":{
+    USDC: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    EURC: "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c",
+    CBBTC: "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    WETH: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    CBETH: "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+  },
+  "polygon-mainnet":{
+    USDC: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+  },
+  "arbitrum-mainnet":{
+    USDC: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+  },
+  "optimism-mainnet":{
+    USDC: "0x0b2c639c533813f4aa9d7837caf62653d097ff85",
   }
 } as const;

--- a/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
@@ -1,8 +1,8 @@
 import { erc20ActionProvider } from "./erc20ActionProvider";
-import { TransferSchema } from "./schemas";
+import { TransferSchema, GetTokenAddressSchema } from "./schemas";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { encodeFunctionData, Hex } from "viem";
-import { abi } from "./constants";
+import { erc20Abi as abi } from "viem";
 
 const MOCK_AMOUNT = 15;
 const MOCK_DECIMALS = 6;
@@ -48,13 +48,13 @@ describe("Get Balance Action", () => {
     mockWallet.readContract.mockResolvedValueOnce(MOCK_DECIMALS);
 
     const args = {
-      contractAddress: MOCK_CONTRACT_ADDRESS,
+      tokenAddress: MOCK_CONTRACT_ADDRESS,
     };
 
     const response = await actionProvider.getBalance(mockWallet, args);
 
     expect(mockWallet.readContract).toHaveBeenCalledWith({
-      address: args.contractAddress as Hex,
+      address: args.tokenAddress as Hex,
       abi,
       functionName: "balanceOf",
       args: [mockWallet.getAddress()],
@@ -66,7 +66,7 @@ describe("Get Balance Action", () => {
 
   it("should fail with an error", async () => {
     const args = {
-      contractAddress: MOCK_CONTRACT_ADDRESS,
+      tokenAddress: MOCK_CONTRACT_ADDRESS,
     };
 
     const error = new Error("Failed to get balance");
@@ -75,7 +75,7 @@ describe("Get Balance Action", () => {
     const response = await actionProvider.getBalance(mockWallet, args);
 
     expect(mockWallet.readContract).toHaveBeenCalledWith({
-      address: args.contractAddress as Hex,
+      address: args.tokenAddress as Hex,
       abi,
       functionName: "balanceOf",
       args: [mockWallet.getAddress()],
@@ -109,18 +109,18 @@ describe("Transfer Action", () => {
   it("should successfully respond", async () => {
     const args = {
       amount: BigInt(MOCK_AMOUNT),
-      contractAddress: MOCK_CONTRACT_ADDRESS,
-      destination: MOCK_DESTINATION,
+      tokenAddress: MOCK_CONTRACT_ADDRESS,
+      destinationAddress: MOCK_DESTINATION,
     };
 
     const response = await actionProvider.transfer(mockWallet, args);
 
     expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-      to: args.contractAddress as Hex,
+      to: args.tokenAddress as Hex,
       data: encodeFunctionData({
         abi,
         functionName: "transfer",
-        args: [args.destination as Hex, BigInt(args.amount)],
+        args: [args.destinationAddress as Hex, BigInt(args.amount)],
       }),
     });
     expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(TRANSACTION_HASH);
@@ -133,8 +133,8 @@ describe("Transfer Action", () => {
   it("should fail with an error", async () => {
     const args = {
       amount: BigInt(MOCK_AMOUNT),
-      contractAddress: MOCK_CONTRACT_ADDRESS,
-      destination: MOCK_DESTINATION,
+      tokenAddress: MOCK_CONTRACT_ADDRESS,
+      destinationAddress: MOCK_DESTINATION,
     };
 
     const error = new Error("Failed to execute transfer");
@@ -143,11 +143,11 @@ describe("Transfer Action", () => {
     const response = await actionProvider.transfer(mockWallet, args);
 
     expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
-      to: args.contractAddress as Hex,
+      to: args.tokenAddress as Hex,
       data: encodeFunctionData({
         abi,
         functionName: "transfer",
-        args: [args.destination as Hex, BigInt(args.amount)],
+        args: [args.destinationAddress as Hex, BigInt(args.amount)],
       }),
     });
     expect(response).toContain(`Error transferring the asset: ${error}`);
@@ -161,5 +161,92 @@ describe("Transfer Action", () => {
     it("should return false when protocolFamily is not evm", () => {
       expect(actionProvider.supportsNetwork({ protocolFamily: "solana" })).toBe(false);
     });
+  });
+});
+
+describe("GetTokenAddress Schema", () => {
+  it("should successfully parse valid token symbol", () => {
+    const validInput = { symbol: "usdc" };
+    const result = GetTokenAddressSchema.safeParse(validInput);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.symbol).toBe("USDC"); // Should be uppercase
+  });
+
+  it("should fail parsing empty symbol", () => {
+    const emptyInput = { symbol: "" };
+    const result = GetTokenAddressSchema.safeParse(emptyInput);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("should fail parsing symbol too long", () => {
+    const longInput = { symbol: "VERYLONGTOKENSYMBOL" };
+    const result = GetTokenAddressSchema.safeParse(longInput);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("Get Token Address Action", () => {
+  let mockWallet: jest.Mocked<EvmWalletProvider>;
+  const actionProvider = erc20ActionProvider();
+
+  beforeEach(() => {
+    mockWallet = {
+      getNetwork: jest.fn(),
+    } as any;
+  });
+
+  it("should return token address for valid symbol on base-mainnet", async () => {
+    mockWallet.getNetwork.mockReturnValue({
+      protocolFamily: "evm",
+      networkId: "base-mainnet",
+    });
+
+    const response = await actionProvider.getTokenAddress(mockWallet, { symbol: "USDC" });
+    expect(response).toContain("Token address for USDC on base-mainnet: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+  });
+
+  it("should return token address for valid symbol on base-sepolia", async () => {
+    mockWallet.getNetwork.mockReturnValue({
+      protocolFamily: "evm",
+      networkId: "base-sepolia",
+    });
+
+    const response = await actionProvider.getTokenAddress(mockWallet, { symbol: "EURC" });
+    expect(response).toContain("Token address for EURC on base-sepolia: 0x808456652fdb597867f38412077A9182bf77359F");
+  });
+
+  it("should return error for unsupported network", async () => {
+    mockWallet.getNetwork.mockReturnValue({
+      protocolFamily: "evm",
+      networkId: "ethereum-mainnet",
+    });
+
+    const response = await actionProvider.getTokenAddress(mockWallet, { symbol: "USDC" });
+    expect(response).toContain("Error: Network ethereum-mainnet is not supported for token symbol lookup");
+    expect(response).toContain("base-mainnet, base-sepolia");
+  });
+
+  it("should return error for unknown token symbol", async () => {
+    mockWallet.getNetwork.mockReturnValue({
+      protocolFamily: "evm",
+      networkId: "base-mainnet",
+    });
+
+    const response = await actionProvider.getTokenAddress(mockWallet, { symbol: "UNKNOWN" });
+    expect(response).toContain('Error: Token symbol "UNKNOWN" not found on base-mainnet');
+    expect(response).toContain("USDC, EURC, CBBTC");
+  });
+
+  it("should return error when network ID is not available", async () => {
+    mockWallet.getNetwork.mockReturnValue({
+      protocolFamily: "evm",
+      // networkId is undefined
+    });
+
+    const response = await actionProvider.getTokenAddress(mockWallet, { symbol: "USDC" });
+    expect(response).toContain("Error: Network ID is not available. Cannot perform token symbol lookup.");
   });
 });

--- a/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
@@ -108,7 +108,7 @@ describe("Transfer Action", () => {
 
   it("should successfully respond", async () => {
     const args = {
-      amount: BigInt(MOCK_AMOUNT),
+      amount: MOCK_AMOUNT.toString(),
       tokenAddress: MOCK_CONTRACT_ADDRESS,
       destinationAddress: MOCK_DESTINATION,
     };
@@ -132,7 +132,7 @@ describe("Transfer Action", () => {
 
   it("should fail with an error", async () => {
     const args = {
-      amount: BigInt(MOCK_AMOUNT),
+      amount: MOCK_AMOUNT.toString(),
       tokenAddress: MOCK_CONTRACT_ADDRESS,
       destinationAddress: MOCK_DESTINATION,
     };

--- a/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.test.ts
@@ -1,8 +1,6 @@
 import { erc20ActionProvider } from "./erc20ActionProvider";
 import { TransferSchema, GetTokenAddressSchema } from "./schemas";
 import { EvmWalletProvider } from "../../wallet-providers";
-import { encodeFunctionData, Hex } from "viem";
-import { erc20Abi as abi } from "viem";
 
 const MOCK_AMOUNT = 15;
 const MOCK_DECIMALS = 6;
@@ -43,7 +41,7 @@ describe("Get Balance Action", () => {
       multicall: mockMulticall,
       getCode: jest.fn().mockResolvedValue("0x"),
     };
-    
+
     mockWallet = {
       getAddress: jest.fn().mockReturnValue(MOCK_ADDRESS),
       getPublicClient: jest.fn().mockReturnValue(mockPublicClient),
@@ -98,7 +96,7 @@ describe("Transfer Action", () => {
       multicall: mockMulticall,
       getCode: jest.fn().mockResolvedValue("0x"),
     };
-    
+
     mockWallet = {
       sendTransaction: jest.fn(),
       waitForTransactionReceipt: jest.fn(),
@@ -118,9 +116,9 @@ describe("Transfer Action", () => {
     mockMulticall.mockResolvedValueOnce([
       { result: "MockToken" }, // name
       { result: MOCK_DECIMALS }, // decimals
-      { result: BigInt(100000 * 10 ** MOCK_DECIMALS) }, // balance 
+      { result: BigInt(100000 * 10 ** MOCK_DECIMALS) }, // balance
     ]);
-    
+
     const args = {
       amount: MOCK_AMOUNT.toString(),
       tokenAddress: MOCK_CONTRACT_ADDRESS,
@@ -128,7 +126,6 @@ describe("Transfer Action", () => {
     };
 
     const response = await actionProvider.transfer(mockWallet, args);
-
 
     expect(mockMulticall).toHaveBeenCalled();
     expect(mockWallet.sendTransaction).toHaveBeenCalled();
@@ -141,7 +138,7 @@ describe("Transfer Action", () => {
 
   it("should fail with an error", async () => {
     mockMulticall.mockRejectedValue(new Error("Failed to get token details"));
-    
+
     const args = {
       amount: MOCK_AMOUNT.toString(),
       tokenAddress: MOCK_CONTRACT_ADDRESS,
@@ -230,9 +227,7 @@ describe("Get Token Address Action", () => {
     });
 
     const response = await actionProvider.getTokenAddress(mockWallet, { symbol: "USDC" });
-    expect(response).toContain(
-      'Error: Token symbol "USDC" not found on unsupported-network',
-    );
+    expect(response).toContain('Error: Token symbol "USDC" not found on unsupported-network');
   });
 
   it("should return error for unknown token symbol", async () => {
@@ -253,8 +248,6 @@ describe("Get Token Address Action", () => {
     });
 
     const response = await actionProvider.getTokenAddress(mockWallet, { symbol: "USDC" });
-    expect(response).toContain(
-      'Error: Token symbol "USDC" not found on undefined',
-    );
+    expect(response).toContain('Error: Token symbol "USDC" not found on undefined');
   });
 });

--- a/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/erc20/erc20ActionProvider.ts
@@ -72,7 +72,6 @@ It takes the following inputs:
 - amount: The amount to transfer in whole units (e.g. 10.5 USDC)
 - tokenAddress: The contract address of the token to transfer
 - destinationAddress: Where to send the funds (can be an onchain address, ENS 'example.eth', or Basename 'example.base.eth')
-- address: (Optional) The address to check the balance for. If not provided, uses the wallet's address
 Important notes:
 - Never assume token or destination addresses, they have to be provided as inputs. If only token symbol is provided, use the get_token_address tool to get the token address first
 `,
@@ -135,7 +134,7 @@ Important notes:
         const hash = await cdpWallet.gaslessERC20Transfer(
           assetId,
           args.destinationAddress as Hex,
-          amountInWei,
+          BigInt(args.amount),
         );
 
         await walletProvider.waitForTransactionReceipt(hash);
@@ -155,8 +154,7 @@ Important notes:
         }),
       });
 
-      const receipt = await walletProvider.waitForTransactionReceipt(hash);
-      console.log(receipt);
+      await walletProvider.waitForTransactionReceipt(hash);
 
       return `Transferred ${args.amount} of ${tokenDetails?.name} (${args.tokenAddress}) to ${
         args.destinationAddress

--- a/typescript/agentkit/src/action-providers/erc20/schemas.ts
+++ b/typescript/agentkit/src/action-providers/erc20/schemas.ts
@@ -43,7 +43,12 @@ export const GetBalanceSchema = z
  */
 export const GetTokenAddressSchema = z
   .object({
-    symbol: z.string().min(1).max(10).toUpperCase().describe("The token symbol (e.g., USDC, WETH, DEGEN)"),
+    symbol: z
+      .string()
+      .min(1)
+      .max(10)
+      .toUpperCase()
+      .describe("The token symbol (e.g., USDC, WETH, DEGEN)"),
   })
   .strip()
   .describe("Instructions for getting a token's contract address by symbol");

--- a/typescript/agentkit/src/action-providers/erc20/schemas.ts
+++ b/typescript/agentkit/src/action-providers/erc20/schemas.ts
@@ -6,8 +6,10 @@ import { z } from "zod";
 export const TransferSchema = z
   .object({
     amount: z.custom<bigint>().describe("The amount of the asset to transfer"),
-    contractAddress: z.string().describe("The contract address of the token to transfer"),
-    destination: z.string().describe("The destination to transfer the funds"),
+    tokenAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
+    .describe("The contract address of the token to transfer"),
+    destinationAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
+    .describe("The destination to transfer the funds"),
   })
   .strip()
   .describe("Instructions for transferring assets");
@@ -17,9 +19,30 @@ export const TransferSchema = z
  */
 export const GetBalanceSchema = z
   .object({
-    contractAddress: z
+    tokenAddress: z
       .string()
-      .describe("The contract address of the token to get the balance for"),
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
+      .describe("The contract address of the ERC20 token to get the balance for"),
+    address: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
+      .optional()
+      .describe("The address to check the balance for. If not provided, uses the wallet's address"),
   })
   .strip()
   .describe("Instructions for getting wallet balance");
+
+/**
+ * Input schema for get token address action.
+ */
+export const GetTokenAddressSchema = z
+  .object({
+    symbol: z
+      .string()
+      .min(1)
+      .max(10)
+      .toUpperCase()
+      .describe("The token symbol (e.g., USDC, WETH, DEGEN)"),
+  })
+  .strip()
+  .describe("Instructions for getting a token's contract address by symbol");

--- a/typescript/agentkit/src/action-providers/erc20/schemas.ts
+++ b/typescript/agentkit/src/action-providers/erc20/schemas.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
  */
 export const TransferSchema = z
   .object({
-    amount: z.custom<bigint>().describe("The amount of the asset to transfer"),
+    amount: z.string().describe("The amount of the asset to transfer in whole units (e.g. 1.5 USDC)"),
     tokenAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
     .describe("The contract address of the token to transfer"),
     destinationAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
@@ -40,7 +40,6 @@ export const GetTokenAddressSchema = z
     symbol: z
       .string()
       .min(1)
-      .max(10)
       .toUpperCase()
       .describe("The token symbol (e.g., USDC, WETH, DEGEN)"),
   })

--- a/typescript/agentkit/src/action-providers/erc20/schemas.ts
+++ b/typescript/agentkit/src/action-providers/erc20/schemas.ts
@@ -5,11 +5,17 @@ import { z } from "zod";
  */
 export const TransferSchema = z
   .object({
-    amount: z.string().describe("The amount of the asset to transfer in whole units (e.g. 1.5 USDC)"),
-    tokenAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
-    .describe("The contract address of the token to transfer"),
-    destinationAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
-    .describe("The destination to transfer the funds"),
+    amount: z
+      .string()
+      .describe("The amount of the asset to transfer in whole units (e.g. 1.5 USDC)"),
+    tokenAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The contract address of the token to transfer"),
+    destinationAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The destination to transfer the funds"),
   })
   .strip()
   .describe("Instructions for transferring assets");
@@ -21,11 +27,11 @@ export const GetBalanceSchema = z
   .object({
     tokenAddress: z
       .string()
-      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
       .describe("The contract address of the ERC20 token to get the balance for"),
     address: z
       .string()
-      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")  
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
       .optional()
       .describe("The address to check the balance for. If not provided, uses the wallet's address"),
   })
@@ -37,11 +43,7 @@ export const GetBalanceSchema = z
  */
 export const GetTokenAddressSchema = z
   .object({
-    symbol: z
-      .string()
-      .min(1)
-      .toUpperCase()
-      .describe("The token symbol (e.g., USDC, WETH, DEGEN)"),
+    symbol: z.string().min(1).max(10).toUpperCase().describe("The token symbol (e.g., USDC, WETH, DEGEN)"),
   })
   .strip()
   .describe("Instructions for getting a token's contract address by symbol");

--- a/typescript/agentkit/src/action-providers/erc20/utils.ts
+++ b/typescript/agentkit/src/action-providers/erc20/utils.ts
@@ -64,7 +64,7 @@ export async function getTokenDetails(
       balance: BigInt(balance),
       formattedBalance,
     };
-  } catch (error) {
+  } catch {
     return null;
   }
 }

--- a/typescript/agentkit/src/action-providers/erc20/utils.ts
+++ b/typescript/agentkit/src/action-providers/erc20/utils.ts
@@ -1,0 +1,70 @@
+import { Hex, erc20Abi, formatUnits } from "viem";
+import { EvmWalletProvider } from "../../wallet-providers";
+
+/**
+ * Interface for token details
+ */
+export interface TokenDetails {
+  name: string;
+  decimals: number;
+  balance: bigint;
+  formattedBalance: string;
+}
+
+/**
+ * Gets the details of an ERC20 token including name, decimals, and balance.
+ *
+ * @param walletProvider - The wallet provider to use for the multicall.
+ * @param contractAddress - The contract address of the ERC20 token.
+ * @param address - The address to check the balance for. If not provided, uses the wallet's address.
+ * @returns A promise that resolves to TokenDetails or null if there's an error.
+ */
+export async function getTokenDetails(
+  walletProvider: EvmWalletProvider,
+  contractAddress: string,
+  address?: string,
+): Promise<TokenDetails | null> {
+  try {
+    const results = await walletProvider.getPublicClient().multicall({
+      contracts: [
+        {
+          address: contractAddress as Hex,
+          abi: erc20Abi,
+          functionName: "name",
+          args: [],
+        },
+        {
+          address: contractAddress as Hex,
+          abi: erc20Abi,
+          functionName: "decimals",
+          args: [],
+        },
+        {
+          address: contractAddress as Hex,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [(address || walletProvider.getAddress()) as Hex],
+        },
+      ],
+    });
+
+    const name = results[0].result;
+    const decimals = results[1]?.result;
+    const balance = results[2]?.result;
+
+    if (balance === undefined || decimals === undefined || name === undefined) {
+      return null;
+    }
+
+    const formattedBalance = formatUnits(BigInt(balance), decimals);
+
+    return {
+      name,
+      decimals,
+      balance: BigInt(balance),
+      formattedBalance,
+    };
+  } catch (error) {
+    return null;
+  }
+}

--- a/typescript/agentkit/src/action-providers/flaunch/constants.ts
+++ b/typescript/agentkit/src/action-providers/flaunch/constants.ts
@@ -1,7 +1,7 @@
 import { parseAbi } from "viem";
 import { base, baseSepolia } from "viem/chains";
 import { Addresses } from "./types";
-import { abi as ERC20_ABI } from "../erc20/constants";
+import { erc20Abi as ERC20_ABI } from "viem";
 
 // Re-export the ERC20 ABI from the erc20 action provider constants
 export { ERC20_ABI };

--- a/typescript/agentkit/src/action-providers/morpho/morphoActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/morpho/morphoActionProvider.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { Decimal } from "decimal.js";
 import { encodeFunctionData, Hex, parseUnits } from "viem";
-import { abi } from "../erc20/constants";
+import { erc20Abi as abi } from "viem";
 import { ActionProvider } from "../actionProvider";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { CreateAction } from "../actionDecorator";

--- a/typescript/agentkit/src/action-providers/superfluid/superfluidSuperTokenCreatorActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/superfluid/superfluidSuperTokenCreatorActionProvider.ts
@@ -10,7 +10,7 @@ import { ActionProvider } from "../actionProvider";
 import { Network } from "../../network";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { CreateAction } from "../actionDecorator";
-import { abi as ERC20ABI } from "../erc20/constants";
+import { erc20Abi as ERC20ABI } from "viem";
 import { extractCreatedSuperTokenAddressAbi } from "./utils/parseLogs";
 
 /**

--- a/typescript/agentkit/src/action-providers/superfluid/superfluidWrapperActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/superfluid/superfluidWrapperActionProvider.test.ts
@@ -2,7 +2,7 @@ import { encodeFunctionData, parseUnits } from "viem";
 import { ISuperTokenAbi } from "./constants";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { superfluidWrapperActionProvider } from "./superfluidWrapperActionProvider";
-import { abi as ERC20ABI } from "../erc20/constants";
+import { erc20Abi as ERC20ABI } from "viem";
 
 describe("SuperfluidWrapperActionProvider", () => {
   const MOCK_ADDRESS = "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83";

--- a/typescript/agentkit/src/action-providers/superfluid/superfluidWrapperActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/superfluid/superfluidWrapperActionProvider.ts
@@ -6,7 +6,7 @@ import { ActionProvider } from "../actionProvider";
 import { Network } from "../../network";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { CreateAction } from "../actionDecorator";
-import { abi as ERC20ABI } from "../erc20/constants";
+import { erc20Abi as ERC20ABI } from "viem";
 
 /**
  * SuperfluidStreamActionProvider is an action provider for wrapping superfluid token.

--- a/typescript/agentkit/src/action-providers/truemarkets/truemarketsActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/truemarkets/truemarketsActionProvider.ts
@@ -14,7 +14,7 @@ import {
   UniswapV3PoolABI,
   YESNO_DECIMALS,
 } from "./constants";
-import { abi as ERC20ABI } from "../erc20/constants";
+import { erc20Abi as ERC20ABI } from "viem";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { Hex, formatUnits } from "viem";
 import { TruthMarket, Slot0Result } from "./utils";

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
@@ -1,6 +1,7 @@
 import { WalletProvider } from "../../wallet-providers";
 import { walletActionProvider } from "./walletActionProvider";
 import { NativeTransferSchema } from "./schemas";
+import { formatUnits } from "viem";
 
 describe("Wallet Action Provider", () => {
   const MOCK_ADDRESS = "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83";
@@ -52,7 +53,7 @@ describe("Wallet Action Provider", () => {
         `  * Network ID: ${MOCK_EVM_NETWORK.networkId}`,
         `  * Chain ID: ${MOCK_EVM_NETWORK.chainId}`,
         `- Native Balance: ${MOCK_ETH_BALANCE.toString()} WEI`,
-        `- Native Balance: 1 ETH`,
+        `- Native Balance: ${formatUnits(MOCK_ETH_BALANCE, 18)} ETH`,
       ].join("\n");
 
       expect(response).toBe(expectedResponse);
@@ -73,7 +74,7 @@ describe("Wallet Action Provider", () => {
         `  * Network ID: ${MOCK_SOLANA_NETWORK.networkId}`,
         `  * Chain ID: N/A`,
         `- Native Balance: ${MOCK_SOL_BALANCE.toString()} LAMPORTS`,
-        `- Native Balance: 1 SOL`,
+        `- Native Balance: ${formatUnits(MOCK_SOL_BALANCE, 9)} SOL`,
       ].join("\n");
 
       expect(response).toBe(expectedResponse);
@@ -156,10 +157,7 @@ describe("Wallet Action Provider", () => {
 
       const response = await actionProvider.nativeTransfer(mockWallet, args);
 
-      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(
-        MOCK_DESTINATION,
-        "1500000000000000000",
-      );
+      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, MOCK_AMOUNT);
       expect(response).toBe(
         `Transferred ${MOCK_AMOUNT} ETH to ${MOCK_DESTINATION}\nTransaction hash: ${MOCK_TRANSACTION_HASH}`,
       );
@@ -175,7 +173,7 @@ describe("Wallet Action Provider", () => {
 
       const response = await actionProvider.nativeTransfer(mockWallet, args);
 
-      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, "1500000000");
+      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, MOCK_AMOUNT);
       expect(response).toBe(
         `Transferred ${MOCK_AMOUNT} SOL to ${MOCK_DESTINATION}\nSignature: ${MOCK_SIGNATURE}`,
       );

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
@@ -52,6 +52,7 @@ describe("Wallet Action Provider", () => {
         `  * Network ID: ${MOCK_EVM_NETWORK.networkId}`,
         `  * Chain ID: ${MOCK_EVM_NETWORK.chainId}`,
         `- Native Balance: ${MOCK_ETH_BALANCE.toString()} WEI`,
+        `- Native Balance: 1 ETH`,
       ].join("\n");
 
       expect(response).toBe(expectedResponse);
@@ -72,6 +73,7 @@ describe("Wallet Action Provider", () => {
         `  * Network ID: ${MOCK_SOLANA_NETWORK.networkId}`,
         `  * Chain ID: N/A`,
         `- Native Balance: ${MOCK_SOL_BALANCE.toString()} LAMPORTS`,
+        `- Native Balance: 1 SOL`,
       ].join("\n");
 
       expect(response).toBe(expectedResponse);
@@ -91,6 +93,7 @@ describe("Wallet Action Provider", () => {
         `  * Protocol Family: ${MOCK_UNKNOWN_NETWORK.protocolFamily}`,
         `  * Network ID: ${MOCK_UNKNOWN_NETWORK.networkId}`,
         `  * Chain ID: N/A`,
+        `- Native Balance: ${MOCK_ETH_BALANCE.toString()} `,
         `- Native Balance: ${MOCK_ETH_BALANCE.toString()} `,
       ].join("\n");
 
@@ -153,7 +156,7 @@ describe("Wallet Action Provider", () => {
 
       const response = await actionProvider.nativeTransfer(mockWallet, args);
 
-      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, MOCK_AMOUNT);
+      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, "1500000000000000000");
       expect(response).toBe(
         `Transferred ${MOCK_AMOUNT} ETH to ${MOCK_DESTINATION}\nTransaction hash: ${MOCK_TRANSACTION_HASH}`,
       );
@@ -169,7 +172,7 @@ describe("Wallet Action Provider", () => {
 
       const response = await actionProvider.nativeTransfer(mockWallet, args);
 
-      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, MOCK_AMOUNT);
+      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, "1500000000");
       expect(response).toBe(
         `Transferred ${MOCK_AMOUNT} SOL to ${MOCK_DESTINATION}\nSignature: ${MOCK_SIGNATURE}`,
       );

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
@@ -1,7 +1,7 @@
 import { WalletProvider } from "../../wallet-providers";
 import { walletActionProvider } from "./walletActionProvider";
 import { NativeTransferSchema } from "./schemas";
-import { formatUnits } from "viem";
+import { formatUnits, parseUnits } from "viem";
 
 describe("Wallet Action Provider", () => {
   const MOCK_ADDRESS = "0xe6b2af36b3bb8d47206a129ff11d5a2de2a63c83";
@@ -157,7 +157,10 @@ describe("Wallet Action Provider", () => {
 
       const response = await actionProvider.nativeTransfer(mockWallet, args);
 
-      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, MOCK_AMOUNT);
+      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(
+        MOCK_DESTINATION,
+        parseUnits(MOCK_AMOUNT, 18).toString(),
+      );
       expect(response).toBe(
         `Transferred ${MOCK_AMOUNT} ETH to ${MOCK_DESTINATION}\nTransaction hash: ${MOCK_TRANSACTION_HASH}`,
       );
@@ -173,7 +176,10 @@ describe("Wallet Action Provider", () => {
 
       const response = await actionProvider.nativeTransfer(mockWallet, args);
 
-      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, MOCK_AMOUNT);
+      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(
+        MOCK_DESTINATION,
+        parseUnits(MOCK_AMOUNT, 9).toString(),
+      );
       expect(response).toBe(
         `Transferred ${MOCK_AMOUNT} SOL to ${MOCK_DESTINATION}\nSignature: ${MOCK_SIGNATURE}`,
       );

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.test.ts
@@ -156,7 +156,10 @@ describe("Wallet Action Provider", () => {
 
       const response = await actionProvider.nativeTransfer(mockWallet, args);
 
-      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(MOCK_DESTINATION, "1500000000000000000");
+      expect(mockWallet.nativeTransfer).toHaveBeenCalledWith(
+        MOCK_DESTINATION,
+        "1500000000000000000",
+      );
       expect(response).toBe(
         `Transferred ${MOCK_AMOUNT} ETH to ${MOCK_DESTINATION}\nTransaction hash: ${MOCK_TRANSACTION_HASH}`,
       );

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
@@ -12,11 +12,17 @@ const PROTOCOL_FAMILY_TO_TERMINOLOGY: Record<
   string,
   { unit: string; displayUnit: string; decimals: number; type: string; verb: string }
 > = {
-  evm: { unit: "WEI", displayUnit: "ETH", decimals: 18, type: "Transaction hash", verb: "transaction" },
+  evm: {
+    unit: "WEI",
+    displayUnit: "ETH",
+    decimals: 18,
+    type: "Transaction hash",
+    verb: "transaction",
+  },
   svm: { unit: "LAMPORTS", displayUnit: "SOL", decimals: 9, type: "Signature", verb: "transfer" },
 };
 
-const DEFAULT_TERMINOLOGY = { unit: "", displayUnit: "", type: "Hash", verb: "transfer" };
+const DEFAULT_TERMINOLOGY = { unit: "", displayUnit: "", decimals: 0, type: "Hash", verb: "transfer" };
 
 /**
  * WalletActionProvider provides actions for getting basic wallet information.

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
@@ -105,7 +105,8 @@ It takes the following inputs:
         args.to = `0x${args.to}`;
       }
 
-      const result = await walletProvider.nativeTransfer(args.to, parseUnits(args.value, terminology.decimals).toString());
+      const amountInAtomicUnits = parseUnits(args.value, terminology.decimals);
+      const result = await walletProvider.nativeTransfer(args.to, amountInAtomicUnits.toString());
       return [
         `Transferred ${args.value} ${terminology.displayUnit} to ${args.to}`,
         `${terminology.type}: ${result}`,

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
@@ -22,7 +22,13 @@ const PROTOCOL_FAMILY_TO_TERMINOLOGY: Record<
   svm: { unit: "LAMPORTS", displayUnit: "SOL", decimals: 9, type: "Signature", verb: "transfer" },
 };
 
-const DEFAULT_TERMINOLOGY = { unit: "", displayUnit: "", decimals: 0, type: "Hash", verb: "transfer" };
+const DEFAULT_TERMINOLOGY = {
+  unit: "",
+  displayUnit: "",
+  decimals: 0,
+  type: "Hash",
+  verb: "transfer",
+};
 
 /**
  * WalletActionProvider provides actions for getting basic wallet information.

--- a/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/wallet/walletActionProvider.ts
@@ -4,15 +4,16 @@ import { CreateAction } from "../actionDecorator";
 import { ActionProvider } from "../actionProvider";
 import { WalletProvider } from "../../wallet-providers";
 import { Network } from "../../network";
+import { formatUnits, parseUnits } from "viem";
 
 import { NativeTransferSchema, GetWalletDetailsSchema } from "./schemas";
 
 const PROTOCOL_FAMILY_TO_TERMINOLOGY: Record<
   string,
-  { unit: string; displayUnit: string; type: string; verb: string }
+  { unit: string; displayUnit: string; decimals: number; type: string; verb: string }
 > = {
-  evm: { unit: "WEI", displayUnit: "ETH", type: "Transaction hash", verb: "transaction" },
-  svm: { unit: "LAMPORTS", displayUnit: "SOL", type: "Signature", verb: "transfer" },
+  evm: { unit: "WEI", displayUnit: "ETH", decimals: 18, type: "Transaction hash", verb: "transaction" },
+  svm: { unit: "LAMPORTS", displayUnit: "SOL", decimals: 9, type: "Signature", verb: "transfer" },
 };
 
 const DEFAULT_TERMINOLOGY = { unit: "", displayUnit: "", type: "Hash", verb: "transfer" };
@@ -67,6 +68,7 @@ export class WalletActionProvider extends ActionProvider {
         `  * Network ID: ${network.networkId || "N/A"}`,
         `  * Chain ID: ${network.chainId || "N/A"}`,
         `- Native Balance: ${balance.toString()} ${terminology.unit}`,
+        `- Native Balance: ${formatUnits(balance, terminology.decimals)} ${terminology.displayUnit}`,
       ].join("\n");
     } catch (error) {
       return `Error getting wallet details: ${error}`;
@@ -83,15 +85,11 @@ export class WalletActionProvider extends ActionProvider {
   @CreateAction({
     name: "native_transfer",
     description: `
-This tool will transfer native tokens from the wallet to another onchain address.
+This tool will transfer (send) native tokens from the wallet to another onchain address.
 
 It takes the following inputs:
-- amount: The amount to transfer in whole units (e.g. 1 ETH, 0.1 SOL)
+- amount: The amount to transfer in whole units (e.g. 4.2 ETH, 0.1 SOL)
 - destination: The address to receive the funds
-
-Important notes:
-- Ensure sufficient balance of the input asset before transferring
-- Ensure there is sufficient native token balance for gas fees
 `,
     schema: NativeTransferSchema,
   })
@@ -107,7 +105,7 @@ Important notes:
         args.to = `0x${args.to}`;
       }
 
-      const result = await walletProvider.nativeTransfer(args.to, args.value);
+      const result = await walletProvider.nativeTransfer(args.to, parseUnits(args.value, terminology.decimals).toString());
       return [
         `Transferred ${args.value} ${terminology.displayUnit} to ${args.to}`,
         `${terminology.type}: ${result}`,

--- a/typescript/agentkit/src/action-providers/zeroX/zeroXActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/zeroX/zeroXActionProvider.ts
@@ -72,6 +72,7 @@ Important notes:
 - This only fetches a price quote and does not execute a swap
 - Supported on all EVM networks compatible with 0x API
 - Use sellToken units exactly as provided, do not convert to wei or any other units
+- Never assume token or address, they have to be provided as inputs. If only token symbol is provided, use the get_token_address tool if available to get the token address first
 `,
     schema: GetSwapPriceSchema,
   })
@@ -191,6 +192,7 @@ Important notes:
 - First fetch a price quote and only execute swap if you are happy with the indicated price
 - Supported on all EVM networks compatible with 0x API
 - Use sellToken units exactly as provided, do not convert to wei or any other units
+- Never assume token or address, they have to be provided as inputs. If only token symbol is provided, use the get_token_address tool if available to get the token address first
 `,
     schema: ExecuteSwapSchema,
   })

--- a/typescript/agentkit/src/wallet-providers/cdpEvmWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpEvmWalletProvider.ts
@@ -285,7 +285,7 @@ export class CdpEvmWalletProvider extends EvmWalletProvider implements WalletPro
    * Transfer the native asset of the network.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in Wei.
+   * @param value - The amount to transfer in atomic units (Wei).
    * @returns The transaction hash.
    */
   async nativeTransfer(to: Address, value: string): Promise<Hex> {

--- a/typescript/agentkit/src/wallet-providers/cdpSmartWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSmartWalletProvider.ts
@@ -342,7 +342,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
    * Transfer the native asset of the network using smart wallet.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in Wei.
+   * @param value - The amount to transfer in atomic units (Wei).
    * @returns The user operation hash.
    */
   async nativeTransfer(to: Address, value: string): Promise<Hex> {

--- a/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.test.ts
@@ -366,7 +366,7 @@ describe("CdpSolanaWalletProvider", () => {
   describe("native transfer", () => {
     it("should transfer SOL", async () => {
       const toAddress = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
-      const amount = "1.0";
+      const amount = "1000000000"; // 1 SOL in lamports
 
       // Set a balance that's high enough to cover the transfer + fees
       mockConnection.getBalance.mockResolvedValueOnce(Number(2000000000n)); // 2 SOL
@@ -380,7 +380,7 @@ describe("CdpSolanaWalletProvider", () => {
       mockConnection.getBalance.mockResolvedValueOnce(Number(1000000n)); // 0.001 SOL
 
       const toAddress = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin";
-      const amount = "1.0";
+      const amount = "1000000000"; // 1 SOL in lamports
 
       await expect(provider.nativeTransfer(toAddress, amount)).rejects.toThrow(
         "Insufficient balance",

--- a/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.test.ts
@@ -44,13 +44,20 @@ jest.mock("@solana/web3.js", () => {
   const MockPublicKey = jest.fn(() => mockPublicKey);
   MockPublicKey.prototype = mockPublicKey;
 
+  const mockVersionedTransaction = {
+    serialize: jest.fn(() => Buffer.from("mock-serialized-tx")),
+    addSignature: jest.fn(),
+  };
+
+  const MockVersionedTransaction = jest.fn(() => mockVersionedTransaction);
+  (MockVersionedTransaction as unknown as { deserialize: jest.Mock }).deserialize = jest.fn(
+    () => mockVersionedTransaction,
+  );
+
   return {
     Connection: jest.fn(() => mockConnection),
     PublicKey: MockPublicKey,
-    VersionedTransaction: jest.fn().mockImplementation(() => ({
-      serialize: jest.fn(() => Buffer.from("mock-serialized-tx")),
-      addSignature: jest.fn(),
-    })),
+    VersionedTransaction: MockVersionedTransaction,
     MessageV0: {
       compile: jest.fn(),
     },
@@ -89,9 +96,9 @@ jest.mock("@coinbase/cdp-sdk", () => {
     }),
   );
 
-  const mockSignTransaction = jest
-    .fn()
-    .mockImplementation(async () => ({ signature: MOCK_SIGNATURE }));
+  const mockSignTransaction = jest.fn().mockImplementation(async () => ({
+    signedTransaction: Buffer.from("mock-signed-transaction").toString("base64"),
+  }));
 
   const mockSolanaClient = {
     createAccount: mockCreateAccount as jest.MockedFunction<typeof mockCreateAccount>,
@@ -159,9 +166,9 @@ describe("CdpSolanaWalletProvider", () => {
         typeof mockCdpClient.solana.createAccount
       >
     ).mockResolvedValue(mockServerAccount);
-    mockCdpClient.solana.signTransaction = jest
-      .fn()
-      .mockResolvedValue({ signature: MOCK_SIGNATURE });
+    mockCdpClient.solana.signTransaction = jest.fn().mockResolvedValue({
+      signedTransaction: Buffer.from("mock-signed-transaction").toString("base64"),
+    });
 
     mockConnection.getBalance.mockResolvedValue(Number(MOCK_BALANCE));
     mockConnection.getLatestBlockhash.mockResolvedValue({

--- a/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.ts
@@ -3,7 +3,6 @@ import {
   clusterApiUrl,
   ComputeBudgetProgram,
   Connection,
-  LAMPORTS_PER_SOL,
   MessageV0,
   PublicKey,
   RpcResponseAndContext,

--- a/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.ts
@@ -285,20 +285,19 @@ export class CdpSolanaWalletProvider extends SvmWalletProvider implements Wallet
    * Transfer SOL from the wallet to another address
    *
    * @param to - The base58 encoded address to transfer the SOL to
-   * @param value - The amount of SOL to transfer (as a decimal string, e.g. "0.0001")
+   * @param value - The amount to transfer in atomic units (Lamports)
    * @returns The signature
    */
   async nativeTransfer(to: string, value: string): Promise<string> {
     const initialBalance = await this.getBalance();
-    const solAmount = parseFloat(value);
-    const lamports = BigInt(Math.floor(solAmount * LAMPORTS_PER_SOL));
+    const lamports = BigInt(value);
 
     // Check if we have enough balance (including estimated fees)
     if (initialBalance < lamports + BigInt(5000)) {
       throw new Error(
-        `Insufficient balance. Have ${Number(initialBalance) / LAMPORTS_PER_SOL} SOL, need ${
-          solAmount + 0.000005
-        } SOL (including fees)`,
+        `Insufficient balance. Have ${Number(initialBalance)} lamports, need ${
+          Number(lamports) + 5000
+        } lamports (including fees)`,
       );
     }
 

--- a/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.ts
@@ -198,16 +198,18 @@ export class CdpSolanaWalletProvider extends SvmWalletProvider implements Wallet
     const serializedTransaction = transaction.serialize();
     const encodedSerializedTransaction = Buffer.from(serializedTransaction).toString("base64");
 
-    const signedTransaction = await this.#cdp.solana.signTransaction({
+    const signedTransactionResponse = await this.#cdp.solana.signTransaction({
       transaction: encodedSerializedTransaction,
       address: this.#serverAccount.address,
     });
-    transaction.addSignature(
-      this.getPublicKey(),
-      Buffer.from(signedTransaction.signature, "base64"),
-    );
 
-    return transaction;
+    const signedTransactionBytes = Buffer.from(
+      signedTransactionResponse.signedTransaction,
+      "base64",
+    );
+    const signedTransaction = VersionedTransaction.deserialize(signedTransactionBytes);
+
+    return signedTransaction;
   }
 
   /**

--- a/typescript/agentkit/src/wallet-providers/legacyCdpSmartWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/legacyCdpSmartWalletProvider.ts
@@ -351,7 +351,7 @@ export class LegacyCdpSmartWalletProvider extends EvmWalletProvider {
    * Transfer the native asset of the network.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in Wei.
+   * @param value - The amount to transfer in atomic units (Wei).
    * @returns The transaction hash.
    */
   async nativeTransfer(to: Address, value: string): Promise<Hex> {

--- a/typescript/agentkit/src/wallet-providers/legacyCdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/legacyCdpWalletProvider.ts
@@ -558,10 +558,8 @@ export class LegacyCdpWalletProvider extends EvmWalletProvider {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
-    // Convert Wei to ETH for Coinbase SDK (expects whole units)
-    const ethAmount = new Decimal(value).div(new Decimal(10).pow(18));
     const transferResult = await this.#cdpWallet.createTransfer({
-      amount: ethAmount,
+      amount: new Decimal(value),
       assetId: Coinbase.assets.Eth,
       destination: to,
       gasless: false,

--- a/typescript/agentkit/src/wallet-providers/legacyCdpWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/legacyCdpWalletProvider.ts
@@ -551,15 +551,17 @@ export class LegacyCdpWalletProvider extends EvmWalletProvider {
    * Transfer the native asset of the network.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in Wei.
+   * @param value - The amount to transfer in atomic units (Wei).
    * @returns The transaction hash.
    */
   async nativeTransfer(to: `0x${string}`, value: string): Promise<`0x${string}`> {
     if (!this.#cdpWallet) {
       throw new Error("Wallet not initialized");
     }
+    // Convert Wei to ETH for Coinbase SDK (expects whole units)
+    const ethAmount = new Decimal(value).div(new Decimal(10).pow(18));
     const transferResult = await this.#cdpWallet.createTransfer({
-      amount: new Decimal(value),
+      amount: ethAmount,
       assetId: Coinbase.assets.Eth,
       destination: to,
       gasless: false,

--- a/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.test.ts
@@ -259,7 +259,7 @@ describe("PrivyEvmDelegatedEmbeddedWalletProvider", () => {
     it("should transfer native tokens", async () => {
       const result = await provider.nativeTransfer(
         "0x1234567890123456789012345678901234567890",
-        "1.0",
+        "1000000000000000000", // 1 ETH in wei
       );
       expect(result).toBe(MOCK_TRANSACTION_HASH);
     });

--- a/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.ts
@@ -385,11 +385,11 @@ export class PrivyEvmDelegatedEmbeddedWalletProvider extends WalletProvider {
    * Transfer the native asset of the network.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in Wei.
+   * @param value - The amount to transfer in atomic units (Wei).
    * @returns The transaction hash.
    */
   async nativeTransfer(to: string, value: string): Promise<Hex> {
-    const valueInWei = parseEther(value);
+    const valueInWei = BigInt(value);
     const valueHex = `0x${valueInWei.toString(16)}`;
 
     const body = {

--- a/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmDelegatedEmbeddedWalletProvider.ts
@@ -14,7 +14,6 @@ import {
   TransactionRequest,
   createPublicClient,
   http,
-  parseEther,
 } from "viem";
 import { Network } from "../network";
 import { NETWORK_ID_TO_CHAIN_ID, getChain } from "../network/network";

--- a/typescript/agentkit/src/wallet-providers/privyEvmWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/privyEvmWalletProvider.test.ts
@@ -310,7 +310,7 @@ describe("PrivyEvmWalletProvider", () => {
     it("should transfer native tokens", async () => {
       const result = await provider.nativeTransfer(
         "0x1234567890123456789012345678901234567890" as Address,
-        "1.0",
+        "1000000000000000000", // 1 ETH in wei
       );
 
       expect(result).toBe(MOCK_TRANSACTION_HASH);

--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.test.ts
@@ -227,7 +227,7 @@ describe("SolanaKeypairWalletProvider", () => {
 
     it("should transfer native tokens", async () => {
       const destination = "EQJqzeeVEnm8rKWQJ5SMTtQBD4xEgixwgzNWKkpeFRZ9";
-      const signature = await wallet.nativeTransfer(destination, "0.1");
+      const signature = await wallet.nativeTransfer(destination, "100000000"); // 0.1 SOL in lamports
 
       expect(signature).toBe("signature123");
     });
@@ -238,7 +238,7 @@ describe("SolanaKeypairWalletProvider", () => {
 
       const destination = "EQJqzeeVEnm8rKWQJ5SMTtQBD4xEgixwgzNWKkpeFRZ9";
 
-      await expect(wallet.nativeTransfer(destination, "1.0")).rejects.toThrow(
+      await expect(wallet.nativeTransfer(destination, "1000000000")).rejects.toThrow( // 1 SOL in lamports
         "Insufficient balance",
       );
     });

--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.test.ts
@@ -238,7 +238,8 @@ describe("SolanaKeypairWalletProvider", () => {
 
       const destination = "EQJqzeeVEnm8rKWQJ5SMTtQBD4xEgixwgzNWKkpeFRZ9";
 
-      await expect(wallet.nativeTransfer(destination, "1000000000")).rejects.toThrow( // 1 SOL in lamports
+      await expect(wallet.nativeTransfer(destination, "1000000000")).rejects.toThrow(
+        // 1 SOL in lamports
         "Insufficient balance",
       );
     });

--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
@@ -5,7 +5,6 @@ import {
   Keypair,
   PublicKey,
   VersionedTransaction,
-  LAMPORTS_PER_SOL,
   SystemProgram,
   MessageV0,
   ComputeBudgetProgram,

--- a/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts
@@ -277,20 +277,19 @@ export class SolanaKeypairWalletProvider extends SvmWalletProvider {
    * Transfer SOL from the wallet to another address
    *
    * @param to - The base58 encoded address to transfer the SOL to
-   * @param value - The amount of SOL to transfer (as a decimal string, e.g. "0.0001")
+   * @param value - The amount to transfer in atomic units (Lamports)
    * @returns The signature
    */
   async nativeTransfer(to: string, value: string): Promise<string> {
     const initialBalance = await this.getBalance();
-    const solAmount = parseFloat(value);
-    const lamports = BigInt(Math.floor(solAmount * LAMPORTS_PER_SOL));
+    const lamports = BigInt(value);
 
     // Check if we have enough balance (including estimated fees)
     if (initialBalance < lamports + BigInt(5000)) {
       throw new Error(
-        `Insufficient balance. Have ${Number(initialBalance) / LAMPORTS_PER_SOL} SOL, need ${
-          solAmount + 0.000005
-        } SOL (including fees)`,
+        `Insufficient balance. Have ${Number(initialBalance)} lamports, need ${
+          Number(lamports) + 5000
+        } lamports (including fees)`,
       );
     }
 

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.test.ts
@@ -320,7 +320,7 @@ describe("ViemWalletProvider", () => {
         expect.objectContaining({
           to: MOCK_ADDRESS_TO,
           value: BigInt("1000000000000000000"),
-        })
+        }),
       );
       expect(hash).toBe(MOCK_TRANSACTION_HASH);
     });
@@ -328,9 +328,9 @@ describe("ViemWalletProvider", () => {
     it("should handle native transfer errors", async () => {
       mockWalletClient.sendTransaction.mockRejectedValueOnce(new Error("Transaction failed"));
 
-      await expect(provider.nativeTransfer(MOCK_ADDRESS_TO as Address, "1000000000000000000")).rejects.toThrow(
-        "Transaction failed",
-      );
+      await expect(
+        provider.nativeTransfer(MOCK_ADDRESS_TO as Address, "1000000000000000000"),
+      ).rejects.toThrow("Transaction failed");
     });
 
     it("should handle invalid address in native transfer", async () => {

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.test.ts
@@ -314,19 +314,21 @@ describe("ViemWalletProvider", () => {
 
   describe("native token operations", () => {
     it("should transfer native tokens", async () => {
-      (viem.parseEther as jest.Mock).mockReturnValueOnce(BigInt(1000000000000000000));
+      const hash = await provider.nativeTransfer(MOCK_ADDRESS_TO as Address, "1000000000000000000");
 
-      const hash = await provider.nativeTransfer(MOCK_ADDRESS_TO as Address, "1.0");
-
-      expect(viem.parseEther as jest.Mock).toHaveBeenCalledWith("1.0");
-      expect(mockWalletClient.sendTransaction).toHaveBeenCalled();
+      expect(mockWalletClient.sendTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: MOCK_ADDRESS_TO,
+          value: BigInt("1000000000000000000"),
+        })
+      );
       expect(hash).toBe(MOCK_TRANSACTION_HASH);
     });
 
     it("should handle native transfer errors", async () => {
       mockWalletClient.sendTransaction.mockRejectedValueOnce(new Error("Transaction failed"));
 
-      await expect(provider.nativeTransfer(MOCK_ADDRESS_TO as Address, "1.0")).rejects.toThrow(
+      await expect(provider.nativeTransfer(MOCK_ADDRESS_TO as Address, "1000000000000000000")).rejects.toThrow(
         "Transaction failed",
       );
     });

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
@@ -9,7 +9,6 @@ import {
   PublicClient as ViemPublicClient,
   ReadContractParameters,
   ReadContractReturnType,
-  parseEther,
   Abi,
   ContractFunctionName,
   ContractFunctionArgs,

--- a/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/viemWalletProvider.ts
@@ -246,11 +246,11 @@ export class ViemWalletProvider extends EvmWalletProvider {
    * Transfer the native asset of the network.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in whole units (e.g. ETH)
+   * @param value - The amount to transfer in atomic units (Wei)
    * @returns The transaction hash.
    */
   async nativeTransfer(to: `0x${string}`, value: string): Promise<`0x${string}`> {
-    const atomicAmount = parseEther(value);
+    const atomicAmount = BigInt(value);
 
     const tx = await this.sendTransaction({
       to: to,

--- a/typescript/agentkit/src/wallet-providers/walletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/walletProvider.ts
@@ -69,7 +69,7 @@ export abstract class WalletProvider {
    * Transfer the native asset of the network.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in whole units (e.g. ETH)
+   * @param value - The amount to transfer in atomic units (e.g. Wei for EVM, Lamports for Solana)
    * @returns The transaction hash.
    */
   abstract nativeTransfer(to: string, value: string): Promise<string>;

--- a/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.test.ts
@@ -364,9 +364,9 @@ describe("ZeroDevWalletProvider", () => {
 
     it("should handle native transfers using nativeTransfer method", async () => {
       const to = "0x1234567890123456789012345678901234567890";
-      const value = "1.0";
+      const value = "1000000000000000000"; // 1 ETH in wei
 
-      const valueInWei = BigInt(parseFloat(value) * 10 ** 18);
+      const valueInWei = BigInt(value);
 
       const txHash = await provider.nativeTransfer(to, value);
 

--- a/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.ts
@@ -344,12 +344,12 @@ export class ZeroDevWalletProvider extends EvmWalletProvider {
    * Transfer the native asset of the network.
    *
    * @param to - The destination address.
-   * @param value - The amount to transfer in whole units (e.g. ETH).
+   * @param value - The amount to transfer in atomic units (Wei).
    * @returns The transaction hash.
    */
   async nativeTransfer(to: string, value: string): Promise<string> {
-    // Convert value to wei (assuming value is in whole units)
-    const valueInWei = BigInt(parseFloat(value) * 10 ** 18);
+    // Value is already in atomic units (Wei)
+    const valueInWei = BigInt(value);
 
     // Get the chain ID from the network
     const chainId = parseInt(this.#network.chainId || "1");

--- a/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.ts
@@ -131,9 +131,10 @@ export class ZeroDevWalletProvider extends EvmWalletProvider {
     const bundlerRpc = `https://rpc.zerodev.app/api/v3/bundler/${config.projectId}`;
 
     // Create public client
+    const rpcUrl = config.rpcUrl || process.env.RPC_URL;
     const publicClient = createPublicClient({
       chain,
-      transport: http(),
+      transport: rpcUrl ? http(rpcUrl) : http(),
     });
 
     // Create ECDSA validator

--- a/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/zeroDevWalletProvider.ts
@@ -348,7 +348,6 @@ export class ZeroDevWalletProvider extends EvmWalletProvider {
    * @returns The transaction hash.
    */
   async nativeTransfer(to: string, value: string): Promise<string> {
-    // Value is already in atomic units (Wei)
     const valueInWei = BigInt(value);
 
     // Get the chain ID from the network

--- a/typescript/examples/langchain-cdp-chatbot/chatbot.ts
+++ b/typescript/examples/langchain-cdp-chatbot/chatbot.ts
@@ -68,7 +68,7 @@ validateEnvironment();
  * @returns True if the wallet provider is an EVM provider, false otherwise
  */
 function isEvmWalletProvider(
-  walletProvider: CdpEvmWalletProvider,
+  walletProvider: CdpEvmWalletProvider | CdpSolanaWalletProvider,
 ): walletProvider is CdpEvmWalletProvider {
   return walletProvider instanceof CdpEvmWalletProvider;
 }
@@ -98,17 +98,22 @@ async function initializeAgent() {
     });
 
     // Configure CDP Wallet Provider
+    const networkId = process.env.NETWORK_ID || "base-sepolia";
+    const isSolana = networkId.includes("solana");
+
     const cdpWalletConfig = {
       apiKeyId: process.env.CDP_API_KEY_ID,
       apiKeySecret: process.env.CDP_API_KEY_SECRET,
       walletSecret: process.env.CDP_WALLET_SECRET,
       idempotencyKey: process.env.IDEMPOTENCY_KEY,
       address: process.env.ADDRESS as `0x${string}` | undefined,
-      networkId: process.env.NETWORK_ID,
+      networkId,
       rpcUrl: process.env.RPC_URL,
     };
 
-    const walletProvider = await CdpEvmWalletProvider.configureWithWallet(cdpWalletConfig);
+    const walletProvider = isSolana
+      ? await CdpSolanaWalletProvider.configureWithWallet(cdpWalletConfig)
+      : await CdpEvmWalletProvider.configureWithWallet(cdpWalletConfig);
     const actionProviders = [
       walletActionProvider(),
       cdpApiActionProvider(),


### PR DESCRIPTION
## Description

Fixes issues for native/erc20 balance actions reported by @Story91:

- `get_wallet_details` returns ETH amount in wei, LLM converts this to whole units in message to user. Result of conversion depends on LLM knowledge, gpt-4o-mini always got it wrong in my tests
-> get_wallet_details returns now both amount in wei and whole units

- when several erc20 token balances are queried in one prompt, default rpc might throw error due to rate limits
-> made rpc calls more efficient using multicall

- when prompting eg "fetch usdc balance", LLM often hallucinates address (for example taking usdc address from mainnet, not base)  
-> refined action description + added new action to retrieve commonly used token addresses by symbol for given network

In addition, the following improvements are made:
- WalletActionProvider `native_transfer` takes amount in whole units as input and passes this to walletProviders. However, most of them expect atomic units instead -> this is now handled consistently as follows: action takes whole unit format as input, converts to atomic units and then calls internal `native_transfer` from walletProviders with that
- remove hardcoded erc20 abi in favor of viem export
- added guardrails for erc20 transfers to prevent loss of funds by sending to token contracts
- added optional address arg (default to wallet address) to `get_balance` erc20 action 
- fixed `examples/langchain-cdp-chatbot /chatbot.ts` to correctly configure CdpSolanaWalletProvider
- fixed native sol transfers for `CdpSolanaWalletProvider` that was throwing `Error during transfer: Error: Signature must be 64 bytes long`

## Tests

```
Chatbot: typescript/examples/langchain-cdp-chatbot/chatbot.ts
Network: Base mainnet

Prompt: wallet info

-------------------
Wallet Details:
- Provider: cdp_evm_wallet_provider
- Address: 0xf2d4580ADfe8E012f5550322706d62DF11fDBE21
- Network:
  * Protocol Family: evm
  * Network ID: base-mainnet
  * Chain ID: 8453
- Native Balance: 411444858090719 WEI
- Native Balance: 0.000411444858090719 ETH
-------------------
Here are the details of your wallet:

- **Address:** 0xf2d4580ADfe8E012f5550322706d62DF11fDBE21
- **Provider:** cdp_evm_wallet_provider
- **Network:**
  - **Protocol Family:** EVM
  - **Network ID:** base-mainnet
  - **Chain ID:** 8453
- **Native Token Balance:** 0.000411444858090719 ETH
-------------------

Prompt: fetch usdc and cbbtc balance

-------------------
Token address for USDC on base-mainnet: 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
-------------------

-------------------
Balance of USD Coin (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913) at address 0xf2d4580ADfe8E012f5550322706d62DF11fDBE21 is 0.231121
-------------------
Here are your balances for USDC and CBBTC:

- **USDC Balance:** 0.231121 USDC
- **CBBTC Balance:** 0.00000024 CBBTC

If you need any further assistance, let me know!
-------------------

Prompt: check bankr balance

-------------------
Error: Token symbol "BANKR" not found on base-mainnet. Available token symbols on base-mainnet: USDC, EURC, CBBTC, CBETH, WETH, ZORA, AERO, BNKR, CLANKER
-------------------

-------------------
Token address for BNKR on base-mainnet: 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b
-------------------

-------------------
Balance of BankrCoin (0x22af33fe49fd1fa80c7149773dde5890d3c76f3b) at address 0xf2d4580ADfe8E012f5550322706d62DF11fDBE21 is 0
-------------------
Your balance for BankrCoin (BNKR) is **0**. If you need assistance with anything else, feel free to ask!
-------------------

Prompt: send 0.001 usdc to 0xa8c1a5D3C372C65c04f91f87a43F549619A9483f
Transferred 0.001 of USD Coin (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913) to 0xa8c1a5D3C372C65c04f91f87a43F549619A9483f.
Transaction hash for the transfer: 0xfc070337f72b5e154e556d007efc6418ff8c74bcc29c087107e07efdcc16daf2
-------------------
I have successfully transferred **0.001 USDC** to the address **0xa8c1a5D3C372C65c04f91f87a43F549619A9483f**. 

The transaction hash is: **0xfc070337f72b5e154e556d007efc6418ff8c74bcc29c087107e07efdcc16daf2**.

If you need anything else, just let me know!
-------------------

Prompt: send 0.000001 eth to 0xa8c1a5D3C372C65c04f91f87a43F549619A9483f

-------------------
Transferred 0.000001 ETH to 0xa8c1a5D3C372C65c04f91f87a43F549619A9483f
Transaction hash: 0xeafcac9aa1beb05a2dd72362741939287b6b951ef70a96de38252d5270b08221
-------------------
I have successfully transferred **0.000001 ETH** to the address **0xa8c1a5D3C372C65c04f91f87a43F549619A9483f**.

The transaction hash is: **0xeafcac9aa1beb05a2dd72362741939287b6b951ef70a96de38252d5270b08221**.

Prompt: check usdc balance for 0xa8c1a5D3C372C65c04f91f87a43F549619A9483f

----------
Balance of USD Coin (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913) at address 0xa8c1a5D3C372C65c04f91f87a43F549619A9483f is 9.076885
-------------------
The balance of USDC for the address **0xa8c1a5D3C372C65c04f91f87a43F549619A9483f** is **9.076885 USDC**.
```

```
Chatbot: typescript/examples/langchain-cdp-chatbot/chatbot.ts
Network: Solana devnet

Prompt: send 0.0001 sol to 91sEBA6DLKakGV4raqW2pE8bmQR1D9dnbdGTjtATur5U 

-------------------
Transferred 0.0001 SOL to 91sEBA6DLKakGV4raqW2pE8bmQR1D9dnbdGTjtATur5U
Signature: 45MJKkm5CEQbCED8s7Ykz8P8bFySyqXq8AoLWzXW2NXUMMWwW2hcUs22yux1M9q5RHvcUGvcVbgHyy3sHGVC6CyM
-------------------
The transfer of 0.0001 SOL to the address **91sEBA6DLKakGV4raqW2pE8bmQR1D9dnbdGTjtATur5U** has been successfully completed. 

Transaction Signature: **45MJKkm5CEQbCED8s7Ykz8P8bFySyqXq8AoLWzXW2NXUMMWwW2hcUs22yux1M9q5RHvcUGvcVbgHyy3sHGVC6CyM**

```


## Checklist

A couple of things to include in your PR for completeness:

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
