### PR TITLE
chore: version python packages

### DIFF
--- a/python/create-onchain-agent/CHANGELOG.md
+++ b/python/create-onchain-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!-- towncrier release notes start -->
 
+## [0.9.0] - 2025-09-05
+
+### Added
+
+- Bump coinbase-agentkit to 0.7.2 in beginner template and chatbot template
+- Bump coinbase-agentkit-langchain to 0.7.0 in beginner template and chatbot template
+- Bump coinbase-agentkit-openai-agents-sdk to 0.7.0 in beginner template and chatbot template
+
+
 ## [0.8.0] - 2025-07-18
 
 ### Added

--- a/python/create-onchain-agent/pyproject.toml
+++ b/python/create-onchain-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "create-onchain-agent"
-version = "0.8.0"
+version = "0.9.0"
 description = "CLI to create an onchain agent project"
 authors = [{ name = "Carson Roscoe", email = "carsonroscoe7@gmail.com" }]
 requires-python = ">=3.10"

--- a/python/create-onchain-agent/templates/beginner/pyproject.toml.jinja
+++ b/python/create-onchain-agent/templates/beginner/pyproject.toml.jinja
@@ -9,11 +9,11 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = "^1.0.1"
-coinbase-agentkit = "^0.7.0"
+coinbase-agentkit = "^0.7.2"
 {% if _framework == "langchain" %}langchain-openai = "^0.2.4"
 langgraph = "^0.2.39"
-coinbase-agentkit-langchain = "^0.6.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
-coinbase-agentkit-openai-agents-sdk = "^0.6.0"
+coinbase-agentkit-langchain = "^0.7.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
+coinbase-agentkit-openai-agents-sdk = "^0.7.0"
 openai = "1.68.0"{% endif %}
 {% if _wallet_provider == "server" or _wallet_provider == "smart"%}cdp-sdk = "1.23.0"{% endif %}
 

--- a/python/create-onchain-agent/templates/chatbot/pyproject.toml.jinja
+++ b/python/create-onchain-agent/templates/chatbot/pyproject.toml.jinja
@@ -9,11 +9,11 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 python-dotenv = "^1.0.1"
-coinbase-agentkit = "^0.7.0"
+coinbase-agentkit = "^0.7.2"
 {% if _framework == "langchain" %}langchain-openai = "^0.2.4"
 langgraph = "^0.2.39"
-coinbase-agentkit-langchain = "^0.6.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
-coinbase-agentkit-openai-agents-sdk = "^0.6.0"
+coinbase-agentkit-langchain = "^0.7.0"{% elif _framework == "openai_agents" %}openai-agents = "0.0.6"
+coinbase-agentkit-openai-agents-sdk = "^0.7.0"
 openai = "1.68.0"{% endif %}
 {% if _wallet_provider == "server" or _wallet_provider == "smart"%}cdp-sdk = "1.23.0"{% endif %}
 

--- a/python/create-onchain-agent/uv.lock
+++ b/python/create-onchain-agent/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -128,7 +128,7 @@ wheels = [
 
 [[package]]
 name = "create-onchain-agent"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/python/examples/autogen-cdp-chatbot/uv.lock
+++ b/python/examples/autogen-cdp-chatbot/uv.lock
@@ -718,7 +718,7 @@ dependencies = [
 requires-dist = [
     { name = "autogen-agentchat", specifier = ">=0.7.1,<0.8" },
     { name = "autogen-ext", extras = ["openai"], specifier = ">=0.7.1,<0.8" },
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-cdp-chatbot-with-amazon-bedrock/uv.lock
+++ b/python/examples/langchain-cdp-chatbot-with-amazon-bedrock/uv.lock
@@ -676,7 +676,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -687,7 +687,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-cdp-chatbot/uv.lock
+++ b/python/examples/langchain-cdp-chatbot/uv.lock
@@ -646,7 +646,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -657,7 +657,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-cdp-smart-wallet-chatbot/uv.lock
+++ b/python/examples/langchain-cdp-smart-wallet-chatbot/uv.lock
@@ -646,7 +646,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -657,7 +657,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-cdp-solana-chatbot/uv.lock
+++ b/python/examples/langchain-cdp-solana-chatbot/uv.lock
@@ -614,7 +614,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -625,7 +625,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-eth-account-chatbot/uv.lock
+++ b/python/examples/langchain-eth-account-chatbot/uv.lock
@@ -646,7 +646,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -657,7 +657,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-nillion-secretvault-chatbot/uv.lock
+++ b/python/examples/langchain-nillion-secretvault-chatbot/uv.lock
@@ -646,7 +646,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -657,7 +657,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/langchain-twitter-chatbot/uv.lock
+++ b/python/examples/langchain-twitter-chatbot/uv.lock
@@ -648,7 +648,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/langchain" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -659,7 +659,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/examples/openai-agents-sdk-cdp-chatbot/uv.lock
+++ b/python/examples/openai-agents-sdk-cdp-chatbot/uv.lock
@@ -613,7 +613,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/openai-agents-sdk" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -626,7 +626,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },

--- a/python/examples/openai-agents-sdk-cdp-voice-chatbot/uv.lock
+++ b/python/examples/openai-agents-sdk-cdp-voice-chatbot/uv.lock
@@ -613,7 +613,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/openai-agents-sdk" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -626,7 +626,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },

--- a/python/examples/openai-agents-sdk-smart-wallet-chatbot/uv.lock
+++ b/python/examples/openai-agents-sdk-smart-wallet-chatbot/uv.lock
@@ -613,7 +613,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../../framework-extensions/openai-agents-sdk" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -626,7 +626,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },

--- a/python/examples/pydantic-ai-cdp-chatbot/uv.lock
+++ b/python/examples/pydantic-ai-cdp-chatbot/uv.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "pydantic-ai", specifier = ">=0.4.0,<0.5" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },

--- a/python/examples/strands-agents-cdp-server-chatbot/uv.lock
+++ b/python/examples/strands-agents-cdp-server-chatbot/uv.lock
@@ -700,7 +700,7 @@ dev = [
 
 [[package]]
 name = "coinbase-agentkit-strands-agents"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "../../framework-extensions/strands-agents" }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -713,7 +713,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.1,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "strands-agents", specifier = ">=1.0.1" },

--- a/python/framework-extensions/autogen/CHANGELOG.md
+++ b/python/framework-extensions/autogen/CHANGELOG.md
@@ -3,3 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 <!-- towncrier release notes start -->
+
+## [0.1.0] - 2025-09-05
+
+### Added
+
+- Initial release of CDP Agentkit Extension - Autogen.

--- a/python/framework-extensions/autogen/pyproject.toml
+++ b/python/framework-extensions/autogen/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit>=0.7.0,<0.9",
+    "coinbase-agentkit>=0.7.2,<0.8",
     "autogen-agentchat>=0.7.1,<0.8",
     "autogen-ext[openai]>=0.7.1,<0.8",
     "python-dotenv>=1.0.1,<2",

--- a/python/framework-extensions/autogen/uv.lock
+++ b/python/framework-extensions/autogen/uv.lock
@@ -463,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.31.0"
+version = "1.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -479,9 +479,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/66/c5afeb752754e4efc83e07803595d6dbdfd6c6ad83ae6576e39c106696b5/cdp_sdk-1.31.0.tar.gz", hash = "sha256:d64591d89fa35e07536f4948e08505d140e13d58e7d8c98d2e3f44a82eb629ae", size = 317695, upload-time = "2025-08-19T19:30:25.288Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/fe/f1daa8e52f320063576318032c67dda346081b4bbb6be00c8bb99f2b12b0/cdp_sdk-1.31.2.tar.gz", hash = "sha256:47d17aaf3da5183123a64d38d3c02c2350758186c48e334b425d8b0f105b7fd8", size = 317633, upload-time = "2025-09-05T20:51:43.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/89/6a5ba1c42b388e08cfc0974a59d8432e8ed904d181e91d7a64038ea5dd19/cdp_sdk-1.31.0-py3-none-any.whl", hash = "sha256:b157cbc52c84cde301903cdc4c253aa97a5d629480e558a1f26345d4c7ef62b1", size = 792658, upload-time = "2025-08-19T19:30:23.508Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/b5a152845d29f04ce51eff1703b1518f2272ff45e139cae9eacd1cc73584/cdp_sdk-1.31.2-py3-none-any.whl", hash = "sha256:a58a67e4bc1e1edd561a57d09e2d5eed847d378ba328ea6c7802634d00800415", size = 792613, upload-time = "2025-09-05T20:51:41.019Z" },
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "coinbase-agentkit"
-version = "0.7.1"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cdp-sdk" },
@@ -701,9 +701,9 @@ dependencies = [
     { name = "web3" },
     { name = "x402" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/17/95dd9eaf0090604fd9e419eff11a4347a7692ee34a9d1d6416dc27835fc5/coinbase_agentkit-0.7.1.tar.gz", hash = "sha256:b2a3a482d895a138d292f189f2755e38c55166973a810f728219c62cd8f3d364", size = 109757, upload-time = "2025-08-01T20:43:02.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/91/9f3efe6d4737707341a4f054c7e236b485d42ec3105ba97db1e6ed747311/coinbase_agentkit-0.7.2.tar.gz", hash = "sha256:621935644118054772d9b047bed4dbca04cd28f6d67ea0779507d2c480a17b41", size = 114875, upload-time = "2025-09-06T00:13:29.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/75/c1eb762d9c9ce53ebf0013592186aef447d61f7da88165770ac1782821fa/coinbase_agentkit-0.7.1-py3-none-any.whl", hash = "sha256:26ee1b49f7495f37127860abe485762549a998c266ab1c41637043a3116e9bb4", size = 170267, upload-time = "2025-08-01T20:43:00.285Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0c/0dc601ace61f967eeced8b33c776d04b2cb08ee029c23a9aed91eaf2d747/coinbase_agentkit-0.7.2-py3-none-any.whl", hash = "sha256:32c097c4a0e87086d88ddb45082b3bf96d40cd20980a7052bffb1cc68f902b97", size = 179654, upload-time = "2025-09-06T00:13:27.834Z" },
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ dev = [
 requires-dist = [
     { name = "autogen-agentchat", specifier = ">=0.7.1,<0.8" },
     { name = "autogen-ext", extras = ["openai"], specifier = ">=0.7.1,<0.8" },
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },

--- a/python/framework-extensions/langchain/CHANGELOG.md
+++ b/python/framework-extensions/langchain/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## [0.7.0] - 2025-09-05
+
+### Added
+
+- Bump coinbase-agentkit to 0.7.2
+
+
 ## [0.6.0] - 2025-07-18
 
 ### Added

--- a/python/framework-extensions/langchain/docs/conf.py
+++ b/python/framework-extensions/langchain/docs/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = 'Coinbase Agentkit LangChain'
 author = 'Coinbase Developer Platform'
-release = '0.6.0'
+release = '0.7.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/python/framework-extensions/langchain/pyproject.toml
+++ b/python/framework-extensions/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 description = "Coinbase AgentKit LangChain extension"
 authors = [{ name = "John Peterson", email = "john.peterson@coinbase.com" }]
 requires-python = "~=3.10"
@@ -17,7 +17,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit>=0.7.0,<0.9",
+    "coinbase-agentkit>=0.7.2,<0.8",
     "langchain>=0.3.4,<0.4",
     "python-dotenv>=1.0.1,<2",
     "nest-asyncio>=1.5.8,<2",

--- a/python/framework-extensions/langchain/uv.lock
+++ b/python/framework-extensions/langchain/uv.lock
@@ -133,38 +133,6 @@ wheels = [
 ]
 
 [[package]]
-name = "allora-sdk"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "annotated-types" },
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "chardet" },
-    { name = "charset-normalizer" },
-    { name = "colorama" },
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "idna" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "pyproject-api" },
-    { name = "requests" },
-    { name = "tox" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/90/46df3515a79bcad5733633f38a7a8d6c7826c48c3e48fa89e2d081bc70f9/allora_sdk-0.2.3.tar.gz", hash = "sha256:d976c17816566114f45327cc843d9a996d807e48d1697c3cbd4355095c5a04c6", size = 6273, upload-time = "2025-04-14T11:35:53.406Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/65/73e1ecfcc802b6178377c2156190dfc84639d9784299119e1b4ca4ca1c68/allora_sdk-0.2.3-py3-none-any.whl", hash = "sha256:ca71c39f7f6410dbb9bc7ab6569eb91a8515490d0c6cc54f9512b7af35ab214e", size = 5008, upload-time = "2025-04-14T11:35:52.01Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -390,15 +358,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cachetools"
-version = "5.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661, upload-time = "2024-08-18T20:28:44.639Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524, upload-time = "2024-08-18T20:28:43.404Z" },
-]
-
-[[package]]
 name = "cattrs"
 version = "24.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -414,7 +373,7 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.23.0"
+version = "1.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -430,9 +389,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/25/d8df9494dfeda749ac6180969cbcdcbf46f97c1153f38b690ab023626145/cdp_sdk-1.23.0.tar.gz", hash = "sha256:7cc5dd13ec74ffa0332245261aaa5f23af9448300ab65932cc4dbcaddf34f055", size = 237257, upload-time = "2025-07-16T14:21:59.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/fe/f1daa8e52f320063576318032c67dda346081b4bbb6be00c8bb99f2b12b0/cdp_sdk-1.31.2.tar.gz", hash = "sha256:47d17aaf3da5183123a64d38d3c02c2350758186c48e334b425d8b0f105b7fd8", size = 317633, upload-time = "2025-09-05T20:51:43.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/4c/1acfbde011cf259720f4df44898f3d75f636bbc43631659994bbe6b1d05e/cdp_sdk-1.23.0-py3-none-any.whl", hash = "sha256:40d59853f1be7ef90029220966055686ab328e973c728703a6de7527ebdd1947", size = 567985, upload-time = "2025-07-16T14:21:58.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/b5a152845d29f04ce51eff1703b1518f2272ff45e139cae9eacd1cc73584/cdp_sdk-1.31.2-py3-none-any.whl", hash = "sha256:a58a67e4bc1e1edd561a57d09e2d5eed847d378ba328ea6c7802634d00800415", size = 792613, upload-time = "2025-09-05T20:51:41.019Z" },
 ]
 
 [[package]]
@@ -499,15 +458,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
-]
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
 ]
 
 [[package]]
@@ -641,10 +591,9 @@ wheels = [
 
 [[package]]
 name = "coinbase-agentkit"
-version = "0.7.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "allora-sdk" },
     { name = "cdp-sdk" },
     { name = "ecdsa" },
     { name = "jsonschema" },
@@ -659,14 +608,14 @@ dependencies = [
     { name = "web3" },
     { name = "x402" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/c4/bf1c392b48eafbd84b2ef56c46d79f1e1466e56dc6e01d2a5823e9c6351e/coinbase_agentkit-0.7.0.tar.gz", hash = "sha256:3a2c925528f23ef0020f470279c739f5d0e92629686af240a523c94722f59b1a", size = 113504, upload-time = "2025-07-18T19:36:48.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/91/9f3efe6d4737707341a4f054c7e236b485d42ec3105ba97db1e6ed747311/coinbase_agentkit-0.7.2.tar.gz", hash = "sha256:621935644118054772d9b047bed4dbca04cd28f6d67ea0779507d2c480a17b41", size = 114875, upload-time = "2025-09-06T00:13:29.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/9d/386654c76fc47cc58e5e6225996f19741be92a1bc91885c0aad9d512394d/coinbase_agentkit-0.7.0-py3-none-any.whl", hash = "sha256:240f1d45fbcb52a09e3231a15d172256e3c164ff6bef5058b9b0ef5c029375e6", size = 175982, upload-time = "2025-07-18T19:36:46.606Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0c/0dc601ace61f967eeced8b33c776d04b2cb08ee029c23a9aed91eaf2d747/coinbase_agentkit-0.7.2-py3-none-any.whl", hash = "sha256:32c097c4a0e87086d88ddb45082b3bf96d40cd20980a7052bffb1cc68f902b97", size = 179654, upload-time = "2025-09-06T00:13:27.834Z" },
 ]
 
 [[package]]
 name = "coinbase-agentkit-langchain"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -694,7 +643,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "langchain", specifier = ">=0.3.4,<0.4" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
@@ -926,15 +875,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/80/3ae356c5e7b8d7dc7d1adb52f6932fee85cd748ed4e1217c269d2dfd610f/cytoolz-1.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a515df8f8aa6e1eaaf397761a6e4aff2eef73b5f920aedf271416d5471ae5ee", size = 406261, upload-time = "2024-12-13T05:47:12.24Z" },
     { url = "https://files.pythonhosted.org/packages/0c/31/8e43761ffc82d90bf9cab7e0959712eedcd1e33c211397e143dd42d7af57/cytoolz-1.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c398e7b7023460bea2edffe5fcd0a76029580f06c3f6938ac3d198b47156f3", size = 397207, upload-time = "2024-12-13T05:47:13.561Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b9/fe9da37090b6444c65f848a83e390f87d8cb43d6a4df46de1556ad7e5ceb/cytoolz-1.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3237e56211e03b13df47435b2369f5df281e02b04ad80a948ebd199b7bc10a47", size = 343358, upload-time = "2024-12-13T05:47:16.291Z" },
-]
-
-[[package]]
-name = "distlib"
-version = "0.3.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
 ]
 
 [[package]]
@@ -1190,15 +1130,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/d7/4a987c3d73ddae4a7c93f5d2982ea5b1dd58d4cc1044568bb180227bd0f7/fastapi_cloud_cli-0.1.4.tar.gz", hash = "sha256:a0ab7633d71d864b4041896b3fe2f462de61546db7c52eb13e963f4d40af0eba", size = 22712, upload-time = "2025-07-11T14:15:25.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/cf/8635cd778b7d89714325b967a28c05865a2b6cab4c0b4b30561df4704f24/fastapi_cloud_cli-0.1.4-py3-none-any.whl", hash = "sha256:1db1ba757aa46a16a5e5dacf7cddc137ca0a3c42f65dba2b1cc6a8f24c41be42", size = 18957, upload-time = "2025-07-11T14:15:24.451Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.16.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/db/3ef5bb276dae18d6ec2124224403d1d67bccdbefc17af4cc8f553e341ab1/filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435", size = 18037, upload-time = "2024-09-17T19:02:01.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0", size = 16163, upload-time = "2024-09-17T19:02:00.268Z" },
 ]
 
 [[package]]
@@ -2064,15 +1995,6 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.3.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload-time = "2024-09-17T19:06:50.688Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload-time = "2024-09-17T19:06:49.212Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2376,19 +2298,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/1a/cc308a884bd299b651f1633acb978e8596c71c33ca85e9dc9fa33a5399b9/PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff", size = 1117912, upload-time = "2022-01-07T22:05:58.665Z" },
     { url = "https://files.pythonhosted.org/packages/25/2d/b7df6ddb0c2a33afdb358f8af6ea3b8c4d1196ca45497dd37a56f0c122be/PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543", size = 204624, upload-time = "2022-01-07T22:06:00.085Z" },
     { url = "https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93", size = 212141, upload-time = "2022-01-07T22:06:01.861Z" },
-]
-
-[[package]]
-name = "pyproject-api"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/19/441e0624a8afedd15bbcce96df1b80479dd0ff0d965f5ce8fde4f2f6ffad/pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496", size = 22340, upload-time = "2024-09-18T23:18:37.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/f4/3c4ddfcc0c19c217c6de513842d286de8021af2f2ab79bbb86c00342d778/pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228", size = 13100, upload-time = "2024-09-18T23:18:35.927Z" },
 ]
 
 [[package]]
@@ -3324,28 +3233,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tox"
-version = "4.23.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "chardet" },
-    { name = "colorama" },
-    { name = "filelock" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pyproject-api" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/86/32b10f91b4b975a37ac402b0f9fa016775088e0565c93602ba0b3c729ce8/tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c", size = 189998, upload-time = "2024-10-22T14:29:04.46Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/c0/124b73d01c120e917383bc6c53ebc34efdf7243faa9fca64d105c94cf2ab/tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38", size = 166758, upload-time = "2024-10-22T14:29:02.087Z" },
-]
-
-[[package]]
 name = "typer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3511,20 +3398,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/19/f5b78616566ea68edd42aacaf645adbf71fbd83fc52281fba555dc27e3f1/uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816", size = 4701068, upload-time = "2024-10-14T23:38:06.385Z" },
     { url = "https://files.pythonhosted.org/packages/47/57/66f061ee118f413cd22a656de622925097170b9380b30091b78ea0c6ea75/uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc", size = 4454428, upload-time = "2024-10-14T23:38:08.416Z" },
     { url = "https://files.pythonhosted.org/packages/63/9a/0962b05b308494e3202d3f794a6e85abe471fe3cafdbcf95c2e8c713aabd/uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553", size = 4660018, upload-time = "2024-10-14T23:38:10.888Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/39/689abee4adc85aad2af8174bb195a819d0be064bf55fcc73b49d2b28ae77/virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329", size = 7650532, upload-time = "2025-01-03T01:56:53.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/8f/dfb257ca6b4e27cb990f1631142361e4712badab8e3ca8dc134d96111515/virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb", size = 4276719, upload-time = "2025-01-03T01:56:50.498Z" },
 ]
 
 [[package]]

--- a/python/framework-extensions/openai-agents-sdk/CHANGELOG.md
+++ b/python/framework-extensions/openai-agents-sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- towncrier release notes start -->
 
+## [0.7.0] - 2025-09-05
+
+### Added
+
+- Bump coinbase-agentkit to 0.7.2
+
+
 ## [0.6.0] - 2025-07-18
 
 ### Added

--- a/python/framework-extensions/openai-agents-sdk/pyproject.toml
+++ b/python/framework-extensions/openai-agents-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.6.0"
+version = "0.7.0"
 description = "Coinbase AgentKit OpenAI Agents SDK extension"
 authors = [{ name = "John Peterson", email = "john.peterson@coinbase.com" }]
 requires-python = "~=3.10"
@@ -17,7 +17,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit>=0.7.0,<0.9",
+    "coinbase-agentkit>=0.7.2,<0.8",
     "python-dotenv>=1.0.1,<2",
     "pytest-asyncio>=0.25.3,<0.26",
     "openai-agents>=0.0.6,<0.0.7",

--- a/python/framework-extensions/openai-agents-sdk/uv.lock
+++ b/python/framework-extensions/openai-agents-sdk/uv.lock
@@ -132,38 +132,6 @@ wheels = [
 ]
 
 [[package]]
-name = "allora-sdk"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "annotated-types" },
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "chardet" },
-    { name = "charset-normalizer" },
-    { name = "colorama" },
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "idna" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "pyproject-api" },
-    { name = "requests" },
-    { name = "tox" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/90/46df3515a79bcad5733633f38a7a8d6c7826c48c3e48fa89e2d081bc70f9/allora_sdk-0.2.3.tar.gz", hash = "sha256:d976c17816566114f45327cc843d9a996d807e48d1697c3cbd4355095c5a04c6", size = 6273, upload-time = "2025-04-14T11:35:53.406Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/65/73e1ecfcc802b6178377c2156190dfc84639d9784299119e1b4ca4ca1c68/allora_sdk-0.2.3-py3-none-any.whl", hash = "sha256:ca71c39f7f6410dbb9bc7ab6569eb91a8515490d0c6cc54f9512b7af35ab214e", size = 5008, upload-time = "2025-04-14T11:35:52.01Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -389,15 +357,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cachetools"
-version = "5.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661, upload-time = "2024-08-18T20:28:44.639Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524, upload-time = "2024-08-18T20:28:43.404Z" },
-]
-
-[[package]]
 name = "cattrs"
 version = "24.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -413,7 +372,7 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.23.0"
+version = "1.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -429,9 +388,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/25/d8df9494dfeda749ac6180969cbcdcbf46f97c1153f38b690ab023626145/cdp_sdk-1.23.0.tar.gz", hash = "sha256:7cc5dd13ec74ffa0332245261aaa5f23af9448300ab65932cc4dbcaddf34f055", size = 237257, upload-time = "2025-07-16T14:21:59.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/fe/f1daa8e52f320063576318032c67dda346081b4bbb6be00c8bb99f2b12b0/cdp_sdk-1.31.2.tar.gz", hash = "sha256:47d17aaf3da5183123a64d38d3c02c2350758186c48e334b425d8b0f105b7fd8", size = 317633, upload-time = "2025-09-05T20:51:43.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/4c/1acfbde011cf259720f4df44898f3d75f636bbc43631659994bbe6b1d05e/cdp_sdk-1.23.0-py3-none-any.whl", hash = "sha256:40d59853f1be7ef90029220966055686ab328e973c728703a6de7527ebdd1947", size = 567985, upload-time = "2025-07-16T14:21:58.13Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/b5a152845d29f04ce51eff1703b1518f2272ff45e139cae9eacd1cc73584/cdp_sdk-1.31.2-py3-none-any.whl", hash = "sha256:a58a67e4bc1e1edd561a57d09e2d5eed847d378ba328ea6c7802634d00800415", size = 792613, upload-time = "2025-09-05T20:51:41.019Z" },
 ]
 
 [[package]]
@@ -498,15 +457,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
-]
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
 ]
 
 [[package]]
@@ -640,10 +590,9 @@ wheels = [
 
 [[package]]
 name = "coinbase-agentkit"
-version = "0.7.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "allora-sdk" },
     { name = "cdp-sdk" },
     { name = "ecdsa" },
     { name = "jsonschema" },
@@ -658,14 +607,14 @@ dependencies = [
     { name = "web3" },
     { name = "x402" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/c4/bf1c392b48eafbd84b2ef56c46d79f1e1466e56dc6e01d2a5823e9c6351e/coinbase_agentkit-0.7.0.tar.gz", hash = "sha256:3a2c925528f23ef0020f470279c739f5d0e92629686af240a523c94722f59b1a", size = 113504, upload-time = "2025-07-18T19:36:48.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/91/9f3efe6d4737707341a4f054c7e236b485d42ec3105ba97db1e6ed747311/coinbase_agentkit-0.7.2.tar.gz", hash = "sha256:621935644118054772d9b047bed4dbca04cd28f6d67ea0779507d2c480a17b41", size = 114875, upload-time = "2025-09-06T00:13:29.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/9d/386654c76fc47cc58e5e6225996f19741be92a1bc91885c0aad9d512394d/coinbase_agentkit-0.7.0-py3-none-any.whl", hash = "sha256:240f1d45fbcb52a09e3231a15d172256e3c164ff6bef5058b9b0ef5c029375e6", size = 175982, upload-time = "2025-07-18T19:36:46.606Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0c/0dc601ace61f967eeced8b33c776d04b2cb08ee029c23a9aed91eaf2d747/coinbase_agentkit-0.7.2-py3-none-any.whl", hash = "sha256:32c097c4a0e87086d88ddb45082b3bf96d40cd20980a7052bffb1cc68f902b97", size = 179654, upload-time = "2025-09-06T00:13:27.834Z" },
 ]
 
 [[package]]
 name = "coinbase-agentkit-openai-agents-sdk"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -695,7 +644,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "openai-agents", specifier = ">=0.0.6,<0.0.7" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },
@@ -929,15 +878,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/80/3ae356c5e7b8d7dc7d1adb52f6932fee85cd748ed4e1217c269d2dfd610f/cytoolz-1.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a515df8f8aa6e1eaaf397761a6e4aff2eef73b5f920aedf271416d5471ae5ee", size = 406261, upload-time = "2024-12-13T05:47:12.24Z" },
     { url = "https://files.pythonhosted.org/packages/0c/31/8e43761ffc82d90bf9cab7e0959712eedcd1e33c211397e143dd42d7af57/cytoolz-1.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c398e7b7023460bea2edffe5fcd0a76029580f06c3f6938ac3d198b47156f3", size = 397207, upload-time = "2024-12-13T05:47:13.561Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b9/fe9da37090b6444c65f848a83e390f87d8cb43d6a4df46de1556ad7e5ceb/cytoolz-1.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3237e56211e03b13df47435b2369f5df281e02b04ad80a948ebd199b7bc10a47", size = 343358, upload-time = "2024-12-13T05:47:16.291Z" },
-]
-
-[[package]]
-name = "distlib"
-version = "0.3.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
 ]
 
 [[package]]
@@ -1202,15 +1142,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/d7/4a987c3d73ddae4a7c93f5d2982ea5b1dd58d4cc1044568bb180227bd0f7/fastapi_cloud_cli-0.1.4.tar.gz", hash = "sha256:a0ab7633d71d864b4041896b3fe2f462de61546db7c52eb13e963f4d40af0eba", size = 22712, upload-time = "2025-07-11T14:15:25.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/cf/8635cd778b7d89714325b967a28c05865a2b6cab4c0b4b30561df4704f24/fastapi_cloud_cli-0.1.4-py3-none-any.whl", hash = "sha256:1db1ba757aa46a16a5e5dacf7cddc137ca0a3c42f65dba2b1cc6a8f24c41be42", size = 18957, upload-time = "2025-07-11T14:15:24.451Z" },
-]
-
-[[package]]
-name = "filelock"
-version = "3.16.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/db/3ef5bb276dae18d6ec2124224403d1d67bccdbefc17af4cc8f553e341ab1/filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435", size = 18037, upload-time = "2024-09-17T19:02:01.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0", size = 16163, upload-time = "2024-09-17T19:02:00.268Z" },
 ]
 
 [[package]]
@@ -1977,15 +1908,6 @@ wheels = [
 ]
 
 [[package]]
-name = "platformdirs"
-version = "4.3.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload-time = "2024-09-17T19:06:50.688Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload-time = "2024-09-17T19:06:49.212Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2289,19 +2211,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/1a/cc308a884bd299b651f1633acb978e8596c71c33ca85e9dc9fa33a5399b9/PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff", size = 1117912, upload-time = "2022-01-07T22:05:58.665Z" },
     { url = "https://files.pythonhosted.org/packages/25/2d/b7df6ddb0c2a33afdb358f8af6ea3b8c4d1196ca45497dd37a56f0c122be/PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543", size = 204624, upload-time = "2022-01-07T22:06:00.085Z" },
     { url = "https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93", size = 212141, upload-time = "2022-01-07T22:06:01.861Z" },
-]
-
-[[package]]
-name = "pyproject-api"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/19/441e0624a8afedd15bbcce96df1b80479dd0ff0d965f5ce8fde4f2f6ffad/pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496", size = 22340, upload-time = "2024-09-18T23:18:37.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/f4/3c4ddfcc0c19c217c6de513842d286de8021af2f2ab79bbb86c00342d778/pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228", size = 13100, upload-time = "2024-09-18T23:18:35.927Z" },
 ]
 
 [[package]]
@@ -3191,28 +3100,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tox"
-version = "4.23.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "chardet" },
-    { name = "colorama" },
-    { name = "filelock" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pyproject-api" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/86/32b10f91b4b975a37ac402b0f9fa016775088e0565c93602ba0b3c729ce8/tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c", size = 189998, upload-time = "2024-10-22T14:29:04.46Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/c0/124b73d01c120e917383bc6c53ebc34efdf7243faa9fca64d105c94cf2ab/tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38", size = 166758, upload-time = "2024-10-22T14:29:02.087Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3390,20 +3277,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/19/f5b78616566ea68edd42aacaf645adbf71fbd83fc52281fba555dc27e3f1/uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816", size = 4701068, upload-time = "2024-10-14T23:38:06.385Z" },
     { url = "https://files.pythonhosted.org/packages/47/57/66f061ee118f413cd22a656de622925097170b9380b30091b78ea0c6ea75/uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc", size = 4454428, upload-time = "2024-10-14T23:38:08.416Z" },
     { url = "https://files.pythonhosted.org/packages/63/9a/0962b05b308494e3202d3f794a6e85abe471fe3cafdbcf95c2e8c713aabd/uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553", size = 4660018, upload-time = "2024-10-14T23:38:10.888Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/39/689abee4adc85aad2af8174bb195a819d0be064bf55fcc73b49d2b28ae77/virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329", size = 7650532, upload-time = "2025-01-03T01:56:53.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/8f/dfb257ca6b4e27cb990f1631142361e4712badab8e3ca8dc134d96111515/virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb", size = 4276719, upload-time = "2025-01-03T01:56:50.498Z" },
 ]
 
 [[package]]

--- a/python/framework-extensions/pydantic-ai/CHANGELOG.md
+++ b/python/framework-extensions/pydantic-ai/CHANGELOG.md
@@ -3,3 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 <!-- towncrier release notes start -->
+
+## [0.1.0] - 2025-09-05
+
+### Added
+
+- Initial release of CDP Agentkit Extension - Langchain Toolkit.

--- a/python/framework-extensions/pydantic-ai/pyproject.toml
+++ b/python/framework-extensions/pydantic-ai/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit>=0.7.0,<0.9",
+    "coinbase-agentkit>=0.7.2,<0.8",
     "python-dotenv>=1.0.1,<2",
     "pytest-asyncio>=0.25.3,<0.26",
     "pydantic-ai>=0.4.0,<0.5",

--- a/python/framework-extensions/pydantic-ai/uv.lock
+++ b/python/framework-extensions/pydantic-ai/uv.lock
@@ -132,38 +132,6 @@ wheels = [
 ]
 
 [[package]]
-name = "allora-sdk"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "annotated-types" },
-    { name = "cachetools" },
-    { name = "certifi" },
-    { name = "chardet" },
-    { name = "charset-normalizer" },
-    { name = "colorama" },
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "idna" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "pyproject-api" },
-    { name = "requests" },
-    { name = "tox" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/90/46df3515a79bcad5733633f38a7a8d6c7826c48c3e48fa89e2d081bc70f9/allora_sdk-0.2.3.tar.gz", hash = "sha256:d976c17816566114f45327cc843d9a996d807e48d1697c3cbd4355095c5a04c6", size = 6273, upload-time = "2025-04-14T11:35:53.406Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/65/73e1ecfcc802b6178377c2156190dfc84639d9784299119e1b4ca4ca1c68/allora_sdk-0.2.3-py3-none-any.whl", hash = "sha256:ca71c39f7f6410dbb9bc7ab6569eb91a8515490d0c6cc54f9512b7af35ab214e", size = 5008, upload-time = "2025-04-14T11:35:52.01Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -502,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.26.0"
+version = "1.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -518,9 +486,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/cd/2e0f7918dc21a309388525ef9d2d8067d607c6ff959e76e99ed0335b572b/cdp_sdk-1.26.0.tar.gz", hash = "sha256:4de48c2f94e9a222833b29df847d6ccfc0bfa165bf0a7f787b035d1962f2285f", size = 276055, upload-time = "2025-08-01T00:26:10.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/fe/f1daa8e52f320063576318032c67dda346081b4bbb6be00c8bb99f2b12b0/cdp_sdk-1.31.2.tar.gz", hash = "sha256:47d17aaf3da5183123a64d38d3c02c2350758186c48e334b425d8b0f105b7fd8", size = 317633, upload-time = "2025-09-05T20:51:43.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/33/b1b861de09d3a950501c16977e4113766dd444024ce355d56b4e4a5ca289/cdp_sdk-1.26.0-py3-none-any.whl", hash = "sha256:72d4b51e0b4b455367fb5e42ee5966313ff9cb70575e761501adf711eee680f1", size = 652515, upload-time = "2025-08-01T00:26:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/b5a152845d29f04ce51eff1703b1518f2272ff45e139cae9eacd1cc73584/cdp_sdk-1.31.2-py3-none-any.whl", hash = "sha256:a58a67e4bc1e1edd561a57d09e2d5eed847d378ba328ea6c7802634d00800415", size = 792613, upload-time = "2025-09-05T20:51:41.019Z" },
 ]
 
 [[package]]
@@ -587,15 +555,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
-]
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
 ]
 
 [[package]]
@@ -749,10 +708,9 @@ wheels = [
 
 [[package]]
 name = "coinbase-agentkit"
-version = "0.7.0"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "allora-sdk" },
     { name = "cdp-sdk" },
     { name = "ecdsa" },
     { name = "jsonschema" },
@@ -767,9 +725,9 @@ dependencies = [
     { name = "web3" },
     { name = "x402" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/c4/bf1c392b48eafbd84b2ef56c46d79f1e1466e56dc6e01d2a5823e9c6351e/coinbase_agentkit-0.7.0.tar.gz", hash = "sha256:3a2c925528f23ef0020f470279c739f5d0e92629686af240a523c94722f59b1a", size = 113504, upload-time = "2025-07-18T19:36:48.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/91/9f3efe6d4737707341a4f054c7e236b485d42ec3105ba97db1e6ed747311/coinbase_agentkit-0.7.2.tar.gz", hash = "sha256:621935644118054772d9b047bed4dbca04cd28f6d67ea0779507d2c480a17b41", size = 114875, upload-time = "2025-09-06T00:13:29.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/9d/386654c76fc47cc58e5e6225996f19741be92a1bc91885c0aad9d512394d/coinbase_agentkit-0.7.0-py3-none-any.whl", hash = "sha256:240f1d45fbcb52a09e3231a15d172256e3c164ff6bef5058b9b0ef5c029375e6", size = 175982, upload-time = "2025-07-18T19:36:46.606Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0c/0dc601ace61f967eeced8b33c776d04b2cb08ee029c23a9aed91eaf2d747/coinbase_agentkit-0.7.2-py3-none-any.whl", hash = "sha256:32c097c4a0e87086d88ddb45082b3bf96d40cd20980a7052bffb1cc68f902b97", size = 179654, upload-time = "2025-09-06T00:13:27.834Z" },
 ]
 
 [[package]]
@@ -804,7 +762,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.0,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.6.0,<2" },
     { name = "pydantic-ai", specifier = ">=0.4.0,<0.5" },
     { name = "pytest-asyncio", specifier = ">=0.25.3,<0.26" },
@@ -1063,15 +1021,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/80/3ae356c5e7b8d7dc7d1adb52f6932fee85cd748ed4e1217c269d2dfd610f/cytoolz-1.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a515df8f8aa6e1eaaf397761a6e4aff2eef73b5f920aedf271416d5471ae5ee", size = 406261, upload-time = "2024-12-13T05:47:12.24Z" },
     { url = "https://files.pythonhosted.org/packages/0c/31/8e43761ffc82d90bf9cab7e0959712eedcd1e33c211397e143dd42d7af57/cytoolz-1.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c398e7b7023460bea2edffe5fcd0a76029580f06c3f6938ac3d198b47156f3", size = 397207, upload-time = "2024-12-13T05:47:13.561Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b9/fe9da37090b6444c65f848a83e390f87d8cb43d6a4df46de1556ad7e5ceb/cytoolz-1.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3237e56211e03b13df47435b2369f5df281e02b04ad80a948ebd199b7bc10a47", size = 343358, upload-time = "2024-12-13T05:47:16.291Z" },
-]
-
-[[package]]
-name = "distlib"
-version = "0.3.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
 ]
 
 [[package]]
@@ -2818,19 +2767,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyproject-api"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/19/441e0624a8afedd15bbcce96df1b80479dd0ff0d965f5ce8fde4f2f6ffad/pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496", size = 22340, upload-time = "2024-09-18T23:18:37.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/f4/3c4ddfcc0c19c217c6de513842d286de8021af2f2ab79bbb86c00342d778/pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228", size = 13100, upload-time = "2024-09-18T23:18:35.927Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3834,28 +3770,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tox"
-version = "4.23.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-    { name = "chardet" },
-    { name = "colorama" },
-    { name = "filelock" },
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "pluggy" },
-    { name = "pyproject-api" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/86/32b10f91b4b975a37ac402b0f9fa016775088e0565c93602ba0b3c729ce8/tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c", size = 189998, upload-time = "2024-10-22T14:29:04.46Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/c0/124b73d01c120e917383bc6c53ebc34efdf7243faa9fca64d105c94cf2ab/tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38", size = 166758, upload-time = "2024-10-22T14:29:02.087Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4033,20 +3947,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/19/f5b78616566ea68edd42aacaf645adbf71fbd83fc52281fba555dc27e3f1/uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816", size = 4701068, upload-time = "2024-10-14T23:38:06.385Z" },
     { url = "https://files.pythonhosted.org/packages/47/57/66f061ee118f413cd22a656de622925097170b9380b30091b78ea0c6ea75/uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc", size = 4454428, upload-time = "2024-10-14T23:38:08.416Z" },
     { url = "https://files.pythonhosted.org/packages/63/9a/0962b05b308494e3202d3f794a6e85abe471fe3cafdbcf95c2e8c713aabd/uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553", size = 4660018, upload-time = "2024-10-14T23:38:10.888Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "20.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/39/689abee4adc85aad2af8174bb195a819d0be064bf55fcc73b49d2b28ae77/virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329", size = 7650532, upload-time = "2025-01-03T01:56:53.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/8f/dfb257ca6b4e27cb990f1631142361e4712badab8e3ca8dc134d96111515/virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb", size = 4276719, upload-time = "2025-01-03T01:56:50.498Z" },
 ]
 
 [[package]]

--- a/python/framework-extensions/strands-agents/CHANGELOG.md
+++ b/python/framework-extensions/strands-agents/CHANGELOG.md
@@ -3,3 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 <!-- towncrier release notes start -->
+## [0.2.0] - 2025-09-05
+
+### Added
+
+- Bump coinbase-agentkit to 0.7.2
+
+## [0.1.0] - 2025-08-28
+
+### Added
+
+- Initial release of CDP AgentKit Extension - Strands Agents

--- a/python/framework-extensions/strands-agents/changelog.d/+bdc60cf1.feature.md
+++ b/python/framework-extensions/strands-agents/changelog.d/+bdc60cf1.feature.md
@@ -1,1 +1,0 @@
-Initial release of CDP AgentKit Extension - Strands Agents

--- a/python/framework-extensions/strands-agents/pyproject.toml
+++ b/python/framework-extensions/strands-agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "coinbase-agentkit-strands-agents"
-version = "0.1.0"
+version = "0.2.0"
 description = "Coinbase AgentKit Strands Agents extension"
 authors = [{ name = "Uchenna Egbe", email = "ucheegbe@amazon.com" }]
 requires-python = "~=3.10"
@@ -18,7 +18,7 @@ keywords = [
     "agent",
 ]
 dependencies = [
-    "coinbase-agentkit>=0.7.1,<0.9",
+    "coinbase-agentkit>=0.7.2,<0.8",
     "python-dotenv>=1.0.1,<2",
     "nest-asyncio>=1.5.8,<2",
     "strands-agents>=1.0.1", 

--- a/python/framework-extensions/strands-agents/uv.lock
+++ b/python/framework-extensions/strands-agents/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "cdp-sdk"
-version = "1.26.0"
+version = "1.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -475,9 +475,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "web3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/cd/2e0f7918dc21a309388525ef9d2d8067d607c6ff959e76e99ed0335b572b/cdp_sdk-1.26.0.tar.gz", hash = "sha256:4de48c2f94e9a222833b29df847d6ccfc0bfa165bf0a7f787b035d1962f2285f", size = 276055, upload-time = "2025-08-01T00:26:10.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/fe/f1daa8e52f320063576318032c67dda346081b4bbb6be00c8bb99f2b12b0/cdp_sdk-1.31.2.tar.gz", hash = "sha256:47d17aaf3da5183123a64d38d3c02c2350758186c48e334b425d8b0f105b7fd8", size = 317633, upload-time = "2025-09-05T20:51:43.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/33/b1b861de09d3a950501c16977e4113766dd444024ce355d56b4e4a5ca289/cdp_sdk-1.26.0-py3-none-any.whl", hash = "sha256:72d4b51e0b4b455367fb5e42ee5966313ff9cb70575e761501adf711eee680f1", size = 652515, upload-time = "2025-08-01T00:26:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/bb/b5a152845d29f04ce51eff1703b1518f2272ff45e139cae9eacd1cc73584/cdp_sdk-1.31.2-py3-none-any.whl", hash = "sha256:a58a67e4bc1e1edd561a57d09e2d5eed847d378ba328ea6c7802634d00800415", size = 792613, upload-time = "2025-09-05T20:51:41.019Z" },
 ]
 
 [[package]]
@@ -677,7 +677,7 @@ wheels = [
 
 [[package]]
 name = "coinbase-agentkit"
-version = "0.7.1"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cdp-sdk" },
@@ -694,14 +694,14 @@ dependencies = [
     { name = "web3" },
     { name = "x402" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/17/95dd9eaf0090604fd9e419eff11a4347a7692ee34a9d1d6416dc27835fc5/coinbase_agentkit-0.7.1.tar.gz", hash = "sha256:b2a3a482d895a138d292f189f2755e38c55166973a810f728219c62cd8f3d364", size = 109757, upload-time = "2025-08-01T20:43:02.154Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/91/9f3efe6d4737707341a4f054c7e236b485d42ec3105ba97db1e6ed747311/coinbase_agentkit-0.7.2.tar.gz", hash = "sha256:621935644118054772d9b047bed4dbca04cd28f6d67ea0779507d2c480a17b41", size = 114875, upload-time = "2025-09-06T00:13:29.564Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/75/c1eb762d9c9ce53ebf0013592186aef447d61f7da88165770ac1782821fa/coinbase_agentkit-0.7.1-py3-none-any.whl", hash = "sha256:26ee1b49f7495f37127860abe485762549a998c266ab1c41637043a3116e9bb4", size = 170267, upload-time = "2025-08-01T20:43:00.285Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0c/0dc601ace61f967eeced8b33c776d04b2cb08ee029c23a9aed91eaf2d747/coinbase_agentkit-0.7.2-py3-none-any.whl", hash = "sha256:32c097c4a0e87086d88ddb45082b3bf96d40cd20980a7052bffb1cc68f902b97", size = 179654, upload-time = "2025-09-06T00:13:27.834Z" },
 ]
 
 [[package]]
 name = "coinbase-agentkit-strands-agents"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "coinbase-agentkit" },
@@ -731,7 +731,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coinbase-agentkit", specifier = ">=0.7.1,<0.9" },
+    { name = "coinbase-agentkit", specifier = ">=0.7.2,<0.8" },
     { name = "nest-asyncio", specifier = ">=1.5.8,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "strands-agents", specifier = ">=1.0.1" },


### PR DESCRIPTION
chore: version python packages

## create-onchain-agent [0.9.0] - 2025-09-05

### Added

- Bump coinbase-agentkit to 0.7.2 in beginner template and chatbot template
- Bump coinbase-agentkit-langchain to 0.7.0 in beginner template and chatbot template
- Bump coinbase-agentkit-openai-agents-sdk to 0.7.0 in beginner template and chatbot template

## autogen [0.1.0] - 2025-09-05

### Added

- Initial release of CDP Agentkit Extension - Autogen.

## langchain [0.7.0] - 2025-09-05

### Added

- Bump coinbase-agentkit to 0.7.2

## openai-agents-sdk [0.7.0] - 2025-09-05

### Added

- Bump coinbase-agentkit to 0.7.2

## Pydantic AI [0.1.0] - 2025-09-05

###  Added

- Initial release of CDP Agentkit Extension - Langchain Toolkit.

##  strands-agents [0.2.0] - 2025-09-05

### Added

- Bump coinbase-agentkit to 0.7.2