### PR TITLE
fix: regex patterns for dependency version handling in TOML

### DIFF
--- a/python/scripts/utils/dependency_version.py
+++ b/python/scripts/utils/dependency_version.py
@@ -10,7 +10,7 @@ def read_dependency_version(file_path: str, dependency_name: str) -> str:
     with open(file_path, "r") as file:
         content = file.read()
 
-    pattern = rf'^\s+"{dependency_name}>=([0-9]+\.[0-9]+\.[0-9]+),.*$'
+    pattern = rf'^\s*{re.escape(dependency_name)}\s*=\s*">=([0-9]+\.[0-9]+\.[0-9]+),.*"$'
     
     for line in content.split("\n"):
         match = re.match(pattern, line)
@@ -29,8 +29,8 @@ def write_dependency_version(file_path: str, dependency_name: str, version: str)
         contents = file.read()
     
     min_version, max_version = calculate_dependency_range(version)
-    pattern = rf'"{dependency_name}>=([0-9]+\.[0-9]+\.[0-9]+),<[^"]+"'
-    replacement = f'"{dependency_name}{min_version},{max_version}"'
+    pattern = rf'{re.escape(dependency_name)}\s*=\s*">=([0-9]+\.[0-9]+\.[0-9]+),<[^"]+"'
+    replacement = f'{dependency_name} = "{min_version},{max_version}"'
     
     updated_content = re.sub(pattern, replacement, contents, flags=re.MULTILINE)
     
@@ -111,4 +111,4 @@ def write_dependency_version_legacy(file_path: str, dependency_name: str, versio
         raise ValueError(f"Could not update legacy dependency {dependency_name} in {file_path}")
     
     with open(file_path, "w") as file:
-        file.write("\n".join(new_lines)) 
+        file.write("\n".join(new_lines))


### PR DESCRIPTION
## Description

fixed regex patterns in `read_dependency_version` and `write_dependency_version` to properly handle TOML syntax.  
- removed extra quotes around `dependency_name`  
- added `re.escape`  
- accounted for `= "..."` format  
- updated replacement to `dependency_name = "{min_version},{max_version}"`  

now both functions correctly parse and write dependencies in TOML.

## Tests

verified on sample TOML files that dependencies are now read and written correctly.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files  
- [ ] Added a changelog entry