### PR TITLE
Update node.js .env.local instructions to not throw error

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ npm create onchain-agent@latest
 cd onchain-agent
 
 # At this point, fill in your CDP API key id/secret, OpenAI API key, and any other environment variables in the .env.local file.
-# Then, rename the .env.local file to .env
-mv .env.local .env
 
 # Install dependencies
 npm install


### PR DESCRIPTION
## Description

Node.js / typescript instructions throw error as `npm run dev` is looking for environment variables in `.env.local` not `.env`.

## Checklist

A couple of things to include in your PR for completeness:

- [x ] Added documentation to all relevant README.md files