### PR TITLE
fix: bug in retrieving tx logs for smart accounts

### DIFF
--- a/typescript/.changeset/moody-places-burn.md
+++ b/typescript/.changeset/moody-places-burn.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Fixed issue in retrieving tx logs in CdpSmartWalletProvider

--- a/typescript/agentkit/src/wallet-providers/cdpSmartWalletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/cdpSmartWalletProvider.ts
@@ -332,9 +332,6 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async waitForTransactionReceipt(userOpHash: Hex): Promise<any> {
     // For smart wallets, we need to wait for the user operation to be confirmed
-    // This is a simplified implementation - in practice you might want to poll
-    // the CDP API for user operation status
-
     const receipt = await this.#cdp.evm.waitForUserOperation({
       smartAccountAddress: this.smartAccount.address,
       userOpHash,
@@ -342,7 +339,7 @@ export class CdpSmartWalletProvider extends EvmWalletProvider implements WalletP
 
     // Append transaction logs if available
     if (receipt.status === "complete") {
-      const receiptTx = await this.#publicClient.getTransactionReceipt({
+      const receiptTx = await this.#publicClient.waitForTransactionReceipt({
         hash: receipt.transactionHash as Hex,
       });
       if (receiptTx.logs) return { ...receipt, logs: receiptTx.logs };


### PR DESCRIPTION
<!--
Thanks for contributing to AgentKit!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Fixes issue in retrieving tx logs in CdpSmartWalletProvider, where occasionally transactionReceipt is not ready even though userOp was awaited

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [x] Added a changelog entry