### PR TITLE
fix(compound): Track base asset supply via balanceOf in portfolio and withdraw

### DIFF
--- a/typescript/agentkit/src/action-providers/compound/compoundActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/compound/compoundActionProvider.ts
@@ -15,6 +15,7 @@ import {
   CompoundPortfolioSchema,
 } from "./schemas";
 import {
+  getBaseAssetBalance,
   getCollateralBalance,
   getHealthRatio,
   getHealthRatioAfterBorrow,
@@ -165,22 +166,40 @@ Important notes:
       const decimals = await getTokenDecimals(wallet, tokenAddress);
       const amountAtomic = parseUnits(args.amount, decimals);
 
-      // Check that there is enough collateral supplied to withdraw
-      const collateralBalance = await getCollateralBalance(wallet, cometAddress, tokenAddress);
-      if (amountAtomic > collateralBalance) {
-        const humanBalance = formatUnits(collateralBalance, decimals);
-        return `Error: Insufficient balance. Trying to withdraw ${args.amount}, but only have ${humanBalance} supplied`;
-      }
+      // Determine if this is the base asset (e.g. USDC) or a collateral asset
+      const baseTokenAddress = await getBaseTokenAddress(wallet, cometAddress);
+      const isBaseAsset =
+        tokenAddress.toLowerCase() === baseTokenAddress.toLowerCase();
 
-      // Check if position would be healthy after withdrawal
-      const projectedHealthRatio = await getHealthRatioAfterWithdraw(
-        wallet,
-        cometAddress,
-        tokenAddress,
-        amountAtomic,
-      );
-      if (projectedHealthRatio.lessThan(1)) {
-        return `Error: Withdrawing ${args.amount} would result in an unhealthy position. Health ratio would be ${projectedHealthRatio.toFixed(2)}`;
+      if (isBaseAsset) {
+        // Base asset: check Comet.balanceOf() (supply balance, earns APY)
+        const baseBalance = await getBaseAssetBalance(wallet, cometAddress);
+        if (amountAtomic > baseBalance) {
+          const humanBalance = formatUnits(baseBalance, decimals);
+          return `Error: Insufficient balance. Trying to withdraw ${args.amount}, but only have ${humanBalance} supplied`;
+        }
+      } else {
+        // Collateral asset: check collateralBalanceOf
+        const collateralBalance = await getCollateralBalance(
+          wallet,
+          cometAddress,
+          tokenAddress,
+        );
+        if (amountAtomic > collateralBalance) {
+          const humanBalance = formatUnits(collateralBalance, decimals);
+          return `Error: Insufficient balance. Trying to withdraw ${args.amount}, but only have ${humanBalance} supplied`;
+        }
+
+        // Only check health ratio for collateral withdrawals (affects borrow capacity)
+        const projectedHealthRatio = await getHealthRatioAfterWithdraw(
+          wallet,
+          cometAddress,
+          tokenAddress,
+          amountAtomic,
+        );
+        if (projectedHealthRatio.lessThan(1)) {
+          return `Error: Withdrawing ${args.amount} would result in an unhealthy position. Health ratio would be ${projectedHealthRatio.toFixed(2)}`;
+        }
       }
 
       // Withdraw from Compound

--- a/typescript/agentkit/src/action-providers/compound/constants.ts
+++ b/typescript/agentkit/src/action-providers/compound/constants.ts
@@ -115,6 +115,13 @@ export const COMET_ABI = [
     stateMutability: "view",
     type: "function",
   },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
 ] as const;
 
 export const PRICE_FEED_ABI = [

--- a/typescript/agentkit/src/action-providers/compound/utils.ts
+++ b/typescript/agentkit/src/action-providers/compound/utils.ts
@@ -91,6 +91,28 @@ export const getCollateralBalance = async (
 };
 
 /**
+ * Get base asset (e.g. USDC) supply balance via Comet.balanceOf().
+ * This is distinct from collateral — the base asset is what earns supply APY.
+ *
+ * @param wallet - The wallet provider instance
+ * @param cometAddress - The address of the Comet contract
+ * @returns The base asset supply balance as a bigint
+ */
+export const getBaseAssetBalance = async (
+  wallet: EvmWalletProvider,
+  cometAddress: Address,
+): Promise<bigint> => {
+  const balance = await wallet.readContract({
+    address: cometAddress,
+    abi: COMET_ABI,
+    functionName: "balanceOf",
+    args: [(await wallet.getAddress()) as `0x${string}`],
+  });
+
+  return balance;
+};
+
+/**
  * Get health ratio for an account
  *
  * @param wallet - The wallet provider instance
@@ -203,8 +225,37 @@ export const getPortfolioDetailsMarkdown = async (
   cometAddress: Address,
 ): Promise<string> => {
   let markdownOutput = "# Portfolio Details\n\n";
-  markdownOutput += "## Supply Details\n\n";
   let totalSupplyValue = new Decimal(0);
+
+  // Base asset supply (e.g. USDC) — tracked via Comet.balanceOf(), earns APY
+  markdownOutput += "## Base Asset Supply\n\n";
+  const baseAssetBalance = await getBaseAssetBalance(wallet, cometAddress);
+  const baseToken = await getBaseTokenAddress(wallet, cometAddress);
+  const baseDecimals = await getTokenDecimals(wallet, baseToken);
+  const baseSymbol = await getTokenSymbol(wallet, baseToken);
+  const basePriceFeed = await wallet.readContract({
+    address: cometAddress,
+    abi: COMET_ABI,
+    functionName: "baseTokenPriceFeed",
+    args: [],
+  });
+  const [basePriceRaw] = await getPriceFeedData(wallet, basePriceFeed);
+  const basePrice = new Decimal(basePriceRaw).div(new Decimal(10).pow(8));
+  const baseSupplyAmount = new Decimal(formatUnits(baseAssetBalance, baseDecimals));
+
+  if (baseAssetBalance > BigInt(0)) {
+    const baseValue = baseSupplyAmount.mul(basePrice);
+    markdownOutput += `### ${baseSymbol} (Base Asset — earns supply APY)\n`;
+    markdownOutput += `- **Supply Amount:** ${baseSupplyAmount.toFixed(baseDecimals)}\n`;
+    markdownOutput += `- **Price:** $${basePrice.toFixed(2)}\n`;
+    markdownOutput += `- **Asset Value:** $${baseValue.toFixed(2)}\n\n`;
+    totalSupplyValue = totalSupplyValue.add(baseValue);
+  } else {
+    markdownOutput += "No base asset supplied.\n\n";
+  }
+
+  // Collateral assets — tracked via collateralBalanceOf(), used to back borrows
+  markdownOutput += "## Collateral Details\n\n";
   const supplyDetails = await getSupplyDetails(wallet, cometAddress);
 
   if (supplyDetails.length > 0) {
@@ -224,7 +275,7 @@ export const getPortfolioDetailsMarkdown = async (
       totalSupplyValue = totalSupplyValue.add(assetValue);
     }
   } else {
-    markdownOutput += "No supplied assets found in your Compound position.\n\n";
+    markdownOutput += "No collateral assets supplied.\n\n";
   }
 
   markdownOutput += `### Total Supply Value: $${totalSupplyValue.toFixed(2)}\n\n`;
@@ -354,7 +405,7 @@ const getSupplyDetails = async (
     const assetAddress = assetInfo.asset;
     const collateralBalance = await getCollateralBalance(wallet, cometAddress, assetAddress);
 
-    if (collateralBalance > 0n) {
+    if (collateralBalance > BigInt(0)) {
       const tokenSymbol = await getTokenSymbol(wallet, assetAddress);
       const decimals = await getTokenDecimals(wallet, assetAddress);
       const [priceRaw] = await getPriceFeedData(wallet, assetInfo.priceFeed);


### PR DESCRIPTION
## Description

The Compound action provider is missing base asset (e.g. USDC) supply tracking. In Compound v3 (Comet), base asset and collateral assets are tracked differently:

  - Base asset (USDC): `Comet.balanceOf(account)`, which earns supply APY
  - Collateral (WETH, cbETH, etc.): `Comet.collateralBalanceOf(account, asset)`, which backs borrows

When using the `supply` action on USDC, subsequent calls to `get_portfolio` will not detect the supplied amounts and `withdraw` also won't work.

This is because texisting code only uses `collateralBalanceOf`, so:
  - `get_portfolio` returns empty when only base asset is supplied
  - `withdraw` checks `collateralBalanceOf` for balance validation, which returns 0 for the base asset, making base asset withdrawals fail

This PR fixes that with the following changes:
  - `constants.ts`: add balanceOf to COMET_ABI
  - `utils.ts`: add getBaseAssetBalance(), update getPortfolioDetailsMarkdown() to show base asset supply
  - `compoundActionProvider.ts`: fix withdraw() to detect base vs collateral — base uses balanceOf() and skips health ratio check, collateral path unchanged

## Tests

Will do soon, made this PR for my project at the ETHDenver 2026 hackathon, using a custom action provider with these fixes for now and will improve this PR with broader tests later.

<!--
When adding new functionality or fixing a bug, you should be testing your changes with one or more
chatbots in the examples directory.

Please provide samples of the prompts you tested with, the Agent outputs for each prompt,
which chatbot you used, and any other relevant context, like which network was used.

Use the following format if helpful:

```
Chatbot: <name of chatbot used>
Network: <network used>
Setup: <any other relevant context>

Prompt: <prompt>

<agent output>
```

For example:

```
Chatbot: typescript/examples/langchain-smart-wallet-chatbot/chatbot.ts
Network: Base Sepolia
Setup: Fauceted with 1 USDC

Prompt: print USDC balance (token address: 0x036CbD53842c5426634e7929541eC2318f3dCF7e)

-------------------
Balance of 0x036CbD53842c5426634e7929541eC2318f3dCF7e is 1
-------------------
The USDC balance for the token address `0x036CbD53842c5426634e7929541eC2318f3dCF7e` is 1.
-------------------
```
 -->

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [ ] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
