### PR TITLE
Update error message for Agentkit.from without walletProvider

### DIFF
--- a/typescript/agentkit/src/agentkit.ts
+++ b/typescript/agentkit/src/agentkit.ts
@@ -50,7 +50,7 @@ export class AgentKit {
     if (!config.walletProvider) {
       if (!config.cdpApiKeyId || !config.cdpApiKeySecret || !config.cdpWalletSecret) {
         throw new Error(
-          "cdpApiKeyId and cdpApiKeySecret are required if not providing a walletProvider",
+          "cdpApiKeyId, cdpApiKeySecret and cdpWalletSecret are required if not providing a walletProvider",
         );
       }
 


### PR DESCRIPTION
## Description

Updates Agentkit.from constructor error message when `walletProvider` is not passed to account for ALL needed config variables. 

## Tests

No tests added.