### PR TITLE
Fix grammatical error in documentation

### DIFF
--- a/CONTRIBUTING-TYPESCRIPT.md
+++ b/CONTRIBUTING-TYPESCRIPT.md
@@ -177,7 +177,7 @@ Do not use the contract address as the destination address. If you are unsure of
 
 Notice the return value contains useful information for the user, such as the transaction hash and link. It's important to include this information in the return value so that the user can easily see the result of the action.
 
-This class is then exported out of [typescript/agentkit/src/action-providers/erc721/index.ts](https://github.com/coinbase/agentkit/blob/master/typescript/agentkit/src/action-providers/erc721/index.ts) so that is consumable by users of the `@coinbase/agentkit` package.
+This class is then exported out of [typescript/agentkit/src/action-providers/erc721/index.ts](https://github.com/coinbase/agentkit/blob/master/typescript/agentkit/src/action-providers/erc721/index.ts) so that it is consumable by users of the `@coinbase/agentkit` package.
 
 ### Testing the action provider
 


### PR DESCRIPTION
## Description

The phrase “so that is consumable by users” contained a grammatical error due to the missing subject “it”. It was corrected to “so that it is consumable by users” to ensure the sentence is grammatically correct and clearer for readers.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [ ] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
