### PR TITLE
Add PayCrow action provider for trust-informed escrow payments

### DIFF
--- a/typescript/.changeset/paycrow-action-provider.md
+++ b/typescript/.changeset/paycrow-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Add PayCrow action provider for trust-informed escrow payments

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -21,6 +21,7 @@ export * from "./pyth";
 export * from "./moonwell";
 export * from "./morpho";
 export * from "./opensea";
+export * from "./paycrow";
 export * from "./spl";
 export * from "./superfluid";
 export * from "./sushi";

--- a/typescript/agentkit/src/action-providers/paycrow/README.md
+++ b/typescript/agentkit/src/action-providers/paycrow/README.md
@@ -1,0 +1,42 @@
+# PayCrow Action Provider
+
+The PayCrow action provider integrates [PayCrow](https://github.com/michu5696/paycrow) trust-informed escrow payments into AgentKit. PayCrow is a trust layer for agent-to-agent payments that protects buyers by checking seller reputation before paying and holding funds in escrow until services are delivered.
+
+## Actions
+
+### trust_gate
+
+Check an agent or seller's trust score before making a payment. Returns a decision (`proceed`, `caution`, or `block`), a recommended timelock duration, and a maximum recommended payment amount.
+
+### safe_pay
+
+Make a trust-informed escrow payment. Combines trust checking and escrow creation into a single action. The escrow protects the buyer by holding funds until the service is delivered.
+
+### escrow_create
+
+Create a USDC escrow with a configurable timelock. Funds are held until service delivery is confirmed or the timelock expires.
+
+### rate_service
+
+Rate a completed escrow (1-5 stars). Ratings contribute to the seller's on-chain trust score, which affects future `trust_gate` decisions.
+
+## Usage
+
+```typescript
+import { AgentKit } from "@coinbase/agentkit";
+import { paycrowActionProvider } from "@coinbase/agentkit";
+
+const agent = new AgentKit({
+  actionProviders: [paycrowActionProvider()],
+});
+```
+
+## Network Support
+
+PayCrow's trust API is network-agnostic and works across all networks.
+
+## Links
+
+- [PayCrow GitHub](https://github.com/michu5696/paycrow)
+- [PayCrow npm](https://www.npmjs.com/package/paycrow)
+- [Trust API](https://paycrow-app.fly.dev)

--- a/typescript/agentkit/src/action-providers/paycrow/index.ts
+++ b/typescript/agentkit/src/action-providers/paycrow/index.ts
@@ -1,0 +1,2 @@
+export * from "./paycrowActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/paycrow/paycrowActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/paycrow/paycrowActionProvider.test.ts
@@ -1,0 +1,228 @@
+import { PayCrowActionProvider } from "./paycrowActionProvider";
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe("PayCrowActionProvider", () => {
+  let provider: PayCrowActionProvider;
+
+  beforeEach(() => {
+    provider = new PayCrowActionProvider();
+    mockFetch.mockReset();
+  });
+
+  describe("constructor", () => {
+    it("should have the correct name", () => {
+      expect(provider.name).toBe("paycrow");
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should return true for any network", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(provider.supportsNetwork({} as any)).toBe(true);
+    });
+  });
+
+  describe("trustGate", () => {
+    it("should return trust score data on success", async () => {
+      const mockResponse = {
+        decision: "proceed",
+        recommended_timelock: 30,
+        max_amount: 100,
+        score: 0.85,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await provider.trustGate({ address: "0x1234" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.address).toBe("0x1234");
+      expect(parsed.decision).toBe("proceed");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/trust?address=0x1234"),
+      );
+    });
+
+    it("should include intendedAmount in query params when provided", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ decision: "caution" }),
+      });
+
+      await provider.trustGate({ address: "0x1234", intendedAmount: 50 });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("amount=50"),
+      );
+    });
+
+    it("should handle API errors gracefully", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      const result = await provider.trustGate({ address: "0x1234" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("HTTP 500");
+    });
+
+    it("should handle network errors gracefully", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await provider.trustGate({ address: "0x1234" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Network error");
+    });
+  });
+
+  describe("safePay", () => {
+    it("should execute a safe payment on success", async () => {
+      const mockResponse = {
+        status: "released",
+        escrowId: "esc_123",
+        txHash: "0xabc",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await provider.safePay({
+        url: "https://api.example.com/service",
+        sellerAddress: "0x5678",
+        amountUsdc: 10,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.status).toBe("released");
+      expect(parsed.escrowId).toBe("esc_123");
+    });
+
+    it("should handle API errors gracefully", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => "Invalid seller address",
+      });
+
+      const result = await provider.safePay({
+        url: "https://api.example.com/service",
+        sellerAddress: "invalid",
+        amountUsdc: 10,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Invalid seller address");
+    });
+  });
+
+  describe("escrowCreate", () => {
+    it("should create an escrow on success", async () => {
+      const mockResponse = {
+        escrowId: "esc_456",
+        txHash: "0xdef",
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await provider.escrowCreate({
+        seller: "0x5678",
+        amountUsdc: 25,
+        timelockMinutes: 120,
+        serviceUrl: "https://api.example.com/data",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.escrowId).toBe("esc_456");
+      expect(parsed.txHash).toBe("0xdef");
+
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(fetchBody.seller).toBe("0x5678");
+      expect(fetchBody.amount_usdc).toBe(25);
+      expect(fetchBody.timelock_minutes).toBe(120);
+      expect(fetchBody.service_url).toBe("https://api.example.com/data");
+    });
+
+    it("should handle API errors gracefully", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Internal server error",
+      });
+
+      const result = await provider.escrowCreate({
+        seller: "0x5678",
+        amountUsdc: 25,
+        timelockMinutes: 60,
+        serviceUrl: "https://api.example.com/data",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("HTTP 500");
+    });
+  });
+
+  describe("rateService", () => {
+    it("should submit a rating on success", async () => {
+      const mockResponse = {
+        rated: true,
+        newScore: 0.9,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await provider.rateService({
+        escrowId: "esc_123",
+        stars: 5,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.rated).toBe(true);
+
+      const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(fetchBody.escrow_id).toBe("esc_123");
+      expect(fetchBody.stars).toBe(5);
+    });
+
+    it("should handle API errors gracefully", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "Escrow not found",
+      });
+
+      const result = await provider.rateService({
+        escrowId: "esc_invalid",
+        stars: 3,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Escrow not found");
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/paycrow/paycrowActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/paycrow/paycrowActionProvider.ts
@@ -1,0 +1,273 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import {
+  TrustGateSchema,
+  SafePaySchema,
+  EscrowCreateSchema,
+  RateServiceSchema,
+} from "./schemas";
+
+const PAYCROW_API_BASE = "https://paycrow-app.fly.dev";
+
+/**
+ * PayCrowActionProvider provides actions for trust-informed escrow payments via PayCrow.
+ *
+ * PayCrow is a trust layer for agent-to-agent payments. It allows agents to check
+ * trust scores before paying, create USDC escrows with timelocks, and rate completed
+ * services to build on-chain reputation.
+ *
+ * API: https://paycrow-app.fly.dev
+ * npm: paycrow
+ * GitHub: https://github.com/michu5696/paycrow
+ */
+export class PayCrowActionProvider extends ActionProvider {
+  /**
+   * Constructs a new PayCrowActionProvider.
+   */
+  constructor() {
+    super("paycrow", []);
+  }
+
+  /**
+   * Check an agent's trust score before paying.
+   *
+   * @param args - The arguments for the action.
+   * @returns The trust gate decision as stringified JSON.
+   */
+  @CreateAction({
+    name: "trust_gate",
+    description: `Check an agent or seller's trust score before making a payment using PayCrow.
+
+This tool queries the PayCrow trust API to evaluate whether it is safe to pay a given address.
+It returns a decision (proceed, caution, or block), a recommended timelock duration, and a
+maximum recommended payment amount based on the address's on-chain reputation.
+
+Inputs:
+- address: The wallet address to check (e.g. "0x1234...")
+- intendedAmount (optional): The amount in USDC you intend to pay, used for threshold evaluation
+
+Use this action BEFORE making any payment to an unfamiliar agent or seller.
+If the decision is "block", do NOT proceed with payment.
+If the decision is "caution", warn the user and suggest a shorter timelock or smaller amount.
+`,
+    schema: TrustGateSchema,
+  })
+  async trustGate(args: z.infer<typeof TrustGateSchema>): Promise<string> {
+    try {
+      const params = new URLSearchParams({ address: args.address });
+      if (args.intendedAmount !== undefined) {
+        params.set("amount", args.intendedAmount.toString());
+      }
+
+      const response = await fetch(`${PAYCROW_API_BASE}/api/trust?${params.toString()}`);
+
+      if (!response.ok) {
+        return JSON.stringify({
+          success: false,
+          error: `Trust API returned HTTP ${response.status}`,
+        });
+      }
+
+      const data = await response.json();
+
+      return JSON.stringify({
+        success: true,
+        address: args.address,
+        ...data,
+      });
+    } catch (error) {
+      return JSON.stringify({
+        success: false,
+        error: `Failed to check trust score: ${error}`,
+      });
+    }
+  }
+
+  /**
+   * Make a trust-informed escrow payment via PayCrow.
+   *
+   * @param args - The arguments for the action.
+   * @returns The escrow result as stringified JSON.
+   */
+  @CreateAction({
+    name: "safe_pay",
+    description: `Make a trust-informed escrow payment via PayCrow.
+
+This tool combines trust checking and escrow creation into a single action. It first checks
+the seller's trust score, then creates an escrow with an appropriate timelock based on the
+trust level. The escrow protects the buyer by holding funds until the service is delivered.
+
+Inputs:
+- url: The service URL being paid for (e.g. "https://api.example.com/service")
+- sellerAddress: The wallet address of the seller (e.g. "0x1234...")
+- amountUsdc: The amount in USDC to pay (e.g. 5.0)
+
+The result includes the escrow status (released or disputed) and transaction details.
+If the seller's trust score is too low, the payment will be blocked automatically.
+`,
+    schema: SafePaySchema,
+  })
+  async safePay(args: z.infer<typeof SafePaySchema>): Promise<string> {
+    try {
+      const response = await fetch(`${PAYCROW_API_BASE}/api/safe-pay`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url: args.url,
+          seller: args.sellerAddress,
+          amount_usdc: args.amountUsdc,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return JSON.stringify({
+          success: false,
+          error: `Safe pay API returned HTTP ${response.status}: ${errorText}`,
+        });
+      }
+
+      const data = await response.json();
+
+      return JSON.stringify({
+        success: true,
+        ...data,
+      });
+    } catch (error) {
+      return JSON.stringify({
+        success: false,
+        error: `Failed to execute safe pay: ${error}`,
+      });
+    }
+  }
+
+  /**
+   * Create a USDC escrow via PayCrow.
+   *
+   * @param args - The arguments for the action.
+   * @returns The escrow creation result as stringified JSON.
+   */
+  @CreateAction({
+    name: "escrow_create",
+    description: `Create a USDC escrow via PayCrow.
+
+This tool creates a new escrow that holds USDC funds until the service is delivered or the
+timelock expires. The escrow protects both buyer and seller in agent-to-agent transactions.
+
+Inputs:
+- seller: The wallet address of the seller (e.g. "0x1234...")
+- amountUsdc: The amount in USDC to escrow (e.g. 10.0)
+- timelockMinutes: How long to lock funds before auto-release (default: 60 minutes)
+- serviceUrl: The URL of the service being purchased (e.g. "https://api.example.com/data")
+
+Returns an escrowId and txHash that can be used to track or rate the escrow later.
+Use the trust_gate action first to determine an appropriate timelock duration.
+`,
+    schema: EscrowCreateSchema,
+  })
+  async escrowCreate(args: z.infer<typeof EscrowCreateSchema>): Promise<string> {
+    try {
+      const response = await fetch(`${PAYCROW_API_BASE}/api/escrow`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          seller: args.seller,
+          amount_usdc: args.amountUsdc,
+          timelock_minutes: args.timelockMinutes,
+          service_url: args.serviceUrl,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return JSON.stringify({
+          success: false,
+          error: `Escrow API returned HTTP ${response.status}: ${errorText}`,
+        });
+      }
+
+      const data = await response.json();
+
+      return JSON.stringify({
+        success: true,
+        ...data,
+      });
+    } catch (error) {
+      return JSON.stringify({
+        success: false,
+        error: `Failed to create escrow: ${error}`,
+      });
+    }
+  }
+
+  /**
+   * Rate a completed escrow service via PayCrow.
+   *
+   * @param args - The arguments for the action.
+   * @returns The rating confirmation as stringified JSON.
+   */
+  @CreateAction({
+    name: "rate_service",
+    description: `Rate a completed escrow service via PayCrow.
+
+This tool submits a rating (1-5 stars) for a completed escrow. Ratings contribute to the
+seller's on-chain trust score, which affects future trust_gate decisions for that seller.
+
+Inputs:
+- escrowId: The ID of the completed escrow to rate (returned by escrow_create or safe_pay)
+- stars: A rating from 1 (poor) to 5 (excellent)
+
+Always rate completed escrows to help build the trust network. Higher ratings improve
+the seller's trust score, leading to higher recommended payment limits and shorter timelocks.
+`,
+    schema: RateServiceSchema,
+  })
+  async rateService(args: z.infer<typeof RateServiceSchema>): Promise<string> {
+    try {
+      const response = await fetch(`${PAYCROW_API_BASE}/api/rate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          escrow_id: args.escrowId,
+          stars: args.stars,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return JSON.stringify({
+          success: false,
+          error: `Rating API returned HTTP ${response.status}: ${errorText}`,
+        });
+      }
+
+      const data = await response.json();
+
+      return JSON.stringify({
+        success: true,
+        ...data,
+      });
+    } catch (error) {
+      return JSON.stringify({
+        success: false,
+        error: `Failed to rate service: ${error}`,
+      });
+    }
+  }
+
+  /**
+   * Checks if the PayCrow action provider supports the given network.
+   * PayCrow is network-agnostic (trust API works across all networks).
+   *
+   * @returns True, as PayCrow supports all networks.
+   */
+  supportsNetwork = () => true;
+}
+
+/**
+ * Factory function to create a new PayCrowActionProvider instance.
+ *
+ * @returns A new PayCrowActionProvider instance.
+ */
+export const paycrowActionProvider = () => new PayCrowActionProvider();

--- a/typescript/agentkit/src/action-providers/paycrow/schemas.ts
+++ b/typescript/agentkit/src/action-providers/paycrow/schemas.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+/**
+ * Input schema for PayCrow trust_gate action.
+ */
+export const TrustGateSchema = z
+  .object({
+    address: z
+      .string()
+      .describe("The wallet address of the agent or seller to check trust for"),
+    intendedAmount: z
+      .number()
+      .optional()
+      .describe("Optional intended payment amount in USDC to evaluate against trust thresholds"),
+  })
+  .strip()
+  .describe("Parameters for checking an agent's trust score before paying");
+
+/**
+ * Input schema for PayCrow safe_pay action.
+ */
+export const SafePaySchema = z
+  .object({
+    url: z.string().url().describe("The service URL to pay for"),
+    sellerAddress: z
+      .string()
+      .describe("The wallet address of the seller to receive payment"),
+    amountUsdc: z
+      .number()
+      .positive()
+      .describe("The amount in USDC to pay"),
+  })
+  .strip()
+  .describe("Parameters for making a trust-informed escrow payment");
+
+/**
+ * Input schema for PayCrow escrow_create action.
+ */
+export const EscrowCreateSchema = z
+  .object({
+    seller: z.string().describe("The wallet address of the seller"),
+    amountUsdc: z
+      .number()
+      .positive()
+      .describe("The amount in USDC to escrow"),
+    timelockMinutes: z
+      .number()
+      .positive()
+      .default(60)
+      .describe("Time lock duration in minutes before the escrow can be released (default: 60)"),
+    serviceUrl: z
+      .string()
+      .url()
+      .describe("The URL of the service being paid for"),
+  })
+  .strip()
+  .describe("Parameters for creating a USDC escrow");
+
+/**
+ * Input schema for PayCrow rate_service action.
+ */
+export const RateServiceSchema = z
+  .object({
+    escrowId: z.string().describe("The ID of the completed escrow to rate"),
+    stars: z
+      .number()
+      .int()
+      .min(1)
+      .max(5)
+      .describe("Rating from 1 to 5 stars"),
+  })
+  .strip()
+  .describe("Parameters for rating a completed escrow service");


### PR DESCRIPTION
## Summary
- Adds a new `paycrow` action provider that integrates [PayCrow](https://github.com/michu5696/paycrow) trust-informed escrow payments into AgentKit
- Exposes 4 actions: `trust_gate` (check seller reputation), `safe_pay` (trust-informed payment), `escrow_create` (USDC escrow with timelock), and `rate_service` (1-5 star ratings)
- Calls the PayCrow trust API at `https://paycrow-app.fly.dev` — no wallet provider dependency, network-agnostic
- Includes unit tests and changeset

## Motivation
Agent-to-agent payments need a trust layer. PayCrow provides on-chain reputation scoring and escrow protection so agents can safely pay unfamiliar sellers. This complements the existing `x402` provider by adding reputation-gated escrow on top of HTTP 402 payments.

## How it works
1. **trust_gate** — Queries PayCrow API for a seller address, returns a decision (proceed/caution/block), recommended timelock, and max amount
2. **safe_pay** — Combines trust check + escrow creation in one call
3. **escrow_create** — Creates a USDC escrow with configurable timelock
4. **rate_service** — Submits a 1-5 star rating that feeds back into the trust score

## Test plan
- [x] Unit tests covering all 4 actions with success and error cases
- [ ] Manual test with a live agent calling the PayCrow trust API

## Links
- [PayCrow GitHub](https://github.com/michu5696/paycrow)
- [PayCrow npm (v1.2.0)](https://www.npmjs.com/package/paycrow)
- [Trust API](https://paycrow-app.fly.dev)

Generated with [Claude Code](https://claude.com/claude-code)