### PR TITLE
fix: add resolveJsonSchemaRefs utility for recursive Zod schemas

### DIFF
--- a/typescript/agentkit/src/index.ts
+++ b/typescript/agentkit/src/index.ts
@@ -2,3 +2,4 @@ export * from "./agentkit";
 export * from "./wallet-providers";
 export * from "./action-providers";
 export * from "./network";
+export { resolveJsonSchemaRefs } from "./resolveJsonSchemaRefs";

--- a/typescript/agentkit/src/resolveJsonSchemaRefs.test.ts
+++ b/typescript/agentkit/src/resolveJsonSchemaRefs.test.ts
@@ -1,0 +1,128 @@
+import { resolveJsonSchemaRefs } from "./resolveJsonSchemaRefs";
+
+describe("resolveJsonSchemaRefs", () => {
+  it("returns schema unchanged when no $ref present", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    };
+    expect(resolveJsonSchemaRefs(schema)).toEqual(schema);
+  });
+
+  it("inlines a simple $ref", () => {
+    const schema = {
+      $ref: "#/$defs/Address",
+      $defs: {
+        Address: {
+          type: "object",
+          properties: {
+            street: { type: "string" },
+          },
+        },
+      },
+    };
+    const result = resolveJsonSchemaRefs(schema);
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        street: { type: "string" },
+      },
+    });
+  });
+
+  it("inlines recursive $ref up to maxDepth", () => {
+    // Simulates zodToJsonSchema output for a recursive type like:
+    // z.object({ value: z.string(), children: z.lazy(() => schema).array() })
+    const schema = {
+      $ref: "#/$defs/TreeNode",
+      $defs: {
+        TreeNode: {
+          type: "object",
+          properties: {
+            value: { type: "string" },
+            children: {
+              type: "array",
+              items: { $ref: "#/$defs/TreeNode" },
+            },
+          },
+        },
+      },
+    };
+
+    const result = resolveJsonSchemaRefs(schema, 2);
+
+    // Depth 0: TreeNode inlined
+    expect(result.type).toBe("object");
+    expect(result.properties.value).toEqual({ type: "string" });
+
+    // Depth 1: children[].items -> TreeNode inlined again
+    expect(result.properties.children.type).toBe("array");
+    expect(result.properties.children.items.type).toBe("object");
+    expect(result.properties.children.items.properties.value).toEqual({ type: "string" });
+
+    // Depth 2: hit maxDepth, replaced with empty schema
+    expect(result.properties.children.items.properties.children.type).toBe("array");
+    expect(result.properties.children.items.properties.children.items).toEqual({});
+  });
+
+  it("handles definitions key (not just $defs)", () => {
+    const schema = {
+      $ref: "#/definitions/Item",
+      definitions: {
+        Item: {
+          type: "object",
+          properties: { id: { type: "number" } },
+        },
+      },
+    };
+    const result = resolveJsonSchemaRefs(schema);
+    expect(result).toEqual({
+      type: "object",
+      properties: { id: { type: "number" } },
+    });
+  });
+
+  it("strips $defs from output", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        child: { $ref: "#/$defs/Child" },
+      },
+      $defs: {
+        Child: { type: "object", properties: { name: { type: "string" } } },
+      },
+    };
+    const result = resolveJsonSchemaRefs(schema);
+    expect(result.$defs).toBeUndefined();
+    expect(result.definitions).toBeUndefined();
+    expect(result.properties.child).toEqual({
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+  });
+
+  it("handles null and primitive values", () => {
+    expect(resolveJsonSchemaRefs({ type: "string" })).toEqual({ type: "string" });
+  });
+
+  it("handles union types with $ref", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [{ type: "string" }, { $ref: "#/$defs/Nested" }],
+        },
+      },
+      $defs: {
+        Nested: { type: "object", properties: { x: { type: "number" } } },
+      },
+    };
+    const result = resolveJsonSchemaRefs(schema);
+    expect(result.properties.value.anyOf).toEqual([
+      { type: "string" },
+      { type: "object", properties: { x: { type: "number" } } },
+    ]);
+  });
+});

--- a/typescript/agentkit/src/resolveJsonSchemaRefs.ts
+++ b/typescript/agentkit/src/resolveJsonSchemaRefs.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Resolves $ref references in a JSON Schema by inlining definitions.
+ *
+ * LLM function-calling APIs (OpenAI, Anthropic) reject schemas that contain
+ * $ref pointers. zodToJsonSchema() produces $ref for recursive Zod types
+ * (z.lazy). This utility inlines those references up to a configurable depth,
+ * replacing deeper levels with a permissive empty schema.
+ *
+ * @param schema - A JSON Schema object, typically from zodToJsonSchema()
+ * @param maxDepth - Maximum recursion depth for inlining (default: 3)
+ * @returns A new JSON Schema with all $ref pointers resolved
+ */
+export function resolveJsonSchemaRefs(
+  schema: Record<string, any>,
+  maxDepth = 3,
+): Record<string, any> {
+  const definitions = schema.$defs || schema.definitions || {};
+
+  /**
+   * Recursively resolves $ref pointers in a JSON Schema node.
+   *
+   * @param node - The current schema node
+   * @param refDepth - How many $ref expansions have occurred on the current path
+   * @returns The resolved schema node
+   */
+  function resolve(node: any, refDepth: number): any {
+    if (node == null || typeof node !== "object") {
+      return node;
+    }
+
+    if (Array.isArray(node)) {
+      return node.map(item => resolve(item, refDepth));
+    }
+
+    // Handle $ref
+    if (typeof node.$ref === "string") {
+      const refPath = node.$ref;
+      // Extract definition name from "#/$defs/Name" or "#/definitions/Name"
+      const match = refPath.match(/^#\/(?:\$defs|definitions)\/(.+)$/);
+      if (!match) {
+        return node;
+      }
+
+      const defName = match[1];
+
+      // Stop inlining at max depth
+      if (refDepth >= maxDepth) {
+        return {};
+      }
+
+      const def = definitions[defName];
+      if (!def) {
+        return node;
+      }
+
+      return resolve(def, refDepth + 1);
+    }
+
+    // Recurse into object properties
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(node)) {
+      if (key === "$defs" || key === "definitions") {
+        continue;
+      }
+      result[key] = resolve(value, refDepth);
+    }
+    return result;
+  }
+
+  return resolve(schema, 0);
+}


### PR DESCRIPTION
## Description

Adds a `resolveJsonSchemaRefs()` utility that inlines `$ref` pointers in JSON Schema output, fixing the `BadRequestError: 400 Invalid schema` when using recursive Zod schemas with OpenAI's function-calling API.

Closes #815

### Problem

`zodToJsonSchema()` produces `$ref` pointers for recursive Zod types (`z.lazy`). OpenAI's function-calling API rejects schemas containing `$ref` with "object schema missing properties" (`actionProvider.ts:9` stores the raw `z.ZodSchema`, and framework extensions like LangChain pass it through `zodToJsonSchema()` to build tool definitions).

### Solution

`resolveJsonSchemaRefs(schema, maxDepth?)` post-processes JSON Schema from `zodToJsonSchema()`:
- Inlines all `$ref` references by substituting the definition body
- Stops at `maxDepth` (default: 3) to handle recursive types
- At max depth, replaces with `{}` (permissive empty schema)
- Strips `$defs`/`definitions` from output

Usage:
```typescript
import { resolveJsonSchemaRefs } from "@coinbase/agentkit";
import { zodToJsonSchema } from "zod-to-json-schema";

const jsonSchema = zodToJsonSchema(myRecursiveZodSchema);
const flatSchema = resolveJsonSchemaRefs(jsonSchema);
// flatSchema has no $ref - safe for OpenAI function calling
```

## Tests

7 unit tests covering: simple refs, recursive refs with depth limiting, `definitions` key (not just `$defs`), stripping definitions from output, union types with refs, and passthrough for schemas without refs.

```
PASS src/resolveJsonSchemaRefs.test.ts
  resolveJsonSchemaRefs
    ✓ returns schema unchanged when no $ref present
    ✓ inlines a simple $ref
    ✓ inlines recursive $ref up to maxDepth
    ✓ handles definitions key (not just $defs)
    ✓ strips $defs from output
    ✓ handles null and primitive values
    ✓ handles union types with $ref
```

Lint and format checks pass.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [ ] I added a changelog fragment for user-facing changes

This contribution was developed with AI assistance (Claude Code).