### PR TITLE
fix: add serverExternalPackages to Next.js template for bundler compatibility

### DIFF
--- a/typescript/create-onchain-agent/templates/next/next.config.js
+++ b/typescript/create-onchain-agent/templates/next/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  serverExternalPackages: ["@noble/hashes", "@noble/curves", "@scure/bip39", "@scure/bip32"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Description

Adds `serverExternalPackages` to the `create-onchain-agent` Next.js template to fix build failures with Next.js 16 (Turbopack and Webpack).

Closes #929

### Problem

Next.js 16's Turbopack aggressively bundles server-side dependencies including `@noble/hashes`. The ESM exports get incorrectly tree-shaken during bundling, causing a runtime `TypeError: Y is not a function` when `keccak256` is called via `viem` (a transitive dependency of AgentKit).

The error appears at build time during page data collection:
```
TypeError: Y is not a function
    at @noble/hashes/esm/sha3.js
    at viem/_esm/utils/hash/keccak256.js
```

This affects both Turbopack and Webpack bundlers in Next.js 16.

### Solution

Adding `@noble/hashes`, `@noble/curves`, `@scure/bip39`, and `@scure/bip32` to `serverExternalPackages` in `next.config.js` tells Next.js to skip bundling these packages and use Node.js `require()` instead. This avoids the ESM/CJS interop issue that breaks the crypto libraries.

The fix is applied to `typescript/create-onchain-agent/templates/next/next.config.js` so all new projects created with `npm create onchain-agent@latest` get the correct config.

Users with existing projects should add the same config:
```js
const nextConfig = {
  serverExternalPackages: ["@noble/hashes", "@noble/curves", "@scure/bip39", "@scure/bip32"],
};
```

## Tests

This is a configuration change in the project template. The fix was verified by reproducing the issue described in #929 and confirming the build succeeds with `serverExternalPackages` set.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [ ] I added a changelog fragment for user-facing changes

This contribution was developed with AI assistance (Claude Code).