### PR TITLE
Fix: private key logging

### DIFF
--- a/typescript/examples/model-context-protocol-smart-wallet-server/index.ts
+++ b/typescript/examples/model-context-protocol-smart-wallet-server/index.ts
@@ -72,7 +72,7 @@ async function initializeServer() {
 
     if (!process.env.PRIVATE_KEY || !process.env.SMART_WALLET_ADDRESS) {
       console.log("Save your private key and smart wallet address to the environment variables");
-      console.log("PRIVATE_KEY=" + privateKey);
+      console.log("PRIVATE_KEY=" + privateKey.slice(0, 6) + "...");
       console.log("SMART_WALLET_ADDRESS=" + walletProvider.getAddress());
     }
 


### PR DESCRIPTION
## Description

In the example, the full private key was being logged to the console. For security reasons, changed the logging to show only the first 6 characters followed by "...", preventing the complete private key from being exposed in logs.

## Tests

No tests required - the change only affects log output and does not impact functionality. The private key remains a valid hex string, and .slice() works as expected with the Hex type.

## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [ ] Added a changelog entry

<!--
For instructions on adding documentation:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#documentation
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#documentation
-->

<!--
For instructions on adding changelog entries:
See here for TypeScript: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-TYPESCRIPT.md#changelog
and here for Python: https://github.com/coinbase/agentkit/blob/main/CONTRIBUTING-PYTHON.md#changelog
-->
