### PR TITLE
feat: add ThoughtProof reasoning verification action provider

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/thoughtproof/__init__.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/thoughtproof/__init__.py
@@ -1,0 +1,1 @@
+"""ThoughtProof action provider for epistemic verification."""

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/thoughtproof/schemas.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/thoughtproof/schemas.py
@@ -1,0 +1,36 @@
+"""Schemas for ThoughtProof action provider."""
+
+from typing import Dict, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class VerifyReasoningSchema(BaseModel):
+    """Input schema for verifying reasoning via adversarial consensus."""
+
+    claim: str = Field(..., description="The reasoning claim or statement to verify")
+    context: Optional[str] = Field(
+        None, description="Additional context for the verification"
+    )
+    domain: Optional[Literal["financial", "medical", "legal", "code", "general"]] = Field(
+        None, description="The domain context for verification (defaults to general)"
+    )
+    speed: Optional[Literal["fast", "standard", "deep"]] = Field(
+        None, description="The verification speed/depth (defaults to standard)"
+    )
+
+
+class GetVerificationReceiptSchema(BaseModel):
+    """Input schema for getting a cryptographically signed verification receipt."""
+
+    agent_id: str = Field(..., description="The ID of the agent requesting verification")
+    claim: str = Field(..., description="The reasoning claim that was verified")
+    verdict: Literal["ALLOW", "BLOCK", "UNCERTAIN"] = Field(
+        ..., description="The verification verdict"
+    )
+    domain: Optional[str] = Field(
+        None, description="The domain context for the verification"
+    )
+    metadata: Optional[Dict[str, str]] = Field(
+        None, description="Additional metadata for the verification receipt"
+    )

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/thoughtproof/thoughtproof_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/thoughtproof/thoughtproof_action_provider.py
@@ -1,0 +1,229 @@
+"""ThoughtProof action provider."""
+
+import json
+import os
+from typing import Any
+
+import requests
+
+from ...network import Network
+from ...wallet_providers import WalletProvider
+from ..action_decorator import create_action
+from ..action_provider import ActionProvider
+from .schemas import GetVerificationReceiptSchema, VerifyReasoningSchema
+
+
+class ThoughtProofActionProvider(ActionProvider[WalletProvider]):
+    """Provides actions for epistemic verification via ThoughtProof.
+
+    ThoughtProof verifies AI agent reasoning using multi-model adversarial consensus
+    (4 independent LLMs cross-verify claims). Returns signed verification receipts
+    that serve as cryptographic proof of reasoning quality.
+
+    API docs: https://api.thoughtproof.ai/openapi.json
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+    ):
+        super().__init__("thoughtproof", [])
+
+        self.api_key = api_key or os.getenv("THOUGHTPROOF_API_KEY")
+        self.base_url = "https://api.thoughtproof.ai/v1"
+
+        if not self.api_key:
+            raise ValueError(
+                "THOUGHTPROOF_API_KEY is not configured. "
+                "Set it as an environment variable or pass api_key to the constructor. "
+                "Get a key at https://thoughtproof.ai"
+            )
+
+    def _get_headers(self) -> dict[str, str]:
+        """Get request headers with API key authentication."""
+        return {
+            "Content-Type": "application/json",
+            "X-API-Key": self.api_key,
+        }
+
+    @create_action(
+        name="verify_reasoning",
+        description="""Verify a reasoning claim via multi-model adversarial consensus.
+
+    Runs 4 independent LLMs to cross-verify whether a reasoning claim is sound.
+    Returns a verdict (ALLOW/BLOCK/UNCERTAIN), confidence score, and any objections.
+
+    Inputs:
+    - claim: The reasoning claim to verify (e.g. "This swap is safe because liquidity is sufficient")
+    - context: Additional context for verification (optional)
+    - domain: Domain hint — financial, medical, legal, code, or general (optional, defaults to general)
+    - speed: Verification depth — fast ($0.008), standard ($0.02), or deep ($0.08) (optional, defaults to standard)
+
+    Examples:
+    - Verify a DeFi decision: claim="Swapping 1 ETH for USDC on Uniswap v3 is safe at current slippage"
+    - Verify a code review: claim="This smart contract has no reentrancy vulnerabilities", domain="code"
+    - Quick check: claim="Market conditions support this trade", speed="fast"
+    """,
+        schema=VerifyReasoningSchema,
+    )
+    def verify_reasoning(self, args: dict[str, Any]) -> str:
+        """Verify reasoning via adversarial consensus.
+
+        Args:
+            args (dict[str, Any]): Arguments containing claim and optional context/domain/speed.
+
+        Returns:
+            str: A JSON string containing the verification results or error details.
+
+        """
+        validated_args = VerifyReasoningSchema(**args)
+
+        request_body: dict[str, Any] = {"claim": validated_args.claim}
+        if validated_args.context:
+            request_body["context"] = validated_args.context
+        if validated_args.domain:
+            request_body["domain"] = validated_args.domain
+        if validated_args.speed:
+            request_body["speed"] = validated_args.speed
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/check",
+                json=request_body,
+                headers=self._get_headers(),
+                timeout=60,
+            )
+
+            if not response.ok:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"API error: {response.status_code} {response.text}",
+                    }
+                )
+
+            result = response.json()
+            return json.dumps(
+                {
+                    "success": True,
+                    "verdict": result.get("verdict"),
+                    "confidence": result.get("confidence"),
+                    "objections": result.get("objections", []),
+                    "modelCount": result.get("modelCount"),
+                    "durationMs": result.get("durationMs"),
+                }
+            )
+
+        except requests.exceptions.RequestException as e:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Request failed: {e}",
+                }
+            )
+
+    @create_action(
+        name="get_verification_receipt",
+        description="""Issue a cryptographically signed verification receipt.
+
+    Creates an EdDSA-signed receipt for a verification verdict. The receipt includes
+    a JWT that can be independently verified via the issuer's JWKS endpoint.
+    Useful for audit trails, compliance, and on-chain settlement.
+
+    Inputs:
+    - agent_id: The ERC-8004 agent ID or identifier requesting the receipt (required)
+    - claim: The reasoning claim that was verified (required)
+    - verdict: The verification verdict — ALLOW, BLOCK, or UNCERTAIN (required)
+    - domain: Domain context for the verification (optional)
+    - metadata: Key-value pairs of additional metadata (optional)
+
+    Examples:
+    - After verification: agent_id="agent-28388", claim="Swap is safe", verdict="ALLOW"
+    - With metadata: agent_id="my-agent", claim="Contract is secure", verdict="ALLOW", metadata={"chain": "base"}
+    """,
+        schema=GetVerificationReceiptSchema,
+    )
+    def get_verification_receipt(self, args: dict[str, Any]) -> str:
+        """Get a cryptographically signed verification receipt.
+
+        Args:
+            args (dict[str, Any]): Arguments containing agentId, claim, verdict and optional domain/metadata.
+
+        Returns:
+            str: A JSON string containing the verification receipt or error details.
+
+        """
+        validated_args = GetVerificationReceiptSchema(**args)
+
+        request_body: dict[str, Any] = {
+            "agentId": validated_args.agent_id,
+            "claim": validated_args.claim,
+            "verdict": validated_args.verdict,
+        }
+        if validated_args.domain:
+            request_body["domain"] = validated_args.domain
+        if validated_args.metadata:
+            request_body["metadata"] = validated_args.metadata
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/verify",
+                json=request_body,
+                headers=self._get_headers(),
+                timeout=30,
+            )
+
+            if not response.ok:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"API error: {response.status_code} {response.text}",
+                    }
+                )
+
+            result = response.json()
+            return json.dumps(
+                {
+                    "success": True,
+                    "receiptId": result.get("receiptId"),
+                    "agentId": result.get("agentId"),
+                    "verdict": result.get("verdict"),
+                    "score": result.get("score"),
+                    "jwt": result.get("jwt"),
+                    "verifyUrl": result.get("verifyUrl"),
+                }
+            )
+
+        except requests.exceptions.RequestException as e:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Request failed: {e}",
+                }
+            )
+
+    def supports_network(self, network: Network) -> bool:
+        """Check if network is supported.
+
+        ThoughtProof operates at the reasoning layer and is network-agnostic.
+
+        Returns:
+            bool: Always True.
+
+        """
+        return True
+
+
+def thoughtproof_action_provider(
+    api_key: str | None = None,
+) -> ThoughtProofActionProvider:
+    """Create and return a new ThoughtProofActionProvider instance.
+
+    Args:
+        api_key: ThoughtProof API key. Falls back to THOUGHTPROOF_API_KEY env var.
+
+    Returns:
+        ThoughtProofActionProvider: A configured provider instance.
+
+    """
+    return ThoughtProofActionProvider(api_key=api_key)

--- a/python/coinbase-agentkit/tests/action_providers/thoughtproof/test_thoughtproof_action_provider.py
+++ b/python/coinbase-agentkit/tests/action_providers/thoughtproof/test_thoughtproof_action_provider.py
@@ -1,0 +1,312 @@
+"""Tests for ThoughtProof action provider."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from coinbase_agentkit.action_providers.thoughtproof.schemas import (
+    GetVerificationReceiptSchema,
+    VerifyReasoningSchema,
+)
+from coinbase_agentkit.action_providers.thoughtproof.thoughtproof_action_provider import (
+    ThoughtProofActionProvider,
+    thoughtproof_action_provider,
+)
+
+MOCK_API_KEY = "tp_test_key_123"
+MOCK_CLAIM = "Swapping 1 ETH for USDC on Uniswap v3 is safe at current slippage"
+MOCK_AGENT_ID = "agent-28388"
+
+
+# ── Schema Tests ──────────────────────────────────────────────────────────
+
+
+def test_verify_reasoning_schema_valid():
+    """Test that VerifyReasoningSchema accepts valid parameters."""
+    schema = VerifyReasoningSchema(claim=MOCK_CLAIM)
+    assert schema.claim == MOCK_CLAIM
+    assert schema.context is None
+    assert schema.domain is None
+    assert schema.speed is None
+
+
+def test_verify_reasoning_schema_all_fields():
+    """Test that VerifyReasoningSchema accepts all optional parameters."""
+    schema = VerifyReasoningSchema(
+        claim=MOCK_CLAIM,
+        context="Uniswap v3 pool has $50M TVL",
+        domain="financial",
+        speed="deep",
+    )
+    assert schema.domain == "financial"
+    assert schema.speed == "deep"
+
+
+def test_verify_reasoning_schema_missing_claim():
+    """Test that VerifyReasoningSchema rejects missing claim."""
+    with pytest.raises(ValueError):
+        VerifyReasoningSchema()
+
+
+def test_verify_reasoning_schema_invalid_domain():
+    """Test that VerifyReasoningSchema rejects invalid domain."""
+    with pytest.raises(ValueError):
+        VerifyReasoningSchema(claim=MOCK_CLAIM, domain="invalid")
+
+
+def test_verify_reasoning_schema_invalid_speed():
+    """Test that VerifyReasoningSchema rejects invalid speed."""
+    with pytest.raises(ValueError):
+        VerifyReasoningSchema(claim=MOCK_CLAIM, speed="turbo")
+
+
+def test_get_verification_receipt_schema_valid():
+    """Test that GetVerificationReceiptSchema accepts valid parameters."""
+    schema = GetVerificationReceiptSchema(
+        agent_id=MOCK_AGENT_ID,
+        claim=MOCK_CLAIM,
+        verdict="ALLOW",
+    )
+    assert schema.agent_id == MOCK_AGENT_ID
+    assert schema.verdict == "ALLOW"
+
+
+def test_get_verification_receipt_schema_invalid_verdict():
+    """Test that GetVerificationReceiptSchema rejects invalid verdict."""
+    with pytest.raises(ValueError):
+        GetVerificationReceiptSchema(
+            agent_id=MOCK_AGENT_ID,
+            claim=MOCK_CLAIM,
+            verdict="MAYBE",
+        )
+
+
+def test_get_verification_receipt_schema_missing_fields():
+    """Test that GetVerificationReceiptSchema rejects missing required fields."""
+    with pytest.raises(ValueError):
+        GetVerificationReceiptSchema(claim=MOCK_CLAIM)
+
+
+# ── Provider Init Tests ───────────────────────────────────────────────────
+
+
+def test_provider_init_with_api_key():
+    """Test provider initialization with explicit API key."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+    assert provider.api_key == MOCK_API_KEY
+
+
+def test_provider_init_with_env_var(monkeypatch):
+    """Test provider initialization with environment variable."""
+    monkeypatch.setenv("THOUGHTPROOF_API_KEY", MOCK_API_KEY)
+    provider = thoughtproof_action_provider()
+    assert provider.api_key == MOCK_API_KEY
+
+
+def test_provider_init_missing_credentials():
+    """Test provider initialization fails without credentials."""
+    with pytest.raises(ValueError, match="THOUGHTPROOF_API_KEY is not configured"):
+        thoughtproof_action_provider()
+
+
+def test_provider_headers():
+    """Test that headers include API key."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+    headers = provider._get_headers()
+    assert headers["X-API-Key"] == MOCK_API_KEY
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_provider_supports_all_networks():
+    """Test that provider supports all networks."""
+    from coinbase_agentkit.network import Network
+
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+    assert provider.supports_network(Network.BASE_MAINNET) is True
+    assert provider.supports_network(Network.BASE_SEPOLIA) is True
+
+
+# ── verify_reasoning Tests ────────────────────────────────────────────────
+
+
+def test_verify_reasoning_success():
+    """Test successful reasoning verification."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "verdict": "ALLOW",
+        "confidence": 0.92,
+        "objections": [],
+        "durationMs": 1500,
+        "modelCount": 4,
+    }
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        result = provider.verify_reasoning({"claim": MOCK_CLAIM})
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["verdict"] == "ALLOW"
+        assert parsed["confidence"] == 0.92
+        assert parsed["modelCount"] == 4
+
+        # Verify correct URL
+        call_args = mock_post.call_args
+        assert "/v1/check" in call_args[0][0]
+        assert call_args[1]["json"]["claim"] == MOCK_CLAIM
+
+
+def test_verify_reasoning_with_options():
+    """Test reasoning verification with all optional parameters."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "verdict": "BLOCK",
+        "confidence": 0.35,
+        "objections": ["High slippage risk", "Low liquidity"],
+        "durationMs": 8000,
+        "modelCount": 4,
+    }
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        result = provider.verify_reasoning({
+            "claim": MOCK_CLAIM,
+            "context": "Pool has only $10K TVL",
+            "domain": "financial",
+            "speed": "deep",
+        })
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["verdict"] == "BLOCK"
+        assert len(parsed["objections"]) == 2
+
+        request_body = mock_post.call_args[1]["json"]
+        assert request_body["context"] == "Pool has only $10K TVL"
+        assert request_body["domain"] == "financial"
+        assert request_body["speed"] == "deep"
+
+
+def test_verify_reasoning_api_error():
+    """Test reasoning verification with API error response."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+
+    mock_response = MagicMock()
+    mock_response.ok = False
+    mock_response.status_code = 429
+    mock_response.text = "Rate limit exceeded"
+
+    with patch("requests.post", return_value=mock_response):
+        result = provider.verify_reasoning({"claim": MOCK_CLAIM})
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "429" in parsed["error"]
+
+
+def test_verify_reasoning_network_error():
+    """Test reasoning verification with network error."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+
+    with patch("requests.post", side_effect=requests.exceptions.ConnectionError("timeout")):
+        result = provider.verify_reasoning({"claim": MOCK_CLAIM})
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "Request failed" in parsed["error"]
+
+
+# ── get_verification_receipt Tests ────────────────────────────────────────
+
+
+def test_get_verification_receipt_success():
+    """Test successful verification receipt creation."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "receiptId": "rec_abc123",
+        "agentId": MOCK_AGENT_ID,
+        "claim": MOCK_CLAIM,
+        "verdict": "ALLOW",
+        "score": 0.92,
+        "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.test",
+        "verifyUrl": "https://api.thoughtproof.ai/v1/receipts/rec_abc123",
+    }
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        result = provider.get_verification_receipt({
+            "agent_id": MOCK_AGENT_ID,
+            "claim": MOCK_CLAIM,
+            "verdict": "ALLOW",
+        })
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["receiptId"] == "rec_abc123"
+        assert parsed["jwt"].startswith("eyJ")
+        assert parsed["verifyUrl"] is not None
+
+        request_body = mock_post.call_args[1]["json"]
+        assert request_body["agentId"] == MOCK_AGENT_ID
+
+
+def test_get_verification_receipt_with_metadata():
+    """Test receipt creation with optional metadata."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "receiptId": "rec_xyz789",
+        "agentId": MOCK_AGENT_ID,
+        "verdict": "BLOCK",
+        "score": 0.25,
+        "jwt": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSJ9.block",
+        "verifyUrl": "https://api.thoughtproof.ai/v1/receipts/rec_xyz789",
+    }
+
+    with patch("requests.post", return_value=mock_response) as mock_post:
+        result = provider.get_verification_receipt({
+            "agent_id": MOCK_AGENT_ID,
+            "claim": MOCK_CLAIM,
+            "verdict": "BLOCK",
+            "domain": "financial",
+            "metadata": {"chain": "base", "txValue": "1.5 ETH"},
+        })
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["verdict"] == "BLOCK"
+
+        request_body = mock_post.call_args[1]["json"]
+        assert request_body["domain"] == "financial"
+        assert request_body["metadata"]["chain"] == "base"
+
+
+def test_get_verification_receipt_api_error():
+    """Test receipt creation with API error."""
+    provider = thoughtproof_action_provider(api_key=MOCK_API_KEY)
+
+    mock_response = MagicMock()
+    mock_response.ok = False
+    mock_response.status_code = 404
+    mock_response.text = "Agent not found"
+
+    with patch("requests.post", return_value=mock_response):
+        result = provider.get_verification_receipt({
+            "agent_id": "nonexistent-agent",
+            "claim": MOCK_CLAIM,
+            "verdict": "ALLOW",
+        })
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "404" in parsed["error"]

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -25,6 +25,7 @@ export * from "./opensea";
 export * from "./spl";
 export * from "./superfluid";
 export * from "./sushi";
+export * from "./thoughtproof";
 export * from "./truemarkets";
 export * from "./twitter";
 export * from "./wallet";

--- a/typescript/agentkit/src/action-providers/thoughtproof/constants.ts
+++ b/typescript/agentkit/src/action-providers/thoughtproof/constants.ts
@@ -1,0 +1,1 @@
+export const THOUGHTPROOF_API_BASE_URL = "https://api.thoughtproof.ai";

--- a/typescript/agentkit/src/action-providers/thoughtproof/index.ts
+++ b/typescript/agentkit/src/action-providers/thoughtproof/index.ts
@@ -1,0 +1,2 @@
+export { ThoughtProofActionProvider, thoughtproofActionProvider } from "./thoughtproofActionProvider";
+export { VerifyReasoningSchema } from "./schemas";

--- a/typescript/agentkit/src/action-providers/thoughtproof/schemas.ts
+++ b/typescript/agentkit/src/action-providers/thoughtproof/schemas.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const VerifyReasoningSchema = z
+  .object({
+    claim: z
+      .string()
+      .describe("The claim, decision, or action to verify (e.g. 'Swap 100 USDC for TOKEN_X at market price')"),
+    stakeLevel: z
+      .enum(["low", "medium", "high", "critical"])
+      .describe("The stakes of the decision. Use 'high' or 'critical' for transactions above $1000 or irreversible actions."),
+    domain: z
+      .enum(["financial", "security", "legal", "medical", "general"])
+      .optional()
+      .describe("The domain of the claim. Defaults to 'financial' for DeFi actions."),
+  })
+  .strip()
+  .describe("Input schema for verifying a reasoning claim before executing an action");

--- a/typescript/agentkit/src/action-providers/thoughtproof/thoughtproofActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/thoughtproof/thoughtproofActionProvider.ts
@@ -7,7 +7,7 @@ import { THOUGHTPROOF_API_BASE_URL } from "./constants";
 /**
  * ThoughtProofActionProvider is an action provider for reasoning verification.
  * Runs adversarial multi-model critique (Claude + Grok + DeepSeek) on any claim
- * before the agent executes it. Returns ALLOW or HOLD with a signed attestation.
+ * before the agent executes it. Returns ALLOW, BLOCK, or UNCERTAIN with a signed attestation.
  *
  * Uses x402 micropayments on Base (USDC). No API key required.
  * Docs: https://thoughtproof.ai/skill.md
@@ -22,13 +22,13 @@ export class ThoughtProofActionProvider extends ActionProvider {
    * Call this before executing high-stakes or irreversible actions.
    *
    * @param args - The verification parameters (claim, stakeLevel, domain)
-   * @returns Verification result with verdict (ALLOW/HOLD), confidence, and objections
+   * @returns Verification result with verdict (ALLOW/BLOCK/UNCERTAIN), confidence, and objections
    */
   @CreateAction({
     name: "verify_reasoning",
     description:
       "Verify a claim or decision using adversarial multi-model reasoning before executing. " +
-      "Returns ALLOW or HOLD with confidence score and key objections. " +
+      "Returns ALLOW, BLOCK, or UNCERTAIN with confidence score and key objections. " +
       "Use before irreversible actions, large transactions, or high-stakes decisions.",
     schema: VerifyReasoningSchema,
   })
@@ -60,15 +60,15 @@ export class ThoughtProofActionProvider extends ActionProvider {
           `✅ ThoughtProof: ALLOW (confidence: ${confidence}%)\n` +
           (objections.length > 0 ? `Minor concerns: ${objections.join("; ")}` : "No objections raised.")
         );
-      } else {
+      } else if (verdict === "BLOCK") {
         return (
-          `🚫 ThoughtProof: HOLD — do not proceed.\n` +
+          `🚫 ThoughtProof: BLOCK — do not proceed.\n` +
           `Confidence: ${confidence}%\n` +
           `Objections:\n${objections.map((o: string) => `- ${o}`).join("\n")}`
         );
       }
     } catch (error) {
-      return `🚫 ThoughtProof: HOLD — verification service unavailable (${error}). Do not proceed until reasoning can be verified.`;
+      return `🚫 ThoughtProof: BLOCK — verification service unavailable (${error}). Do not proceed until reasoning can be verified.`;
     }
   }
 

--- a/typescript/agentkit/src/action-providers/thoughtproof/thoughtproofActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/thoughtproof/thoughtproofActionProvider.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { VerifyReasoningSchema } from "./schemas";
+import { THOUGHTPROOF_API_BASE_URL } from "./constants";
+
+/**
+ * ThoughtProofActionProvider is an action provider for reasoning verification.
+ * Runs adversarial multi-model critique (Claude + Grok + DeepSeek) on any claim
+ * before the agent executes it. Returns ALLOW or HOLD with a signed attestation.
+ *
+ * Uses x402 micropayments on Base (USDC). No API key required.
+ * Docs: https://thoughtproof.ai/skill.md
+ */
+export class ThoughtProofActionProvider extends ActionProvider {
+  constructor() {
+    super("thoughtproof", []);
+  }
+
+  /**
+   * Verifies a claim or decision using adversarial multi-model reasoning.
+   * Call this before executing high-stakes or irreversible actions.
+   *
+   * @param args - The verification parameters (claim, stakeLevel, domain)
+   * @returns Verification result with verdict (ALLOW/HOLD), confidence, and objections
+   */
+  @CreateAction({
+    name: "verify_reasoning",
+    description:
+      "Verify a claim or decision using adversarial multi-model reasoning before executing. " +
+      "Returns ALLOW or HOLD with confidence score and key objections. " +
+      "Use before irreversible actions, large transactions, or high-stakes decisions.",
+    schema: VerifyReasoningSchema,
+  })
+  async verifyReasoning(args: z.infer<typeof VerifyReasoningSchema>): Promise<string> {
+    try {
+      const response = await fetch(`${THOUGHTPROOF_API_BASE_URL}/v1/check`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          claim: args.claim,
+          stakeLevel: args.stakeLevel ?? "medium",
+          domain: args.domain ?? "financial",
+        }),
+      });
+
+      if (!response.ok) {
+        return `ThoughtProof verification failed: HTTP ${response.status}. Proceed with caution.`;
+      }
+
+      const data = await response.json();
+      const verdict = data.verdict ?? "UNCERTAIN";
+      const confidence = data.confidence ?? 0;
+      const objections = data.objections ?? [];
+
+      if (verdict === "ALLOW") {
+        return (
+          `✅ ThoughtProof: ALLOW (confidence: ${confidence}%)\n` +
+          (objections.length > 0 ? `Minor concerns: ${objections.join("; ")}` : "No objections raised.")
+        );
+      } else {
+        return (
+          `🚫 ThoughtProof: HOLD — do not proceed.\n` +
+          `Confidence: ${confidence}%\n` +
+          `Objections:\n${objections.map((o: string) => `- ${o}`).join("\n")}`
+        );
+      }
+    } catch (error) {
+      return `🚫 ThoughtProof: HOLD — verification service unavailable (${error}). Do not proceed until reasoning can be verified.`;
+    }
+  }
+
+  supportsNetwork = () => true;
+}
+
+export const thoughtproofActionProvider = () => new ThoughtProofActionProvider();


### PR DESCRIPTION

## Summary

New action provider for **pre-execution reasoning verification** — adversarial multi-model critique before high-stakes agent actions.

## Actions

| Action | Description |
|--------|-------------|
| `verify_reasoning` | Runs Claude + Grok + DeepSeek adversarial critique on a claim. Returns ALLOW or HOLD with confidence score and key objections. |

## Why

Agents executing DeFi transactions, fund transfers, or irreversible actions need a reasoning check layer — not just token safety, but **decision quality verification**:

1. Agent receives: "Swap 500 USDC for TOKEN_X at market"
2. Agent calls `verify_reasoning({ claim, stakeLevel: 'high', domain: 'financial' })`
3. If HOLD → agent refuses and surfaces objections to the user
4. If ALLOW → agent proceeds with confidence

## Design

- **Fail-safe:** API errors return HOLD (never silently proceed)
- **Stake-aware:** low / medium / high / critical levels route to appropriate model depth
- **Signed attestations:** responses include JWKS-signed EdDSA attestation for audit trails
- **Payment:** x402 micropayments on Base (USDC) via `api.thoughtproof.ai`

## Links

- API: https://api.thoughtproof.ai
- Docs: https://thoughtproof.ai/skill.md
- npm MCP: `npx @thoughtproof/mcp-server`