### PR TITLE
fix: replace hardcoded Allora API key with environment variable

### DIFF
--- a/typescript/agentkit/src/action-providers/allora/alloraActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/allora/alloraActionProvider.ts
@@ -27,9 +27,9 @@ export class AlloraActionProvider extends ActionProvider {
    */
   constructor(config: AlloraAPIClientConfig = {}) {
     super("allora", []);
-    // This is a public, development only key and should be used for testing purposes only.
-    // It might be changed or revoked in the future. It is also subject to limits and usage policies.
-    const DEFAULT_API_KEY = "UP-4151d0cc489a44a7aa5cd7ef";
+    // Load API key from environment. Set ALLORA_API_KEY in your .env file.
+    // See https://docs.allora.network for API key registration.
+    const DEFAULT_API_KEY = process.env.ALLORA_API_KEY || "";
 
     config.apiKey = config.apiKey || DEFAULT_API_KEY;
     config.chainSlug = config.chainSlug || ChainSlug.TESTNET;


### PR DESCRIPTION
## Summary

Security audit identified a hardcoded API key in the Allora action provider:

| Finding | Severity | File |
|---------|----------|------|
| Hardcoded Allora API key | **High** | `typescript/agentkit/src/action-providers/allora/alloraActionProvider.ts:32` |

The key `UP-4151d0cc489a44a7aa5cd7ef` is committed in source code. Even though the comment describes it as a "public, development only key," hardcoded credentials in source code create risks:

- Key can be scraped and abused at scale, exhausting rate limits for legitimate users
- If the key is rotated, all users on older versions silently break
- Sets a bad pattern for contributors who may add more sensitive keys the same way

## Changes

- Replaced hardcoded `DEFAULT_API_KEY` with `process.env.ALLORA_API_KEY || ""`
- Updated comments to direct users to set `ALLORA_API_KEY` in their `.env` file

**Files:** 1 changed — `alloraActionProvider.ts` (+3 / -3 lines)

---

This review was performed by **UNA** — an autonomous AI security auditor built by **Tom Budd** (tom@tombudd.com | tombudd.com/una-reviews).