### PR TITLE
Add AgentTax action provider

### DIFF
--- a/typescript/.changeset/add-agenttax-action-provider.md
+++ b/typescript/.changeset/add-agenttax-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added AgentTax action provider — US sales tax calculation, zip-level rate lookup, nexus status, 1099-DA export, and tax-compliant USDC remittance on Base. The remit action appends the AgentTax Base Builder Code (ERC-8021) to transaction calldata for attribution in the Base developer dashboard.

--- a/typescript/agentkit/src/action-providers/agenttax/README.md
+++ b/typescript/agentkit/src/action-providers/agenttax/README.md
@@ -1,0 +1,189 @@
+# AgentTax Action Provider
+
+This directory contains the **AgentTaxActionProvider** implementation, which exposes the [AgentTax](https://agenttax.io) tax-compliance API as AgentKit actions and ships a tax-compliant USDC remittance action on Base.
+
+Every onchain transaction submitted through this provider carries the **AgentTax Base Builder Code** (`bc_626v2pr2`) in its calldata (ERC-8021), so the agent's tax-compliant activity attributes back to AgentTax for analytics and Base ecosystem rewards.
+
+## Why
+
+Agent-to-agent commerce on Base is growing fast, but every marketplace, micropayment service, and x402-powered API has the same unsolved problem: **who collects and remits sales tax on these transactions?**
+
+AgentTax is the compliance layer for the agent economy. This action provider lets any AgentKit agent:
+
+1. Calculate the correct US sales tax on a transaction (51-jurisdiction coverage, 105+ zip-level local rates)
+2. Check nexus status across states
+3. Export IRS Form 1099-DA data
+4. Remit collected tax onchain as a USDC transfer on Base — with Builder Code attribution
+
+## Directory Structure
+
+```
+agenttax/
+├── agentTaxActionProvider.ts        # Main provider + 5 actions
+├── agentTaxActionProvider.test.ts   # Unit tests
+├── schemas.ts                        # Zod schemas + AgentTaxConfig
+├── constants.ts                      # Builder Code suffix + USDC addresses
+├── index.ts                          # Public exports
+└── README.md                         # This file
+```
+
+## Configuration
+
+```typescript
+import { agentTaxActionProvider, AgentTaxConfig } from "@coinbase/agentkit";
+
+const config: AgentTaxConfig = {
+  // Optional. Public actions work without a key.
+  // With a key, check_nexus_status and export_1099_da return real data
+  // for the authenticated entity (instead of AgentTax demo data), and
+  // remit_tax_onchain logs the remittance to the AgentTax audit trail.
+  // Get a key at https://agenttax.io/dashboard
+  apiKey: process.env.AGENTTAX_API_KEY,
+
+  // Override for staging / self-hosted. Defaults to https://agenttax.io
+  baseUrl: "https://agenttax.io",
+
+  // Default treasury wallet for remit_tax_onchain when no recipient is supplied
+  reserveWallet: "0xYourTreasuryWallet",
+
+  // Whether to append the AgentTax Base Builder Code to onchain transactions.
+  // Defaults to true. Disable only if you want to attribute elsewhere.
+  builderCodeEnabled: true,
+};
+
+const provider = agentTaxActionProvider(config);
+```
+
+All config fields are optional. The provider also reads `AGENTTAX_API_KEY` from the environment when no explicit `apiKey` is passed.
+
+## Actions
+
+### `calculate_tax`
+
+Calculates US sales tax for an agent transaction.
+
+**Inputs**
+- `amount` (number): Amount in whole USD (e.g. `10.5`)
+- `buyerState` (string): Two-letter state code (e.g. `"TX"`)
+- `buyerZip` (string, optional): 5- or 9-digit ZIP for zip-level precision
+- `transactionType` (enum): one of
+  `compute`, `api_access`, `data_purchase`, `saas`, `ai_labor`, `storage`,
+  `digital_good`, `consulting`, `data_processing`, `cloud_infrastructure`,
+  `ai_model_access`, `marketplace_fee`, `subscription`, `license`, `service`
+- `counterpartyId` (string, **required**): Buyer identifier (wallet address, agent ID) for audit trail
+- `isB2B` (boolean, optional): Defaults to `false`
+
+**Example**
+```typescript
+await agent.run("calculate_tax", {
+  amount: 10,
+  buyerState: "TX",
+  buyerZip: "77001",
+  transactionType: "compute",
+  counterpartyId: "agent_abc123",
+});
+```
+
+### `get_local_rate`
+
+Looks up the combined (state + local) sales tax rate for a ZIP code.
+
+**Inputs**
+- `zip` (string): 5- or 9-digit US ZIP code
+
+**Example**
+```typescript
+await agent.run("get_local_rate", { zip: "77001" });
+```
+
+### `check_nexus_status`
+
+Checks sales tax nexus status across one or more states.
+
+Without an `apiKey`, returns AgentTax demo data. With an `apiKey`, returns nexus data for the authenticated entity.
+
+**Inputs**
+- `states` (string[]): States to check
+
+**Example**
+```typescript
+await agent.run("check_nexus_status", { states: ["TX", "CA", "NY"] });
+```
+
+### `export_1099_da`
+
+Exports IRS Form 1099-DA draft data for a given tax year. Without an `apiKey`, returns demo data. With an `apiKey`, returns real data for the authenticated entity.
+
+**Inputs**
+- `year` (number): Tax year (e.g. `2026`)
+
+**Example**
+```typescript
+await agent.run("export_1099_da", { year: 2026 });
+```
+
+### `remit_tax_onchain`
+
+Remits collected sales tax as a USDC transfer on Base. The transaction carries the AgentTax Base Builder Code in its calldata (ERC-8021). If `apiKey` is configured, the remittance is also logged to the AgentTax audit trail (best-effort — failures do not block the transfer).
+
+**Supported networks:** `base-mainnet`, `base-sepolia`
+
+**Inputs**
+- `amountUsdc` (number): Amount of USDC to remit in whole units
+- `recipient` (string, optional): Treasury wallet — defaults to `reserveWallet` from provider config
+- `jurisdiction` (string, optional): Two-letter state code for the jurisdiction being remitted to
+- `reference` (string, optional): External reference (e.g. AgentTax transaction ID) for audit trail
+
+**Example**
+```typescript
+await agent.run("remit_tax_onchain", {
+  amountUsdc: 2.5,
+  jurisdiction: "TX",
+  reference: "txn_abc123",
+});
+```
+
+## Base Builder Code
+
+This provider participates in the [Base Builder Codes](https://docs.base.org/base-chain/builder-codes/builder-codes) program. Every onchain transaction it submits appends the ERC-8021 suffix:
+
+```
+0x62635f36323676327072320b0080218021802180218021802180218021
+```
+
+Decoded: `bc_626v2pr2` (ascii) + length byte (`0x0b`) + ERC-8021 magic pattern.
+
+Gas overhead: ~450 gas per transaction (16 gas per non-zero byte). Smart contracts ignore the suffix, so there is no behavioral impact on the transfer itself.
+
+To disable attribution, set `builderCodeEnabled: false` in the provider config.
+
+## End-to-End Example
+
+```typescript
+import { AgentKit, agentTaxActionProvider, erc20ActionProvider, walletActionProvider } from "@coinbase/agentkit";
+
+const agentKit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [
+    walletActionProvider(),
+    erc20ActionProvider(),
+    agentTaxActionProvider({
+      apiKey: process.env.AGENTTAX_API_KEY,
+      reserveWallet: "0xYourTreasuryWallet",
+    }),
+  ],
+});
+
+// Agent workflow:
+// 1. calculate_tax for the current sale
+// 2. collect payment from the buyer via erc20 transfer
+// 3. remit_tax_onchain to treasury (Builder Code attached automatically)
+```
+
+## Links
+
+- **AgentTax website:** https://agenttax.io
+- **AgentTax dashboard:** https://agenttax.io/dashboard
+- **AgentTax docs:** https://agenttax.io/docs
+- **Base Builder Codes:** https://docs.base.org/base-chain/builder-codes/builder-codes
+- **ERC-8021 spec:** https://eips.ethereum.org/EIPS/eip-8021

--- a/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.test.ts
@@ -451,6 +451,24 @@ describe("nexus / 1099-da actions with apiKey", () => {
     expect(response).toContain("triggered");
   });
 
+  it("check_nexus_status surfaces { success: false } as an error", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          success: false,
+          error: "entity not found",
+        }),
+    });
+
+    const response = await provider.checkNexusStatus(makeMockWallet(), {
+      states: ["TX"],
+    });
+
+    expect(response).toContain("Error (check_nexus_status): entity not found");
+  });
+
   it("export_1099_da passes year and returns data", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -471,6 +489,21 @@ describe("nexus / 1099-da actions with apiKey", () => {
       }),
     );
     expect(response).toContain('"total_proceeds": 12500');
+  });
+
+  it("export_1099_da surfaces { success: false } as an error", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          success: false,
+          error: "no transactions found for year",
+        }),
+    });
+
+    const response = await provider.export1099Da(makeMockWallet(), { year: 2020 });
+    expect(response).toContain("Error (export_1099_da): no transactions found for year");
   });
 });
 

--- a/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.test.ts
@@ -1,0 +1,663 @@
+import { agentTaxActionProvider, AgentTaxActionProvider } from "./agentTaxActionProvider";
+import { AGENTTAX_BUILDER_CODE, AGENTTAX_BUILDER_CODE_SUFFIX, USDC_ADDRESSES } from "./constants";
+import {
+  CalculateTaxSchema,
+  CheckNexusStatusSchema,
+  Export1099DaSchema,
+  GetLocalRateSchema,
+  RemitTaxOnchainSchema,
+} from "./schemas";
+import { EvmWalletProvider } from "../../wallet-providers";
+
+// -----------------------------------------------------------------------------
+// Test fixtures
+// -----------------------------------------------------------------------------
+
+const MOCK_API_KEY = "agenttax_test_key_0123456789";
+const MOCK_BASE_URL = "https://test.agenttax.io";
+const MOCK_RESERVE_WALLET = "0x1111111111111111111111111111111111111111";
+const MOCK_RECIPIENT = "0x2222222222222222222222222222222222222222";
+const MOCK_WALLET_ADDRESS = "0x3333333333333333333333333333333333333333";
+const MOCK_TX_HASH = "0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1";
+
+/**
+ * Builds a mocked EvmWalletProvider preconfigured for a given Base network.
+ *
+ * @param networkId - Network ID to return from `getNetwork()`. Defaults to base-mainnet.
+ * @returns A jest-mocked EvmWalletProvider suitable for unit tests.
+ */
+function makeMockWallet(networkId: string = "base-mainnet"): jest.Mocked<EvmWalletProvider> {
+  const wallet = {
+    getAddress: jest.fn().mockReturnValue(MOCK_WALLET_ADDRESS),
+    getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId }),
+    sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH),
+    waitForTransactionReceipt: jest.fn().mockResolvedValue({}),
+    getName: jest.fn().mockReturnValue("evm_wallet_provider"),
+  } as unknown as jest.Mocked<EvmWalletProvider>;
+  return wallet;
+}
+
+/**
+ * Installs a mock for `global.fetch` and returns the jest mock function so
+ * individual tests can configure its return values.
+ *
+ * @returns The jest.Mock that has been installed as `global.fetch`.
+ */
+function mockFetch(): jest.Mock {
+  const fn = jest.fn();
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+// -----------------------------------------------------------------------------
+// Schema validation
+// -----------------------------------------------------------------------------
+
+describe("CalculateTaxSchema", () => {
+  it("accepts valid input and normalizes state code + isB2B default", () => {
+    const parsed = CalculateTaxSchema.safeParse({
+      amount: 10.5,
+      buyerState: "tx",
+      buyerZip: "77001",
+      transactionType: "compute",
+      counterpartyId: "agent_abc123",
+      isB2B: null,
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.buyerState).toBe("TX");
+    expect(parsed.data?.isB2B).toBe(false);
+  });
+
+  it("rejects non-positive amount", () => {
+    const parsed = CalculateTaxSchema.safeParse({
+      amount: 0,
+      buyerState: "TX",
+      buyerZip: null,
+      transactionType: "compute",
+      counterpartyId: "agent_abc",
+      isB2B: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects invalid state code length", () => {
+    const parsed = CalculateTaxSchema.safeParse({
+      amount: 1,
+      buyerState: "TEX",
+      buyerZip: null,
+      transactionType: "compute",
+      counterpartyId: "agent_abc",
+      isB2B: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects invalid transactionType", () => {
+    const parsed = CalculateTaxSchema.safeParse({
+      amount: 1,
+      buyerState: "TX",
+      buyerZip: null,
+      transactionType: "not_a_real_type",
+      counterpartyId: "agent_abc",
+      isB2B: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects missing counterpartyId", () => {
+    const parsed = CalculateTaxSchema.safeParse({
+      amount: 1,
+      buyerState: "TX",
+      buyerZip: null,
+      transactionType: "compute",
+      counterpartyId: "",
+      isB2B: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects invalid zip format", () => {
+    const parsed = CalculateTaxSchema.safeParse({
+      amount: 1,
+      buyerState: "TX",
+      buyerZip: "ABC",
+      transactionType: "compute",
+      counterpartyId: "agent_abc",
+      isB2B: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("GetLocalRateSchema", () => {
+  it("accepts 5-digit and 9-digit zips", () => {
+    expect(GetLocalRateSchema.safeParse({ zip: "77001" }).success).toBe(true);
+    expect(GetLocalRateSchema.safeParse({ zip: "77001-1234" }).success).toBe(true);
+  });
+
+  it("rejects non-numeric zip", () => {
+    expect(GetLocalRateSchema.safeParse({ zip: "ABCDE" }).success).toBe(false);
+  });
+});
+
+describe("CheckNexusStatusSchema", () => {
+  it("accepts one or more state codes", () => {
+    expect(CheckNexusStatusSchema.safeParse({ states: ["TX", "NY", "CA"] }).success).toBe(true);
+  });
+
+  it("rejects empty states array", () => {
+    expect(CheckNexusStatusSchema.safeParse({ states: [] }).success).toBe(false);
+  });
+});
+
+describe("Export1099DaSchema", () => {
+  it("accepts a valid tax year", () => {
+    expect(Export1099DaSchema.safeParse({ year: 2026 }).success).toBe(true);
+  });
+
+  it("rejects non-integer year", () => {
+    expect(Export1099DaSchema.safeParse({ year: 2026.5 }).success).toBe(false);
+  });
+
+  it("rejects out-of-range year", () => {
+    expect(Export1099DaSchema.safeParse({ year: 1999 }).success).toBe(false);
+  });
+});
+
+describe("RemitTaxOnchainSchema", () => {
+  it("accepts minimum valid input", () => {
+    const parsed = RemitTaxOnchainSchema.safeParse({
+      amountUsdc: 1.25,
+      recipient: null,
+      jurisdiction: null,
+      reference: null,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects invalid recipient address", () => {
+    const parsed = RemitTaxOnchainSchema.safeParse({
+      amountUsdc: 1.25,
+      recipient: "not-an-address",
+      jurisdiction: null,
+      reference: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects non-positive amount", () => {
+    const parsed = RemitTaxOnchainSchema.safeParse({
+      amountUsdc: 0,
+      recipient: null,
+      jurisdiction: null,
+      reference: null,
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Builder Code encoding — regression test on the canonical suffix
+// -----------------------------------------------------------------------------
+
+describe("Builder Code constants", () => {
+  it("raw code matches registered value", () => {
+    expect(AGENTTAX_BUILDER_CODE).toBe("bc_626v2pr2");
+  });
+
+  it("encoded suffix matches the ERC-8021 hex issued by base.dev", () => {
+    expect(AGENTTAX_BUILDER_CODE_SUFFIX).toBe(
+      "0x62635f36323676327072320b0080218021802180218021802180218021",
+    );
+  });
+
+  it("encoded suffix decodes to [ascii code][length 0x0b][magic 0x8021 pattern]", () => {
+    const hex = AGENTTAX_BUILDER_CODE_SUFFIX.slice(2);
+    // First 11 bytes = ASCII "bc_626v2pr2"
+    const codeBytes = hex.slice(0, 22);
+    const decodedCode = Buffer.from(codeBytes, "hex").toString("ascii");
+    expect(decodedCode).toBe(AGENTTAX_BUILDER_CODE);
+
+    // Next byte = length of the code (11 = 0x0b)
+    expect(hex.slice(22, 24)).toBe("0b");
+
+    // Remaining bytes start with 00 then alternating 8021 pattern
+    const magic = hex.slice(24);
+    expect(magic.startsWith("0080218021")).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// calculate_tax
+// -----------------------------------------------------------------------------
+
+describe("calculate_tax action", () => {
+  let fetchMock: jest.Mock;
+  const provider = agentTaxActionProvider({ baseUrl: MOCK_BASE_URL });
+
+  beforeEach(() => {
+    fetchMock = mockFetch();
+  });
+
+  it("returns parsed tax data on success and sends the correct request body", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          success: true,
+          total_tax: 0.825,
+          combined_rate: 0.0825,
+          buyer_state: "TX",
+          jurisdiction: "TX",
+          transaction_type: "compute",
+          work_type: "compute",
+        }),
+    });
+
+    const response = await provider.calculateTax(makeMockWallet(), {
+      amount: 10,
+      buyerState: "TX",
+      buyerZip: null,
+      transactionType: "compute",
+      counterpartyId: "agent_abc123",
+      isB2B: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${MOCK_BASE_URL}/api/v1/calculate`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    // Verify the request body shape matches the AgentTax API contract.
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse((options as { body: string }).body);
+    expect(body).toMatchObject({
+      role: "seller",
+      amount: 10,
+      buyer_state: "TX",
+      transaction_type: "compute",
+      counterparty_id: "agent_abc123",
+      is_b2b: false,
+    });
+    expect(response).toContain('"total_tax": 0.825');
+    expect(response).toContain('"buyer_state": "TX"');
+  });
+
+  it("surfaces HTTP-level errors as a descriptive error string", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      text: async () => JSON.stringify({ error: "invalid state" }),
+    });
+
+    const response = await provider.calculateTax(makeMockWallet(), {
+      amount: 10,
+      buyerState: "XX",
+      buyerZip: null,
+      transactionType: "compute",
+      counterpartyId: "agent_abc",
+      isB2B: false,
+    });
+
+    expect(response).toContain("Error (calculate_tax): HTTP 422 — invalid state");
+  });
+
+  it("surfaces { success: false, error } 200 responses as errors", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          success: false,
+          error: 'Invalid transaction_type "foo"',
+        }),
+    });
+
+    const response = await provider.calculateTax(makeMockWallet(), {
+      amount: 10,
+      buyerState: "TX",
+      buyerZip: null,
+      transactionType: "compute",
+      counterpartyId: "agent_abc",
+      isB2B: false,
+    });
+
+    expect(response).toContain('Error (calculate_tax): Invalid transaction_type "foo"');
+  });
+
+  it("handles network errors without throwing", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const response = await provider.calculateTax(makeMockWallet(), {
+      amount: 10,
+      buyerState: "TX",
+      buyerZip: null,
+      transactionType: "compute",
+      counterpartyId: "agent_abc",
+      isB2B: false,
+    });
+
+    expect(response).toContain("Error (calculate_tax)");
+    expect(response).toContain("ECONNREFUSED");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// get_local_rate
+// -----------------------------------------------------------------------------
+
+describe("get_local_rate action", () => {
+  let fetchMock: jest.Mock;
+  const provider = agentTaxActionProvider({ baseUrl: MOCK_BASE_URL });
+
+  beforeEach(() => {
+    fetchMock = mockFetch();
+  });
+
+  it("returns parsed rate data", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          state_rate: 0.0625,
+          local_rate: 0.02,
+          combined_rate: 0.0825,
+          jurisdiction: "Harris County",
+          confidence: 0.97,
+        }),
+    });
+
+    const response = await provider.getLocalRate(makeMockWallet(), { zip: "77001" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${MOCK_BASE_URL}/api/v1/rates/local?zip=77001`,
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(response).toContain('"combined_rate": 0.0825');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// check_nexus_status & export_1099_da — work with or without apiKey.
+// Without a key the API returns demo data, with one it returns real data.
+// -----------------------------------------------------------------------------
+
+describe("nexus / 1099-da actions without apiKey (demo mode)", () => {
+  let fetchMock: jest.Mock;
+  const provider = agentTaxActionProvider({ baseUrl: MOCK_BASE_URL });
+
+  beforeEach(() => {
+    fetchMock = mockFetch();
+  });
+
+  it("check_nexus_status sends request without X-API-Key header when no key", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ entity_id: "demo_entity", total_nexus_states: 0 }),
+    });
+    await provider.checkNexusStatus(makeMockWallet(), { states: ["TX"] });
+    const [, options] = fetchMock.mock.calls[0];
+    const headers = (options as { headers: Record<string, string> }).headers;
+    expect(headers["X-API-Key"]).toBeUndefined();
+  });
+
+  it("export_1099_da sends request without X-API-Key header when no key", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ form: "1099-DA", tax_year: 2026 }),
+    });
+    await provider.export1099Da(makeMockWallet(), { year: 2026 });
+    const [, options] = fetchMock.mock.calls[0];
+    const headers = (options as { headers: Record<string, string> }).headers;
+    expect(headers["X-API-Key"]).toBeUndefined();
+  });
+});
+
+describe("nexus / 1099-da actions with apiKey", () => {
+  let fetchMock: jest.Mock;
+  const provider = agentTaxActionProvider({
+    baseUrl: MOCK_BASE_URL,
+    apiKey: MOCK_API_KEY,
+  });
+
+  beforeEach(() => {
+    fetchMock = mockFetch();
+  });
+
+  it("check_nexus_status builds a multi-state query and passes the api key", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          nexus: { TX: "triggered", NY: "approaching" },
+        }),
+    });
+
+    const response = await provider.checkNexusStatus(makeMockWallet(), {
+      states: ["TX", "NY"],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${MOCK_BASE_URL}/api/v1/nexus?states=TX&states=NY`,
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ "X-API-Key": MOCK_API_KEY }),
+      }),
+    );
+    expect(response).toContain("triggered");
+  });
+
+  it("export_1099_da passes year and returns data", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          year: 2026,
+          entity_name: "Example LLC",
+          total_proceeds: 12500.0,
+        }),
+    });
+
+    const response = await provider.export1099Da(makeMockWallet(), { year: 2026 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${MOCK_BASE_URL}/api/v1/export/1099-da?year=2026`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-API-Key": MOCK_API_KEY }),
+      }),
+    );
+    expect(response).toContain('"total_proceeds": 12500');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// remit_tax_onchain — the headline Builder Code action
+// -----------------------------------------------------------------------------
+
+describe("remit_tax_onchain action", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = mockFetch();
+  });
+
+  it("errors when called on a non-Base network", async () => {
+    const provider = agentTaxActionProvider({
+      baseUrl: MOCK_BASE_URL,
+      reserveWallet: MOCK_RESERVE_WALLET,
+    });
+    const wallet = makeMockWallet("ethereum-mainnet");
+    const response = await provider.remitTaxOnchain(wallet, {
+      amountUsdc: 1,
+      recipient: null,
+      jurisdiction: null,
+      reference: null,
+    });
+    expect(response).toContain("only supports base-mainnet and base-sepolia");
+    expect(wallet.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("errors when no recipient and no reserveWallet", async () => {
+    const provider = agentTaxActionProvider({ baseUrl: MOCK_BASE_URL });
+    const wallet = makeMockWallet("base-mainnet");
+    const response = await provider.remitTaxOnchain(wallet, {
+      amountUsdc: 1,
+      recipient: null,
+      jurisdiction: null,
+      reference: null,
+    });
+    expect(response).toContain("no recipient address provided");
+    expect(wallet.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it("sends USDC transfer with Builder Code suffix appended on base-mainnet", async () => {
+    const provider = agentTaxActionProvider({
+      baseUrl: MOCK_BASE_URL,
+      apiKey: MOCK_API_KEY,
+      reserveWallet: MOCK_RESERVE_WALLET,
+    });
+    const wallet = makeMockWallet("base-mainnet");
+
+    // Best-effort audit log call — mock fetch to succeed
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ logged: true }),
+    });
+
+    const response = await provider.remitTaxOnchain(wallet, {
+      amountUsdc: 2.5,
+      recipient: MOCK_RECIPIENT,
+      jurisdiction: "TX",
+      reference: "txn_abc123",
+    });
+
+    // Verify sendTransaction was called
+    expect(wallet.sendTransaction).toHaveBeenCalledTimes(1);
+    const call = wallet.sendTransaction.mock.calls[0][0] as { to: string; data: string };
+
+    // Correct USDC address for base-mainnet
+    expect(call.to.toLowerCase()).toBe(USDC_ADDRESSES["base-mainnet"].toLowerCase());
+
+    // Calldata must end with the Builder Code suffix body (without 0x)
+    const expectedSuffix = AGENTTAX_BUILDER_CODE_SUFFIX.slice(2);
+    expect(call.data.toLowerCase().endsWith(expectedSuffix.toLowerCase())).toBe(true);
+
+    // Calldata should include the ERC20 transfer selector 0xa9059cbb
+    expect(call.data.toLowerCase().startsWith("0xa9059cbb")).toBe(true);
+
+    // Audit log was called
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${MOCK_BASE_URL}/api/v1/transactions`,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "X-API-Key": MOCK_API_KEY }),
+      }),
+    );
+
+    expect(response).toContain("Remitted 2.5 USDC");
+    expect(response).toContain(MOCK_RECIPIENT);
+    expect(response).toContain(MOCK_TX_HASH);
+    expect(response).toContain("Builder Code: bc_626v2pr2");
+    expect(response).toContain("Jurisdiction: TX");
+    expect(response).toContain("Reference: txn_abc123");
+    expect(response).toContain("Audit log: recorded in AgentTax");
+  });
+
+  it("skips audit log when no apiKey is configured but still completes the transfer", async () => {
+    const provider = agentTaxActionProvider({
+      baseUrl: MOCK_BASE_URL,
+      reserveWallet: MOCK_RESERVE_WALLET,
+    });
+    const wallet = makeMockWallet("base-mainnet");
+
+    const response = await provider.remitTaxOnchain(wallet, {
+      amountUsdc: 1,
+      recipient: null,
+      jurisdiction: null,
+      reference: null,
+    });
+
+    expect(wallet.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response).toContain("Audit log: skipped");
+  });
+
+  it("does NOT append the Builder Code suffix when builderCodeEnabled is false", async () => {
+    const provider = agentTaxActionProvider({
+      baseUrl: MOCK_BASE_URL,
+      reserveWallet: MOCK_RESERVE_WALLET,
+      builderCodeEnabled: false,
+    });
+    const wallet = makeMockWallet("base-mainnet");
+
+    await provider.remitTaxOnchain(wallet, {
+      amountUsdc: 1,
+      recipient: MOCK_RECIPIENT,
+      jurisdiction: null,
+      reference: null,
+    });
+
+    const call = wallet.sendTransaction.mock.calls[0][0] as { data: string };
+    const suffix = AGENTTAX_BUILDER_CODE_SUFFIX.slice(2);
+    expect(call.data.toLowerCase().endsWith(suffix.toLowerCase())).toBe(false);
+  });
+
+  it("gracefully returns error string on sendTransaction failure", async () => {
+    const provider = agentTaxActionProvider({
+      baseUrl: MOCK_BASE_URL,
+      reserveWallet: MOCK_RESERVE_WALLET,
+    });
+    const wallet = makeMockWallet("base-mainnet");
+    wallet.sendTransaction.mockRejectedValueOnce(new Error("insufficient funds"));
+
+    const response = await provider.remitTaxOnchain(wallet, {
+      amountUsdc: 1,
+      recipient: MOCK_RECIPIENT,
+      jurisdiction: null,
+      reference: null,
+    });
+
+    expect(response).toContain("Error submitting remittance transaction");
+    expect(response).toContain("insufficient funds");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// supportsNetwork
+// -----------------------------------------------------------------------------
+
+describe("supportsNetwork", () => {
+  const provider = agentTaxActionProvider();
+
+  it("returns true for EVM networks", () => {
+    expect(provider.supportsNetwork({ protocolFamily: "evm", networkId: "base-mainnet" })).toBe(
+      true,
+    );
+    expect(provider.supportsNetwork({ protocolFamily: "evm", networkId: "ethereum-mainnet" })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for non-EVM networks", () => {
+    expect(
+      provider.supportsNetwork({ protocolFamily: "solana", networkId: "solana-mainnet" }),
+    ).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Provider factory + class sanity
+// -----------------------------------------------------------------------------
+
+describe("provider factory", () => {
+  it("agentTaxActionProvider() returns an AgentTaxActionProvider instance", () => {
+    const provider = agentTaxActionProvider();
+    expect(provider).toBeInstanceOf(AgentTaxActionProvider);
+    expect(provider.name).toBe("agenttax");
+  });
+});

--- a/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.ts
@@ -1,0 +1,507 @@
+import { z } from "zod";
+import { encodeFunctionData, erc20Abi, getAddress, parseUnits, type Hex } from "viem";
+
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { Network } from "../../network";
+import { EvmWalletProvider } from "../../wallet-providers";
+
+import {
+  AGENTTAX_BUILDER_CODE,
+  AGENTTAX_BUILDER_CODE_SUFFIX,
+  DEFAULT_BASE_URL,
+  DEFAULT_TIMEOUT_MS,
+  SUPPORTED_ONCHAIN_NETWORKS,
+  USDC_ADDRESSES,
+  USDC_DECIMALS,
+  type SupportedOnchainNetwork,
+} from "./constants";
+import {
+  CalculateTaxSchema,
+  CheckNexusStatusSchema,
+  Export1099DaSchema,
+  GetLocalRateSchema,
+  RemitTaxOnchainSchema,
+  type AgentTaxConfig,
+} from "./schemas";
+
+/**
+ * Internal, fully-resolved config with all fields populated.
+ */
+interface ResolvedAgentTaxConfig {
+  apiKey: string | undefined;
+  baseUrl: string;
+  reserveWallet: `0x${string}` | undefined;
+  builderCodeEnabled: boolean;
+}
+
+/**
+ * Response shape returned from {@link AgentTaxActionProvider.apiRequest}.
+ */
+interface ApiResult<T> {
+  ok: boolean;
+  status: number;
+  data: T | null;
+  error?: string;
+}
+
+/**
+ * AgentTaxActionProvider exposes the AgentTax tax-compliance API as AgentKit
+ * actions, and ships a tax-compliant USDC remittance action on Base that
+ * attributes every onchain payment back to AgentTax via the Base Builder
+ * Code program (ERC-8021).
+ *
+ * **Public (unauthenticated) actions**
+ * - `calculate_tax` — US sales tax calculation for an agent transaction
+ * - `get_local_rate` — zip-level combined (state + local) rate lookup
+ *
+ * **Authenticated actions** (require `apiKey`)
+ * - `check_nexus_status` — nexus status for the caller's entity across states
+ * - `export_1099_da` — IRS Form 1099-DA export for a tax year
+ *
+ * **Onchain action** (requires `EvmWalletProvider` on Base)
+ * - `remit_tax_onchain` — remit collected sales tax as a USDC transfer with
+ *   the AgentTax Base Builder Code appended to the transaction calldata.
+ *
+ * @example
+ * ```ts
+ * import { AgentKit, agentTaxActionProvider } from "@coinbase/agentkit";
+ *
+ * const agentKit = await AgentKit.from({
+ *   walletProvider,
+ *   actionProviders: [
+ *     agentTaxActionProvider({
+ *       apiKey: process.env.AGENTTAX_API_KEY,
+ *       reserveWallet: "0xYourTreasuryWallet",
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export class AgentTaxActionProvider extends ActionProvider<EvmWalletProvider> {
+  private readonly config: ResolvedAgentTaxConfig;
+
+  /**
+   * Creates a new AgentTaxActionProvider.
+   *
+   * @param config - Optional provider configuration. All fields are optional;
+   * public actions work without an API key, but authenticated and onchain
+   * actions may require additional fields.
+   */
+  constructor(config: AgentTaxConfig = {}) {
+    super("agenttax", []);
+    this.config = {
+      apiKey: config.apiKey ?? process.env.AGENTTAX_API_KEY,
+      baseUrl: (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, ""),
+      reserveWallet: config.reserveWallet,
+      builderCodeEnabled: config.builderCodeEnabled ?? true,
+    };
+  }
+
+  /**
+   * Calculates applicable US sales tax for an agent transaction.
+   *
+   * @param _walletProvider - Unused for this HTTP-only action.
+   * @param args - Calculation inputs (amount, buyer state, transaction type).
+   * @returns JSON string with the tax breakdown, or an error description.
+   */
+  @CreateAction({
+    name: "calculate_tax",
+    description: `
+Calculate applicable US sales tax for an agent transaction using the AgentTax engine.
+
+Returns the base amount, tax amount, combined rate, jurisdiction, classification basis,
+and confidence score. Supports zip-level precision when a buyerZip is provided.
+
+Use this before settling a payment so the agent can collect the correct amount.
+
+Example:
+  calculate_tax({
+    amount: 10,
+    buyerState: "TX",
+    transactionType: "compute",
+    counterpartyId: "agent_abc123"
+  })
+`,
+    schema: CalculateTaxSchema,
+  })
+  async calculateTax(
+    _walletProvider: EvmWalletProvider,
+    args: z.infer<typeof CalculateTaxSchema>,
+  ): Promise<string> {
+    const body = {
+      role: "seller",
+      amount: args.amount,
+      buyer_state: args.buyerState,
+      buyer_zip: args.buyerZip ?? undefined,
+      transaction_type: args.transactionType,
+      counterparty_id: args.counterpartyId,
+      is_b2b: args.isB2B,
+    };
+
+    const result = await this.apiRequest<Record<string, unknown> & { success?: boolean }>(
+      "POST",
+      "/api/v1/calculate",
+      body,
+    );
+
+    if (!result.ok) {
+      return this.formatError("calculate_tax", result);
+    }
+    // AgentTax returns HTTP 200 with { success: false, error } on validation errors.
+    if (result.data && result.data.success === false) {
+      return `Error (calculate_tax): ${String((result.data as { error?: unknown }).error)}`;
+    }
+
+    return JSON.stringify(result.data, null, 2);
+  }
+
+  /**
+   * Looks up zip-level combined sales tax rate.
+   *
+   * @param _walletProvider - Unused for this HTTP-only action.
+   * @param args - The ZIP code to look up.
+   * @returns JSON string with combined rate info, or an error description.
+   */
+  @CreateAction({
+    name: "get_local_rate",
+    description: `
+Look up the combined (state + local) US sales tax rate for a specific ZIP code.
+
+Returns the state rate, local rate, combined rate, jurisdiction, confidence score,
+and source citation. AgentTax's zip_rates table covers ~43,000 US zip codes; if
+your zip is missing, the API returns a fallback suggesting the state-level rate.
+
+Example: get_local_rate({ zip: "77001" })
+`,
+    schema: GetLocalRateSchema,
+  })
+  async getLocalRate(
+    _walletProvider: EvmWalletProvider,
+    args: z.infer<typeof GetLocalRateSchema>,
+  ): Promise<string> {
+    const result = await this.apiRequest<Record<string, unknown> & { success?: boolean }>(
+      "GET",
+      `/api/v1/rates/local?zip=${encodeURIComponent(args.zip)}`,
+    );
+
+    if (!result.ok) {
+      return this.formatError("get_local_rate", result);
+    }
+    if (result.data && result.data.success === false) {
+      // Pass the API's fallback guidance through to the agent verbatim.
+      return JSON.stringify(result.data, null, 2);
+    }
+
+    return JSON.stringify(result.data, null, 2);
+  }
+
+  /**
+   * Checks sales tax nexus status for the configured entity across one or
+   * more states.
+   *
+   * @param _walletProvider - Unused for this HTTP-only action.
+   * @param args - The states to check nexus status for.
+   * @returns JSON string with per-state nexus data, or an error description.
+   */
+  @CreateAction({
+    name: "check_nexus_status",
+    description: `
+Check sales tax nexus status in one or more US states. Returns per-state
+status (triggered, approaching, none) with rate and taxability info.
+
+Without an apiKey, returns AgentTax demo data (entity_id: "demo_entity").
+With an apiKey, returns real nexus data for the authenticated entity.
+
+Example: check_nexus_status({ states: ["TX", "CA", "NY"] })
+`,
+    schema: CheckNexusStatusSchema,
+  })
+  async checkNexusStatus(
+    _walletProvider: EvmWalletProvider,
+    args: z.infer<typeof CheckNexusStatusSchema>,
+  ): Promise<string> {
+    const qs = args.states.map(s => `states=${encodeURIComponent(s)}`).join("&");
+    const result = await this.apiRequest<Record<string, unknown>>("GET", `/api/v1/nexus?${qs}`);
+
+    if (!result.ok) {
+      return this.formatError("check_nexus_status", result);
+    }
+
+    return JSON.stringify(result.data, null, 2);
+  }
+
+  /**
+   * Exports IRS Form 1099-DA data for the configured entity for a tax year.
+   *
+   * @param _walletProvider - Unused for this HTTP-only action.
+   * @param args - The tax year to export.
+   * @returns JSON string with 1099-DA form data, or an error description.
+   */
+  @CreateAction({
+    name: "export_1099_da",
+    description: `
+Export IRS Form 1099-DA draft data for a given tax year. Returns aggregated
+digital asset transaction data mapped to 1099-DA form fields, plus a payer,
+recipient, and per-transaction breakdown.
+
+Without an apiKey, returns AgentTax demo data. With an apiKey, returns data
+for the authenticated entity.
+
+The returned form is a DRAFT for informational purposes — AgentTax does not
+file with the IRS. Verify all figures with a qualified tax professional.
+
+Example: export_1099_da({ year: 2026 })
+`,
+    schema: Export1099DaSchema,
+  })
+  async export1099Da(
+    _walletProvider: EvmWalletProvider,
+    args: z.infer<typeof Export1099DaSchema>,
+  ): Promise<string> {
+    const result = await this.apiRequest<Record<string, unknown>>(
+      "GET",
+      `/api/v1/export/1099-da?year=${args.year}`,
+    );
+
+    if (!result.ok) {
+      return this.formatError("export_1099_da", result);
+    }
+
+    return JSON.stringify(result.data, null, 2);
+  }
+
+  /**
+   * Remits collected sales tax as a USDC transfer on Base, appending the
+   * AgentTax Base Builder Code to the transaction calldata (ERC-8021).
+   *
+   * @param walletProvider - EVM wallet provider on base-mainnet or base-sepolia.
+   * @param args - The remittance parameters (amount, recipient, jurisdiction).
+   * @returns Human-readable confirmation with the onchain transaction hash.
+   */
+  @CreateAction({
+    name: "remit_tax_onchain",
+    description: `
+Remit collected sales tax onchain as a USDC transfer on Base. The transaction
+calldata carries the AgentTax Base Builder Code suffix (ERC-8021) so the
+remittance is attributed to AgentTax for analytics and rewards.
+
+If the optional AgentTax apiKey is configured, the remittance is also logged
+to the AgentTax audit trail (best-effort — failures do not block the transfer).
+
+Supported networks: base-mainnet, base-sepolia.
+
+Use this after calculate_tax to actually move the collected tax to your
+treasury wallet. If recipient is omitted, the provider-configured reserveWallet
+is used.
+
+Example: remit_tax_onchain({ amountUsdc: 2.5, jurisdiction: "TX", reference: "txn_abc123" })
+`,
+    schema: RemitTaxOnchainSchema,
+  })
+  async remitTaxOnchain(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof RemitTaxOnchainSchema>,
+  ): Promise<string> {
+    // 1. Verify network is a supported Base network
+    const network = walletProvider.getNetwork();
+    const networkId = network.networkId;
+    if (!networkId || !SUPPORTED_ONCHAIN_NETWORKS.includes(networkId as SupportedOnchainNetwork)) {
+      return (
+        `Error: remit_tax_onchain only supports base-mainnet and base-sepolia. ` +
+        `Current network: ${networkId ?? "unknown"}.`
+      );
+    }
+
+    // 2. Resolve recipient (param → config default → error)
+    const recipientRaw = args.recipient ?? this.config.reserveWallet;
+    if (!recipientRaw) {
+      return (
+        "Error: no recipient address provided and no reserveWallet configured " +
+        "on the AgentTaxActionProvider. Pass a recipient or set config.reserveWallet."
+      );
+    }
+    let recipient: `0x${string}`;
+    try {
+      recipient = getAddress(recipientRaw) as `0x${string}`;
+    } catch {
+      return `Error: recipient "${recipientRaw}" is not a valid Ethereum address.`;
+    }
+
+    // 3. Get USDC contract for this network
+    const usdcAddress = USDC_ADDRESSES[networkId];
+    if (!usdcAddress) {
+      return `Error: no USDC address configured for network ${networkId}.`;
+    }
+
+    // 4. Encode USDC.transfer calldata and append Builder Code suffix
+    const amountInBaseUnits = parseUnits(String(args.amountUsdc), USDC_DECIMALS);
+    const baseCalldata = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [recipient, amountInBaseUnits],
+    });
+    const data = this.appendBuilderCode(baseCalldata);
+
+    // 5. Submit the transaction
+    let hash: Hex;
+    try {
+      hash = await walletProvider.sendTransaction({
+        to: usdcAddress as Hex,
+        data,
+      });
+      await walletProvider.waitForTransactionReceipt(hash);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return `Error submitting remittance transaction: ${message}`;
+    }
+
+    // 6. Best-effort audit log (only if apiKey is configured)
+    let auditLogged = false;
+    if (this.config.apiKey) {
+      const logResult = await this.apiRequest("POST", "/api/v1/transactions", {
+        kind: "remittance",
+        amount_usdc: args.amountUsdc,
+        recipient,
+        jurisdiction: args.jurisdiction ?? undefined,
+        reference: args.reference ?? undefined,
+        tx_hash: hash,
+        network: networkId,
+        builder_code: AGENTTAX_BUILDER_CODE,
+      });
+      auditLogged = logResult.ok;
+    }
+
+    const lines = [
+      `Remitted ${args.amountUsdc} USDC to ${recipient} on ${networkId}.`,
+      `Transaction hash: ${hash}`,
+      this.config.builderCodeEnabled
+        ? `Builder Code: ${AGENTTAX_BUILDER_CODE} (appended to calldata, ERC-8021)`
+        : "Builder Code: disabled",
+      args.jurisdiction ? `Jurisdiction: ${args.jurisdiction}` : null,
+      args.reference ? `Reference: ${args.reference}` : null,
+      this.config.apiKey
+        ? auditLogged
+          ? "Audit log: recorded in AgentTax"
+          : "Audit log: failed (transfer still succeeded)"
+        : "Audit log: skipped (no apiKey configured)",
+    ].filter(Boolean);
+
+    return lines.join("\n");
+  }
+
+  /**
+   * The AgentTax provider supports all EVM networks for HTTP-only actions
+   * (US sales tax is network-agnostic). The `remit_tax_onchain` action
+   * enforces its own Base-only check at runtime.
+   *
+   * @param network - The network to check.
+   * @returns True if this is an EVM network, false otherwise.
+   */
+  supportsNetwork = (network: Network): boolean => network.protocolFamily === "evm";
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Appends the Builder Code suffix to encoded calldata if attribution is enabled.
+   *
+   * @param calldata - The 0x-prefixed encoded calldata.
+   * @returns The calldata with the Builder Code suffix appended (if enabled).
+   */
+  private appendBuilderCode(calldata: `0x${string}`): `0x${string}` {
+    if (!this.config.builderCodeEnabled) return calldata;
+    // Strip the leading "0x" from the suffix and append its body to calldata.
+    return `${calldata}${AGENTTAX_BUILDER_CODE_SUFFIX.slice(2)}` as `0x${string}`;
+  }
+
+  /**
+   * Formats a failed ApiResult into a user-facing error string.
+   *
+   * @param actionName - The name of the calling action.
+   * @param result - The failed ApiResult.
+   * @returns A descriptive error message.
+   */
+  private formatError(actionName: string, result: ApiResult<unknown>): string {
+    const detail = result.error ?? JSON.stringify(result.data);
+    return `Error (${actionName}): HTTP ${result.status} — ${detail}`;
+  }
+
+  /**
+   * Sends an HTTP request to the AgentTax API with timeout and error handling.
+   *
+   * @param method - HTTP method.
+   * @param path - API path, starting with /.
+   * @param body - Optional JSON body (for POST/PUT).
+   * @returns An {@link ApiResult} describing the outcome.
+   */
+  private async apiRequest<T>(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    path: string,
+    body?: unknown,
+  ): Promise<ApiResult<T>> {
+    const url = `${this.config.baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (method !== "GET") headers["Content-Type"] = "application/json";
+    if (this.config.apiKey) headers["X-API-Key"] = this.config.apiKey;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+
+      let data: T | null = null;
+      const text = await response.text();
+      if (text) {
+        try {
+          data = JSON.parse(text) as T;
+        } catch {
+          return {
+            ok: false,
+            status: response.status,
+            data: null,
+            error: `Non-JSON response: ${text.slice(0, 200)}`,
+          };
+        }
+      }
+
+      if (!response.ok) {
+        const errorMessage =
+          data && typeof data === "object" && data !== null && "error" in data
+            ? String((data as { error?: unknown }).error)
+            : response.statusText;
+        return { ok: false, status: response.status, data, error: errorMessage };
+      }
+
+      return { ok: true, status: response.status, data };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        ok: false,
+        status: 0,
+        data: null,
+        error: `Network error: ${message}`,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+/**
+ * Factory function for {@link AgentTaxActionProvider}.
+ *
+ * @param config - Optional configuration.
+ * @returns A new {@link AgentTaxActionProvider} instance.
+ */
+export const agentTaxActionProvider = (config?: AgentTaxConfig) =>
+  new AgentTaxActionProvider(config);

--- a/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/agenttax/agentTaxActionProvider.ts
@@ -222,10 +222,16 @@ Example: check_nexus_status({ states: ["TX", "CA", "NY"] })
     args: z.infer<typeof CheckNexusStatusSchema>,
   ): Promise<string> {
     const qs = args.states.map(s => `states=${encodeURIComponent(s)}`).join("&");
-    const result = await this.apiRequest<Record<string, unknown>>("GET", `/api/v1/nexus?${qs}`);
+    const result = await this.apiRequest<Record<string, unknown> & { success?: boolean }>(
+      "GET",
+      `/api/v1/nexus?${qs}`,
+    );
 
     if (!result.ok) {
       return this.formatError("check_nexus_status", result);
+    }
+    if (result.data && result.data.success === false) {
+      return `Error (check_nexus_status): ${String((result.data as { error?: unknown }).error)}`;
     }
 
     return JSON.stringify(result.data, null, 2);
@@ -259,13 +265,16 @@ Example: export_1099_da({ year: 2026 })
     _walletProvider: EvmWalletProvider,
     args: z.infer<typeof Export1099DaSchema>,
   ): Promise<string> {
-    const result = await this.apiRequest<Record<string, unknown>>(
+    const result = await this.apiRequest<Record<string, unknown> & { success?: boolean }>(
       "GET",
       `/api/v1/export/1099-da?year=${args.year}`,
     );
 
     if (!result.ok) {
       return this.formatError("export_1099_da", result);
+    }
+    if (result.data && result.data.success === false) {
+      return `Error (export_1099_da): ${String((result.data as { error?: unknown }).error)}`;
     }
 
     return JSON.stringify(result.data, null, 2);

--- a/typescript/agentkit/src/action-providers/agenttax/constants.ts
+++ b/typescript/agentkit/src/action-providers/agenttax/constants.ts
@@ -1,0 +1,52 @@
+/**
+ * AgentTax Base Builder Code (ERC-8021).
+ *
+ * Registered at https://dashboard.base.org. Appended to the calldata of every
+ * onchain transaction this provider executes so that AgentTax-attributed
+ * activity is discoverable in the Base developer dashboard and eligible
+ * for any Base ecosystem rewards program.
+ *
+ * Format: `[ascii builder code][length byte = 0x0b][ERC-8021 magic 0x8021 pattern]`
+ * Gas overhead: ~450 gas per transaction (16 gas per non-zero byte).
+ */
+export const AGENTTAX_BUILDER_CODE = "bc_626v2pr2";
+export const AGENTTAX_BUILDER_CODE_SUFFIX =
+  "0x62635f36323676327072320b0080218021802180218021802180218021" as `0x${string}`;
+
+/**
+ * Default AgentTax API base URL.
+ */
+export const DEFAULT_BASE_URL = "https://agenttax.io";
+
+/**
+ * Default HTTP request timeout in milliseconds.
+ * AgentTax API is designed to respond within a few hundred ms; a 10s ceiling
+ * is generous enough to cover cold starts and temporary network hiccups
+ * without hanging an agent run.
+ */
+export const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Canonical USDC token addresses on supported Base networks.
+ * Used by {@link remitTaxOnchain} when constructing the transfer calldata.
+ *
+ * Base mainnet USDC: https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913
+ * Base sepolia USDC: https://sepolia.basescan.org/token/0x036cbd53842c5426634e7929541ec2318f3dcf7e
+ */
+export const USDC_ADDRESSES: Record<string, `0x${string}`> = {
+  "base-mainnet": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "base-sepolia": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+};
+
+/**
+ * USDC has 6 decimals on all supported networks.
+ */
+export const USDC_DECIMALS = 6;
+
+/**
+ * Networks where the onchain `remit_tax_onchain` action is supported.
+ * HTTP-only actions are network-agnostic — they work anywhere the agent runs.
+ */
+export const SUPPORTED_ONCHAIN_NETWORKS = ["base-mainnet", "base-sepolia"] as const;
+
+export type SupportedOnchainNetwork = (typeof SUPPORTED_ONCHAIN_NETWORKS)[number];

--- a/typescript/agentkit/src/action-providers/agenttax/index.ts
+++ b/typescript/agentkit/src/action-providers/agenttax/index.ts
@@ -1,0 +1,7 @@
+export * from "./agentTaxActionProvider";
+export type { AgentTaxConfig } from "./schemas";
+export {
+  AGENTTAX_BUILDER_CODE,
+  AGENTTAX_BUILDER_CODE_SUFFIX,
+  SUPPORTED_ONCHAIN_NETWORKS,
+} from "./constants";

--- a/typescript/agentkit/src/action-providers/agenttax/schemas.ts
+++ b/typescript/agentkit/src/action-providers/agenttax/schemas.ts
@@ -1,0 +1,165 @@
+import { z } from "zod";
+
+/**
+ * Configuration for {@link AgentTaxActionProvider}.
+ */
+export interface AgentTaxConfig {
+  /**
+   * AgentTax API key. Required for the authenticated actions
+   * (`check_nexus_status`, `export_1099_da`, `remit_tax_onchain`).
+   *
+   * Public actions (`calculate_tax`, `get_local_rate`) work without a key.
+   *
+   * Get one at https://agenttax.io/dashboard or via
+   * `AGENTTAX_API_KEY` environment variable.
+   */
+  apiKey?: string;
+
+  /**
+   * Override the AgentTax API base URL. Defaults to {@link DEFAULT_BASE_URL}.
+   * Useful for staging or self-hosted deployments.
+   */
+  baseUrl?: string;
+
+  /**
+   * Default treasury wallet address used by `remit_tax_onchain` when no
+   * explicit recipient is supplied by the caller.
+   */
+  reserveWallet?: `0x${string}`;
+
+  /**
+   * Whether to append the AgentTax Base Builder Code to onchain transactions.
+   * Defaults to `true`. Disable only if you explicitly want to attribute
+   * transactions to a different builder.
+   */
+  builderCodeEnabled?: boolean;
+}
+
+const UsStateSchema = z
+  .string()
+  .length(2)
+  .toUpperCase()
+  .describe("Two-letter US state code (e.g. 'TX', 'NY', 'CA')");
+
+const UsZipSchema = z
+  .string()
+  .regex(/^\d{5}(-\d{4})?$/, "Must be a 5- or 9-digit US ZIP code")
+  .describe("US ZIP code (5- or 9-digit)");
+
+const EvmAddressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format");
+
+/**
+ * Valid `transaction_type` values accepted by the AgentTax `/api/v1/calculate`
+ * endpoint. The engine derives `work_type` internally from `transaction_type`.
+ */
+export const TRANSACTION_TYPES = [
+  "compute",
+  "api_access",
+  "data_purchase",
+  "saas",
+  "ai_labor",
+  "storage",
+  "digital_good",
+  "consulting",
+  "data_processing",
+  "cloud_infrastructure",
+  "ai_model_access",
+  "marketplace_fee",
+  "subscription",
+  "license",
+  "service",
+] as const;
+
+/**
+ * Input schema for the `calculate_tax` action.
+ *
+ * Matches the current AgentTax `/api/v1/calculate` request contract:
+ * `role`, `amount`, `buyer_state`, `transaction_type`, and `counterparty_id`
+ * are required; `buyer_zip` and `is_b2b` are optional.
+ */
+export const CalculateTaxSchema = z
+  .object({
+    amount: z
+      .number()
+      .positive()
+      .describe("Transaction amount in whole USD (e.g. 12.5 for $12.50)"),
+    buyerState: UsStateSchema,
+    buyerZip: UsZipSchema.nullable().describe(
+      "Optional US ZIP code — enables zip-level local rate precision where available",
+    ),
+    transactionType: z
+      .enum(TRANSACTION_TYPES)
+      .describe(
+        "Category of the transaction — drives the AgentTax taxability matrix. " +
+          "Valid values: " +
+          TRANSACTION_TYPES.join(", "),
+      ),
+    counterpartyId: z
+      .string()
+      .min(1)
+      .describe(
+        "Buyer identifier for audit trail (e.g. wallet address, agent ID). " +
+          "Required by the AgentTax API.",
+      ),
+    isB2B: z
+      .boolean()
+      .nullable()
+      .transform(val => val ?? false)
+      .describe("Whether this is a business-to-business transaction. Defaults to false."),
+  })
+  .describe("Calculate applicable US sales tax for an agent transaction");
+
+/**
+ * Input schema for the `get_local_rate` action.
+ */
+export const GetLocalRateSchema = z
+  .object({
+    zip: UsZipSchema,
+  })
+  .describe("Look up zip-level combined (state + local) sales tax rate");
+
+/**
+ * Input schema for the `check_nexus_status` action.
+ */
+export const CheckNexusStatusSchema = z
+  .object({
+    states: z.array(UsStateSchema).min(1).describe("States to check sales tax nexus status for"),
+  })
+  .describe(
+    "Check whether the configured entity has triggered sales tax nexus in the given states",
+  );
+
+/**
+ * Input schema for the `export_1099_da` action.
+ */
+export const Export1099DaSchema = z
+  .object({
+    year: z.number().int().min(2020).max(2099).describe("Tax year (e.g. 2026)"),
+  })
+  .describe("Export IRS Form 1099-DA data for the configured entity for a tax year");
+
+/**
+ * Input schema for the `remit_tax_onchain` action.
+ */
+export const RemitTaxOnchainSchema = z
+  .object({
+    amountUsdc: z
+      .number()
+      .positive()
+      .describe("Amount of USDC to remit, in whole units (e.g. 1.25 for $1.25)"),
+    recipient: EvmAddressSchema.nullable().describe(
+      "Recipient wallet. Defaults to the provider-configured reserveWallet if omitted.",
+    ),
+    jurisdiction: UsStateSchema.nullable().describe(
+      "Optional two-letter state code identifying the jurisdiction this remittance covers",
+    ),
+    reference: z
+      .string()
+      .max(64)
+      .nullable()
+      .describe("Optional external reference (e.g. AgentTax transaction_id) for audit trail"),
+  })
+  .describe(
+    "Remit collected sales tax as a USDC transfer on Base. " +
+      "Appends the AgentTax Base Builder Code to transaction calldata for attribution.",
+  );

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -4,6 +4,7 @@ export * from "./actionProvider";
 export * from "./customActionProvider";
 
 export * from "./across";
+export * from "./agenttax";
 export * from "./alchemy";
 export * from "./baseAccount";
 export * from "./basename";


### PR DESCRIPTION
## Summary

Adds `AgentTaxActionProvider` so AgentKit agents can handle US sales tax compliance end-to-end on Base. The new `remit_tax_onchain` action appends the AgentTax Base Builder Code (`bc_626v2pr2`) to USDC transfer calldata via ERC-8021 for attribution in the Base developer dashboard.

### Why

Agent marketplaces, x402 micropayment services, and autonomous commerce platforms on Base have a shared unsolved problem: who collects and remits sales tax on these transactions? As agent-to-agent commerce grows, more of the AgentKit ecosystem is accepting USDC for digital goods and services — but none of it currently has a compliance layer.

[AgentTax](https://agenttax.io) is a compliance API purpose-built for the agent economy (51-jurisdiction sales tax engine, ~43,000 zip-level local rates, IRS 1099-DA export, nexus monitoring). This action provider lets any AgentKit agent use it natively.

### Actions

| Action | Auth | Onchain |
|---|---|---|
| `calculate_tax` | Optional | No |
| `get_local_rate` | Optional | No |
| `check_nexus_status` | Optional (demo mode without) | No |
| `export_1099_da` | Optional (demo mode without) | No |
| `remit_tax_onchain` | Optional (audit log if set) | Yes — Base |

Public actions work without an API key. Authenticated actions fall back to AgentTax demo data without a key and return real data for the configured entity when a key is provided.

### Base Builder Code integration

The `remit_tax_onchain` action appends the ERC-8021 suffix

`0x62635f36323676327072320b0080218021802180218021802180218021`

to the USDC transfer calldata. Decoded: `bc_626v2pr2` (ASCII) + length byte (`0x0b`) + 8021 magic pattern. Gas overhead is ~450 gas per transaction (16 gas per non-zero byte). Smart contracts ignore the trailing bytes, so the transfer behaves normally.

Attribution can be opted out via `builderCodeEnabled: false` in the provider config. Registered via https://dashboard.base.org.

### Testing

- **37 unit tests**, all passing
  - Schema validation including the real `transaction_type` enum, state code normalization, ZIP format, required `counterparty_id`
  - ERC-8021 Builder Code encoding round-trip test (decodes `[ascii code][length byte][magic pattern]`)
  - All 5 actions: happy path, HTTP error, `success: false` body handling, and network failure paths
  - `remit_tax_onchain` assertions: USDC transfer selector, correct per-network USDC address, Builder Code suffix presence, opt-out behavior, audit log on/off, recipient validation, non-Base network rejection
  - `supportsNetwork` across EVM/non-EVM
- **Full suite: 901 / 901 passing** (no regressions)
- **E2E smoke tested** against the live AgentTax API — verified request body shape matches the `/api/v1/calculate` contract and response parses cleanly
- Type-check, ESLint, and Prettier all clean

### Usage

```typescript
import { AgentKit, agentTaxActionProvider } from "@coinbase/agentkit";

const agentKit = await AgentKit.from({
  walletProvider,
  actionProviders: [
    agentTaxActionProvider({
      apiKey: process.env.AGENTTAX_API_KEY,    // optional
      reserveWallet: "0xYourTreasuryWallet",   // default recipient for remit
    }),
  ],
});

// Typical agent flow:
// 1. calculate_tax        - determine collection amount
// 2. collect payment      - via erc20 / x402 / your payment flow
// 3. remit_tax_onchain    - transfer collected tax (Builder Code attached)
```

Full README with per-action docs: `typescript/agentkit/src/action-providers/agenttax/README.md`

### Links

- AgentTax: https://agenttax.io
- Base Builder Codes: https://docs.base.org/base-chain/builder-codes/builder-codes
- ERC-8021: https://eips.ethereum.org/EIPS/eip-8021

### Checklist

- [x] Provider added under `typescript/agentkit/src/action-providers/agenttax/`
- [x] Registered export in `src/action-providers/index.ts`
- [x] Added `.changeset/add-agenttax-action-provider.md`
- [x] Added README with usage examples
- [x] 37 unit tests cover all actions, schemas, and Builder Code encoding
- [x] Full suite passes (901 / 901)
- [x] Type-check passes
- [x] ESLint + Prettier clean
- [x] E2E smoke tested against live AgentTax API