### PR TITLE
fix: update legacy CDP wallet provider references in docs and generator

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -28,17 +28,17 @@ body:
       from coinbase_agentkit import (
           AgentKit, 
           AgentKitConfig, 
-          CdpWalletProvider,
-          CdpWalletProviderConfig,
+          CdpEvmWalletProvider,
+          CdpEvmWalletProviderConfig,
           erc20_action_provider
       )
       from coinbase_agentkit_langchain import get_langchain_tools
 
       # A succinct reproducing example trimmed down to the essential parts:
-      cdp_config = CdpWalletProviderConfig(
+      cdp_config = CdpEvmWalletProviderConfig(
           network_id="base-sepolia"
       )
-      wallet_provider = CdpWalletProvider(cdp_config)
+      wallet_provider = CdpEvmWalletProvider(cdp_config)
       agentkit = AgentKit(AgentKitConfig(
           wallet_provider=wallet_provider,
           action_providers=[
@@ -49,20 +49,20 @@ body:
       ```
 
       ```typescript
-      # All necessary imports at the beginning
-      import { AgentKit, CdpWalletProvider, cdpWalletActionProvider } from '@coinbase/agentkit';
+      // All necessary imports at the beginning
+      import { AgentKit, CdpEvmWalletProvider, walletActionProvider } from '@coinbase/agentkit';
       import { getLangChainTools } from '@coinbase/agentkit-langchain';
 
-      # A succinct reproducing example trimmed down to the essential parts:
+      // A succinct reproducing example trimmed down to the essential parts:
       const config = {
         networkId: "base-sepolia"
       };
 
-      const walletProvider = await CdpWalletProvider.configureWithWallet(config);
+      const walletProvider = await CdpEvmWalletProvider.configureWithWallet(config);
       const agentkit = await AgentKit.from({
         walletProvider,
         actionProviders: [
-          cdpWalletActionProvider()
+          walletActionProvider()
         ]
       });
 

--- a/CONTRIBUTING-PYTHON.md
+++ b/CONTRIBUTING-PYTHON.md
@@ -108,11 +108,14 @@ This says that the input schema has two fields: `contract_address` and `destinat
 ### Implementing the action provider
 
 ```python
-class CdpWalletActionProvider(ActionProvider[CdpWalletProvider]):
-    """Provides actions for interacting with CDP wallets."""
+from coinbase_agentkit import ActionProvider, EvmWalletProvider
+from coinbase_agentkit.network import Network
+
+class Erc721ActionProvider(ActionProvider[EvmWalletProvider]):
+    """Provides ERC-721 actions for EVM wallets."""
 
     def __init__(self):
-        super().__init__("cdp-wallet", [])
+        super().__init__("erc721", [])
 
     def supports_network(self, network: Network) -> bool:
         return network.protocol_family == "evm"
@@ -123,6 +126,11 @@ class CdpWalletActionProvider(ActionProvider[CdpWalletProvider]):
 Now we need to implement the actual function that the AI will call when using your action. Actions are defined using the `@create_action` decorator. The function receives as input the wallet provider that the Agent has access to, along with the inputs defined in the input schema, and it must return a string. Here's an example of the Mint NFT implementation:
 
 ```python
+from eth_typing import HexStr
+from web3 import Web3
+
+from coinbase_agentkit import EvmWalletProvider, create_action
+
 @create_action(
     name="mint",
     description="""
@@ -132,20 +140,27 @@ Do not use the contract address as the destination address. If you are unsure of
     """,
     schema=MintSchema,
 )
-def mint(self, wallet_provider: CdpWalletProvider, args: dict[str, Any]) -> str:
+def mint(self, wallet_provider: EvmWalletProvider, args: dict[str, Any]) -> str:
     """Mint an NFT."""
     try:
-        nft_contract = wallet_provider.mint(
-            contract_address=args["contract_address"],
-            destination=args["destination"]
-        ).wait()
-    except Exception as e:
-        return f"Error deploying NFT {e!s}"
+        contract = Web3().eth.contract(address=args["contract_address"], abi=ERC721_ABI)
+        data = contract.encode_abi("mint", args=[args["destination"], 1])
 
-    return f"Minted NFT to address {args['destination']}.\nTransaction hash: {nft_contract.transaction.transaction_hash}\nTransaction link: {nft_contract.transaction.transaction_link}"
+        tx_hash = wallet_provider.send_transaction(
+            {
+                "to": HexStr(args["contract_address"]),
+                "data": HexStr(data),
+            }
+        )
+
+        wallet_provider.wait_for_transaction_receipt(tx_hash)
+    except Exception as e:
+        return f"Error minting NFT {args['contract_address']} to {args['destination']}: {e!s}"
+
+    return f"Successfully minted NFT {args['contract_address']} to {args['destination']}"
 ```
 
-Notice the return value contains useful information for the user, such as the transaction hash and link. It's important to include this information in the return value so that the user can easily see the result of the action.
+Notice the return value contains useful information for the user about the result of the action. When possible, include details such as transaction hashes so the user can inspect what happened onchain.
 
 This class is then exported out of [python/coinbase-agentkit/coinbase_agentkit/\_\_init\_\_.py](https://github.com/coinbase/agentkit/blob/master/python/coinbase-agentkit/coinbase_agentkit/__init__.py) so that it is consumable by users of the `coinbase-agentkit` package.
 

--- a/python/coinbase-agentkit/README.md
+++ b/python/coinbase-agentkit/README.md
@@ -32,7 +32,6 @@ AgentKit is a framework for easily enabling AI agents to take actions onchain. I
   - [EthAccountWalletProvider](#ethaccountwalletprovider)
     - [Configuring gas parameters](#configuring-ethaccountwalletprovider-gas-parameters)
     - [Configuring `EthAccountWalletProvider` rpc url](#configuring-ethaccountwalletprovider-rpc-url)
-  - [SmartWalletProvider](#smartwalletprovider)
   - [CdpSolanaWalletProvider](#cdpsolanawalletprovider)
     - [Configuring with API credentials](#configuring-with-api-credentials)
     - [Using environment variables](#using-environment-variables)
@@ -56,10 +55,10 @@ pip install coinbase-agentkit
 
 ### Create an AgentKit instance
 
-If no wallet or action providers are specified, the agent will use the `CdpWalletProvider` and `WalletActionProvider` action provider by default.
+If no wallet or action providers are specified, the agent will use the `CdpEvmWalletProvider` and `WalletActionProvider` action provider by default. Make sure `CDP_API_KEY_ID`, `CDP_API_KEY_SECRET`, and `CDP_WALLET_SECRET` are set in your environment if you rely on this default.
 
 ```python
-from coinbase_agentkit import AgentKit, AgentKitConfig
+from coinbase_agentkit import AgentKit
 
 agent_kit = AgentKit()
 ```
@@ -70,13 +69,14 @@ agent_kit = AgentKit()
 from coinbase_agentkit import (
     AgentKit,
     AgentKitConfig,
-    CdpWalletProvider,
-    CdpWalletProviderConfig
+    CdpEvmWalletProvider,
+    CdpEvmWalletProviderConfig,
 )
 
-wallet_provider = CdpWalletProvider(CdpWalletProviderConfig(
+wallet_provider = CdpEvmWalletProvider(CdpEvmWalletProviderConfig(
     api_key_id="CDP API KEY NAME",
     api_key_secret="CDP API KEY SECRET",
+    wallet_secret="CDP WALLET SECRET",
     network_id="base-mainnet"
 ))
 
@@ -98,10 +98,7 @@ from coinbase_agentkit import (
 agent_kit = AgentKit(AgentKitConfig(
     wallet_provider=wallet_provider,
     action_providers=[
-        cdp_api_action_provider(
-            api_key_id="CDP API KEY NAME",
-            api_key_secret="CDP API KEY SECRET"
-        ),
+        cdp_api_action_provider(),
         pyth_action_provider()
     ]
 ))
@@ -952,43 +949,6 @@ wallet_provider = EthAccountWalletProvider(
         rpc_url="https://sepolia.base.org",
     )
 )
-
-agent_kit = AgentKit(AgentKitConfig(
-    wallet_provider=wallet_provider
-))
-```
-
-### CDPSmartWalletProvider
-
-The `CDPSmartWalletProvider` is a wallet provider that uses [CDP Smart Wallets](https://docs.cdp.coinbase.com/wallet-api/docs/smart-wallets).
-
-```python
-import os
-from eth_account import Account
-
-from coinbase_agentkit import (
-    AgentKit,
-    AgentKitConfig,
-    SmartWalletProvider,
-    SmartWalletProviderConfig
-)
-
-# See here for creating a private key:
-# https://web3py.readthedocs.io/en/stable/web3.eth.account.html#creating-a-private-key
-private_key = os.environ.get("PRIVATE_KEY")
-assert private_key is not None, "You must set PRIVATE_KEY environment variable"
-assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"
-
-signer = Account.from_key(private_key)
-
-network_id = os.getenv("NETWORK_ID", "base-sepolia")
-
-wallet_provider = SmartWalletProvider(SmartWalletProviderConfig(
-    network_id=network_id,
-    signer=signer,
-    smart_wallet_address=None, # If not provided, a new smart wallet will be created
-    paymaster_url=None, # Sponsor transactions: https://docs.cdp.coinbase.com/paymaster/docs/welcome
-))
 
 agent_kit = AgentKit(AgentKitConfig(
     wallet_provider=wallet_provider

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/compound/README.md
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/compound/README.md
@@ -61,7 +61,10 @@ from coinbase_agentkit.action_providers.compound.compound_action_provider import
     CompoundActionProvider,
 )
 from coinbase_agentkit.action_providers.weth.weth_action_provider import WethActionProvider
-from coinbase_agentkit.wallet_providers import CdpWalletProvider
+from coinbase_agentkit.wallet_providers import (
+    CdpEvmWalletProvider,
+    CdpEvmWalletProviderConfig,
+)
 
 # Constants
 USDC_ASSET = "usdc"
@@ -71,7 +74,7 @@ WAIT_TIME = 15
 @pytest.fixture
 def wallet():
     """Create a real wallet instance for testing using the CDP wallet provider."""
-    return CdpWalletProvider()
+    return CdpEvmWalletProvider(CdpEvmWalletProviderConfig())
 
 @pytest.fixture
 def compound_provider():

--- a/python/framework-extensions/autogen/README.md
+++ b/python/framework-extensions/autogen/README.md
@@ -22,7 +22,8 @@ Set the following environment variables:
 ```bash
 export OPENAI_API_KEY=<your-openai-api-key>
 export CDP_API_KEY_ID=<your-cdp-api-key-id>
-export CDP_API_KEY_PRIVATE=<your-cdp-api-key-private>
+export CDP_API_KEY_SECRET=<your-cdp-api-key-secret>
+export CDP_WALLET_SECRET=<your-cdp-wallet-secret>
 ```
 
 ## Usage

--- a/python/framework-extensions/langchain/README.md
+++ b/python/framework-extensions/langchain/README.md
@@ -22,7 +22,8 @@ Set the following environment variables:
 ```bash
 export OPENAI_API_KEY=<your-openai-api-key>
 export CDP_API_KEY_ID=<your-cdp-api-key-id>
-export CDP_API_KEY_PRIVATE=<your-cdp-api-key-private>
+export CDP_API_KEY_SECRET=<your-cdp-api-key-secret>
+export CDP_WALLET_SECRET=<your-cdp-wallet-secret>
 ```
 
 ## Usage

--- a/python/framework-extensions/openai-agents-sdk/README.md
+++ b/python/framework-extensions/openai-agents-sdk/README.md
@@ -22,7 +22,8 @@ Set the following environment variables:
 ```bash
 export OPENAI_API_KEY=<your-openai-api-key>
 export CDP_API_KEY_ID=<your-cdp-api-key-id>
-export CDP_API_KEY_PRIVATE=<your-cdp-api-key-private>
+export CDP_API_KEY_SECRET=<your-cdp-api-key-secret>
+export CDP_WALLET_SECRET=<your-cdp-wallet-secret>
 ```
 
 ## Usage

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -9,7 +9,7 @@ AgentKit is a framework for easily enabling AI agents to take actions onchain. I
   - [Getting Started](#getting-started)
   - [Installation](#installation)
   - [Usage](#usage)
-    - [Create an AgentKit instance. If no wallet or action providers are specified, the agent will use the `CdpWalletProvider` and `WalletProvider` action provider.](#create-an-agentkit-instance-if-no-wallet-or-action-providers-are-specified-the-agent-will-use-the-cdpwalletprovider-and-walletprovider-action-provider)
+    - [Create an AgentKit instance with the default smart wallet provider.](#create-an-agentkit-instance-with-the-default-smart-wallet-provider)
     - [Create an AgentKit instance](#create-an-agentkit-instance)
     - [Create an AgentKit instance with a specified wallet provider.](#create-an-agentkit-instance-with-a-specified-wallet-provider)
     - [Create an AgentKit instance with a specified action providers.](#create-an-agentkit-instance-with-a-specified-action-providers)
@@ -45,13 +45,12 @@ AgentKit is a framework for easily enabling AI agents to take actions onchain. I
     - [Supported Operations](#supported-operations)
       - [Authorization Keys](#authorization-keys)
       - [Exporting Privy Wallet information](#exporting-privy-wallet-information)
-    - [SmartWalletProvider](#smartwalletprovider)
     - [ZeroDevWalletProvider](#zerodevwalletprovider)
-      - [Configuring from CdpWalletProvider](#configuring-from-cdpwalletprovider)
+      - [Configuring from CdpEvmWalletProvider](#configuring-from-cdpevmwalletprovider)
       - [Configuring from PrivyWalletProvider](#configuring-from-privywalletprovider)
       - [Configuring from ViemWalletProvider](#configuring-from-viemwalletprovider)
   - [SVM Wallet Providers](#svm-wallet-providers)
-    - [CdpV2SolanaWalletProvider](#cdpv2solanawalletprovider)
+    - [CdpSolanaWalletProvider](#cdpsolanawalletprovider)
       - [Basic Configuration](#basic-configuration-2)
       - [Using an Existing Wallet](#using-an-existing-wallet-1)
       - [Creating a New Wallet](#creating-a-new-wallet-1)
@@ -81,34 +80,39 @@ npm install @coinbase/agentkit
 
 ## Usage
 
-### Create an AgentKit instance. If no wallet or action providers are specified, the agent will use the `CdpWalletProvider` and `WalletProvider` action provider.
+### Create an AgentKit instance with the default smart wallet provider.
+
+If no wallet or action providers are specified, the agent will use `CdpSmartWalletProvider` and `WalletActionProvider` by default.
 
 ```typescript
 const agentKit = await AgentKit.from({
   cdpApiKeyId: "CDP API KEY NAME",
   cdpApiKeySecret: "CDP API KEY SECRET",
+  cdpWalletSecret: "CDP WALLET SECRET",
 });
 ```
 
 ### Create an AgentKit instance
 
-If no wallet or action provider are specified, the agent will use the `CdpWalletProvider` and `WalletActionProvider` action provider by default.
+If no wallet or action provider are specified, the agent will use the `CdpSmartWalletProvider` and `WalletActionProvider` action provider by default.
 
 ```typescript
 const agentKit = await AgentKit.from({
   cdpApiKeyId: "CDP API KEY NAME",
   cdpApiKeySecret: "CDP API KEY SECRET",
+  cdpWalletSecret: "CDP WALLET SECRET",
 });
 ```
 
 ### Create an AgentKit instance with a specified wallet provider.
 
 ```typescript
-import { CdpWalletProvider } from "@coinbase/agentkit";
+import { CdpEvmWalletProvider } from "@coinbase/agentkit";
 
-const walletProvider = await CdpWalletProvider.configureWithWallet({
+const walletProvider = await CdpEvmWalletProvider.configureWithWallet({
   apiKeyId: "CDP API KEY NAME",
-  apiKeyPrivate: "CDP API KEY SECRET",
+  apiKeySecret: "CDP API KEY SECRET",
+  walletSecret: "CDP WALLET SECRET",
   networkId: "base-mainnet",
 });
 
@@ -125,10 +129,7 @@ import { cdpApiActionProvider, pythActionProvider } from "@coinbase/agentkit";
 const agentKit = await AgentKit.from({
   walletProvider,
   actionProviders: [
-    cdpApiActionProvider({
-      apiKeyId: "CDP API KEY NAME",
-      apiKeyPrivate: "CDP API KEY SECRET",
-    }),
+    cdpApiActionProvider(),
     pythActionProvider(),
   ],
 });
@@ -963,9 +964,10 @@ class MyActionProvider extends ActionProvider<WalletProvider> {
 This gives your agent access to the actions defined in the action provider.
 
 ```typescript
-const agentKit = new AgentKit({
+const agentKit = await AgentKit.from({
   cdpApiKeyId: "CDP API KEY NAME",
   cdpApiKeySecret: "CDP API KEY SECRET",
+  cdpWalletSecret: "CDP WALLET SECRET",
   actionProviders: [myActionProvider()],
 });
 ```
@@ -1317,28 +1319,6 @@ const walletData = await walletProvider.exportWallet();
 }
 ```
 
-### SmartWalletProvider
-
-The `SmartWalletProvider` is a wallet provider that uses [CDP Smart Wallets](https://docs.cdp.coinbase.com/wallet-api/docs/smart-wallets).
-
-```typescript
-import { SmartWalletProvider, SmartWalletConfig } from "@coinbase/agentkit";
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-
-const networkId = process.env.NETWORK_ID || "base-sepolia";
-
-const privateKey = process.env.PRIVATE_KEY || generatePrivateKey();
-const signer = privateKeyToAccount(privateKey);
-
-// Configure Wallet Provider
-const walletProvider = await SmartWalletProvider.configureWithWallet({
-  networkId,
-  signer,
-  smartWalletAddress: undefined, // If not provided a new smart wallet will be created
-  paymasterUrl: undefined, // Sponsor transactions: https://docs.cdp.coinbase.com/paymaster/docs/welcome
-});
-```
-
 ### ZeroDevWalletProvider
 
 The `ZeroDevWalletProvider` is a wallet provider that uses [ZeroDev](https://docs.zerodev.app/) smart accounts. It supports features like chain abstraction, gasless transactions, batched transactions, and more.
@@ -1347,15 +1327,16 @@ In the context of Agent Kit, "chain abstraction" means that the agent can spend 
 
 The ZeroDev wallet provider does not itself manage keys. Rather, it can be used with any EVM wallet provider (e.g. CDP/Privy/Viem) which serves as the "signer" for the ZeroDev smart account.
 
-#### Configuring from CdpWalletProvider
+#### Configuring from CdpEvmWalletProvider
 
 ```typescript
-import { ZeroDevWalletProvider, CdpWalletProvider } from "@coinbase/agentkit";
+import { ZeroDevWalletProvider, CdpEvmWalletProvider } from "@coinbase/agentkit";
 
 // First create a CDP wallet provider as the signer
-const cdpWalletProvider = await CdpWalletProvider.configureWithWallet({
+const cdpWalletProvider = await CdpEvmWalletProvider.configureWithWallet({
   apiKeyId: "CDP API KEY NAME",
-  apiKeyPrivate: "CDP API KEY SECRET",
+  apiKeySecret: "CDP API KEY SECRET",
+  walletSecret: "CDP WALLET SECRET",
   networkId: "base-mainnet",
 });
 
@@ -1423,20 +1404,20 @@ Wallet providers give an agent access to a wallet. AgentKit currently supports t
 
 SVM:
 
-- [CdpV2SolanaWalletProvider](https://github.com/coinbase/agentkit/blob/main/typescript/agentkit/src/wallet-providers/cdpV2SolanaWalletProvider.ts)
+- [CdpSolanaWalletProvider](https://github.com/coinbase/agentkit/blob/main/typescript/agentkit/src/wallet-providers/cdpSolanaWalletProvider.ts)
 - [SolanaKeypairWalletProvider](https://github.com/coinbase/agentkit/blob/main/typescript/agentkit/src/wallet-providers/solanaKeypairWalletProvider.ts)
 - [PrivyWalletProvider](https://github.com/coinbase/agentkit/blob/main/typescript/agentkit/src/wallet-providers/privySvmWalletProvider.ts)
 
-### CdpV2SolanaWalletProvider
+### CdpSolanaWalletProvider
 
-The `CdpV2SolanaWalletProvider` is a wallet provider that uses the Coinbase Developer Platform (CDP) V2 API for Solana. It provides a more modern and streamlined interface for interacting with CDP wallets on the Solana network.
+The `CdpSolanaWalletProvider` is a wallet provider that uses the Coinbase Developer Platform (CDP) Wallet API for Solana. It provides a streamlined interface for interacting with CDP wallets on the Solana network.
 
 #### Basic Configuration
 
 ```typescript
-import { CdpV2SolanaWalletProvider } from "@coinbase/agentkit";
+import { CdpSolanaWalletProvider } from "@coinbase/agentkit";
 
-const walletProvider = await CdpV2SolanaWalletProvider.configureWithWallet({
+const walletProvider = await CdpSolanaWalletProvider.configureWithWallet({
   apiKeyId: "CDP_API_KEY_ID",
   apiKeySecret: "CDP_API_KEY_SECRET",
   walletSecret: "CDP_WALLET_SECRET",
@@ -1449,9 +1430,9 @@ const walletProvider = await CdpV2SolanaWalletProvider.configureWithWallet({
 You can configure the provider with an existing wallet by providing the wallet's address:
 
 ```typescript
-import { CdpV2SolanaWalletProvider } from "@coinbase/agentkit";
+import { CdpSolanaWalletProvider } from "@coinbase/agentkit";
 
-const walletProvider = await CdpV2SolanaWalletProvider.configureWithWallet({
+const walletProvider = await CdpSolanaWalletProvider.configureWithWallet({
   apiKeyId: "CDP_API_KEY_ID",
   apiKeySecret: "CDP_API_KEY_SECRET",
   walletSecret: "CDP_WALLET_SECRET",
@@ -1465,9 +1446,9 @@ const walletProvider = await CdpV2SolanaWalletProvider.configureWithWallet({
 To create a new wallet, you can provide an idempotency key. The same idempotency key will always generate the same wallet address, and these keys are valid for 24 hours:
 
 ```typescript
-import { CdpV2SolanaWalletProvider } from "@coinbase/agentkit";
+import { CdpSolanaWalletProvider } from "@coinbase/agentkit";
 
-const walletProvider = await CdpV2SolanaWalletProvider.configureWithWallet({
+const walletProvider = await CdpSolanaWalletProvider.configureWithWallet({
   apiKeyId: "CDP_API_KEY_ID",
   apiKeySecret: "CDP_API_KEY_SECRET",
   walletSecret: "CDP_WALLET_SECRET",
@@ -1488,12 +1469,12 @@ The provider can also be configured using environment variables:
 // NETWORK_ID=solana-devnet (optional)
 // IDEMPOTENCY_KEY=unique-key-123 (optional)
 
-const walletProvider = await CdpV2SolanaWalletProvider.configureWithWallet();
+const walletProvider = await CdpSolanaWalletProvider.configureWithWallet();
 ```
 
 #### Supported Networks
 
-The `CdpV2SolanaWalletProvider` supports the following Solana networks:
+The `CdpSolanaWalletProvider` supports the following Solana networks:
 
 - `solana-mainnet`
 - `solana-devnet`

--- a/typescript/agentkit/scripts/generate-action-provider/README.md
+++ b/typescript/agentkit/scripts/generate-action-provider/README.md
@@ -36,10 +36,10 @@ Create a Evm provider for Evm networks:
 pnpm run generate:action-provider -- -n example -p evm
 ```
 
-Create an Evm provider with CDP wallet provider:
+Create an EVM provider with the CDP EVM wallet provider:
 
 ```bash
-pnpm run generate:action-provider -- -n example -p evm -w CdpWalletProvider
+pnpm run generate:action-provider -- -n example -p evm -w CdpEvmWalletProvider
 ```
 
 ## Generated Files

--- a/typescript/agentkit/scripts/generate-action-provider/constants.test.ts
+++ b/typescript/agentkit/scripts/generate-action-provider/constants.test.ts
@@ -1,0 +1,24 @@
+import * as walletProviders from "../../src/wallet-providers";
+import { WALLET_PROVIDERS_BY_PROTOCOL } from "./constants";
+
+describe("WALLET_PROVIDERS_BY_PROTOCOL", () => {
+  it("only includes exported wallet providers", () => {
+    const exportedWalletProviders = new Set(Object.keys(walletProviders));
+    const configuredWalletProviders = Object.values(WALLET_PROVIDERS_BY_PROTOCOL).flatMap(
+      providers => providers.map(provider => provider.value),
+    );
+
+    expect(configuredWalletProviders).toEqual(
+      expect.arrayContaining([
+        "CdpEvmWalletProvider",
+        "CdpSmartWalletProvider",
+        "PrivyEvmDelegatedEmbeddedWalletProvider",
+        "CdpSolanaWalletProvider",
+      ]),
+    );
+
+    for (const walletProvider of configuredWalletProviders) {
+      expect(exportedWalletProviders.has(walletProvider)).toBe(true);
+    }
+  });
+});

--- a/typescript/agentkit/scripts/generate-action-provider/constants.ts
+++ b/typescript/agentkit/scripts/generate-action-provider/constants.ts
@@ -103,14 +103,14 @@ const EVM_WALLET_PROVIDERS = [
     description: "For EVM-compatible blockchain networks (Ethereum, Base, etc.)",
   },
   {
-    title: "CdpWalletProvider",
-    value: "CdpWalletProvider",
-    description: "Coinbase Developer Platform wallet provider with built-in key management",
+    title: "CdpEvmWalletProvider",
+    value: "CdpEvmWalletProvider",
+    description: "Coinbase Developer Platform API Server wallet provider for EVM networks",
   },
   {
-    title: "EthAccountWalletProvider",
-    value: "EthAccountWalletProvider",
-    description: "Local private key wallet provider for EVM networks",
+    title: "CdpSmartWalletProvider",
+    value: "CdpSmartWalletProvider",
+    description: "Coinbase Developer Platform smart wallet provider for EVM networks",
   },
   {
     title: "PrivyEvmWalletProvider",
@@ -118,14 +118,19 @@ const EVM_WALLET_PROVIDERS = [
     description: "Privy's server wallet API provider for EVM networks",
   },
   {
-    title: "PrivyEvmDelegatedWalletProvider",
-    value: "PrivyEvmDelegatedWalletProvider",
+    title: "PrivyEvmDelegatedEmbeddedWalletProvider",
+    value: "PrivyEvmDelegatedEmbeddedWalletProvider",
     description: "Privy's delegated embedded wallet provider for EVM networks",
   },
   {
     title: "ViemWalletProvider",
     value: "ViemWalletProvider",
     description: "Viem-based wallet provider for EVM networks",
+  },
+  {
+    title: "ZeroDevWalletProvider",
+    value: "ZeroDevWalletProvider",
+    description: "ZeroDev smart account wallet provider for EVM networks",
   },
 ] as const;
 
@@ -137,6 +142,11 @@ const SVM_WALLET_PROVIDERS = [
     title: "SvmWalletProvider",
     value: "SvmWalletProvider",
     description: "For Solana Virtual Machine networks",
+  },
+  {
+    title: "CdpSolanaWalletProvider",
+    value: "CdpSolanaWalletProvider",
+    description: "Coinbase Developer Platform wallet provider for Solana networks",
   },
   {
     title: "PrivySvmWalletProvider",

--- a/typescript/agentkit/src/action-providers/across/README.md
+++ b/typescript/agentkit/src/action-providers/across/README.md
@@ -38,7 +38,7 @@ The status of bridge deposit can only be checked on Mainnets.
 
 Before bridging funds, always make sure that you have access to the destination address on the destination chain!
 
-Note that when using a CDP server wallet with CdpWalletProvider, a new wallet address is generated for each chain. This means that if you bridge tokens to the sender's address on one chain, you may not be able to access those funds on the destination chain within AgentKit since a different wallet address will be used. 
+Note that when using a CDP server wallet with `CdpEvmWalletProvider`, a new wallet address is generated for each chain. This means that if you bridge tokens to the sender's address on one chain, you may not be able to access those funds on the destination chain within AgentKit since a different wallet address will be used.
 While you can export the private key to access funds in external wallets, it's recommended to either use ViemWalletProvider for consistent addresses across chains or ensure the destination address is different from the sender's address.
 
 ## Configuration

--- a/typescript/agentkit/src/action-providers/x402/README.md
+++ b/typescript/agentkit/src/action-providers/x402/README.md
@@ -19,7 +19,7 @@ x402/
 The X402ActionProvider accepts an optional configuration object when initialized:
 
 ```typescript
-import { x402ActionProvider, X402Config } from "@coinbase/cdp-agentkit";
+import { x402ActionProvider, X402Config } from "@coinbase/agentkit";
 
 const config: X402Config = {
   // Service URLs the agent can call (whitelist)

--- a/typescript/framework-extensions/langchain/README.md
+++ b/typescript/framework-extensions/langchain/README.md
@@ -37,6 +37,7 @@ import { AgentKit } from "@coinbase/agentkit";
 const agentKit = await AgentKit.from({
   cdpApiKeyId: "CDP API KEY NAME",
   cdpApiKeySecret: "CDP API KEY SECRET",
+  cdpWalletSecret: "CDP WALLET SECRET",
 });
 
 const tools = await getLangChainTools(agentKit);

--- a/typescript/framework-extensions/model-context-protocol/README.md
+++ b/typescript/framework-extensions/model-context-protocol/README.md
@@ -29,6 +29,7 @@ import { AgentKit } from "@coinbase/agentkit";
 const agentKit = await AgentKit.from({
   cdpApiKeyId: "CDP API KEY NAME",
   cdpApiKeySecret: "CDP API KEY SECRET",
+  cdpWalletSecret: "CDP WALLET SECRET",
 });
 
 const { tools, toolHandler } = await getMcpTools(agentKit);

--- a/typescript/framework-extensions/vercel-ai-sdk/README.md
+++ b/typescript/framework-extensions/vercel-ai-sdk/README.md
@@ -47,6 +47,7 @@ import { openai } from "@ai-sdk/openai";
 const agentKit = await AgentKit.from({
   cdpApiKeyId: process.env.CDP_API_KEY_ID,
   cdpApiKeySecret: process.env.CDP_API_KEY_SECRET,
+  cdpWalletSecret: process.env.CDP_WALLET_SECRET,
 });
 
 const tools = await getVercelAITools(agentKit);


### PR DESCRIPTION
## Description

Across the TypeScript and Python sides of the repo, a number of docs, the bug-report issue template, the Python contributing guide, and the `generate-action-provider` script still referenced wallet providers that were removed or renamed during the CDP Wallet API v2 migration:

- `CdpWalletProvider` (now `CdpEvmWalletProvider`)
- `SmartWalletProvider` / `CDPSmartWalletProvider` (now `CdpSmartWalletProvider`)
- `CdpV2SolanaWalletProvider` (now `CdpSolanaWalletProvider`)
- `EthAccountWalletProvider` (removed)
- `PrivyEvmDelegatedWalletProvider` (now `PrivyEvmDelegatedEmbeddedWalletProvider`)
- `cdpWalletActionProvider` (collapsed into `walletActionProvider`)

New users copying snippets from these docs hit import errors, config-shape mismatches (missing `walletSecret` / `CDP_WALLET_SECRET`), and an x402 example that imported from `@coinbase/cdp-agentkit` instead of `@coinbase/agentkit`. The `generate-action-provider` script was also offering these stale names as prompts, so scaffolding a new action provider with any of them produced code that imported symbols the package no longer exports.

This PR is scoped to bringing those references back in line with the current public surface. No runtime source under `typescript/agentkit/src/` or `coinbase_agentkit/` is modified.

### What changed

**`fix(generate-action-provider)`**

- Replace the stale `EVM_WALLET_PROVIDERS` / `SVM_WALLET_PROVIDERS` entries in `typescript/agentkit/scripts/generate-action-provider/constants.ts` with the current exports (`CdpEvmWalletProvider`, `CdpSmartWalletProvider`, `PrivyEvmDelegatedEmbeddedWalletProvider`, `ZeroDevWalletProvider`, `CdpSolanaWalletProvider`).
- Add `constants.test.ts`, a regression test that imports `* as walletProviders from "../../src/wallet-providers"` and asserts every provider value surfaced by the generator is an actually-exported symbol. This fails loudly if wallet provider exports and the generator drift apart again.

**`docs`**

- Rewrite the wallet-provider sections of `typescript/agentkit/README.md` and `python/coinbase-agentkit/README.md` to use the current `CdpEvm` / `CdpSmart` / `CdpSolana` providers with their current `apiKeySecret` + `walletSecret` config surface. Drop the obsolete `SmartWalletProvider` and `CDPSmartWalletProvider` sections entirely.
- Add `cdpWalletSecret` / `CDP_WALLET_SECRET` to the default `AgentKit.from(...)` examples in the core TS README and in the LangChain, Model Context Protocol, and Vercel AI SDK framework-extension READMEs so the happy path actually runs.
- In `python/framework-extensions/{autogen,langchain,openai-agents-sdk}/README.md`, replace the removed `CDP_API_KEY_PRIVATE` env var with `CDP_API_KEY_SECRET` + `CDP_WALLET_SECRET`.
- Rewrite the action-provider walkthrough in `CONTRIBUTING-PYTHON.md` so it uses the canonical `Erc721ActionProvider` / `EvmWalletProvider` shape with a `send_transaction` + `wait_for_transaction_receipt` flow instead of the removed `CdpWalletProvider.mint` helper.
- Update `.github/ISSUE_TEMPLATE/bug-report.yml` to reproduce with `CdpEvmWalletProvider` + `walletActionProvider`, and correct the TypeScript snippet to use `//` comments instead of `#`.
- Fix the Compound action provider README test fixture (`python/coinbase-agentkit/coinbase_agentkit/action_providers/compound/README.md`) to construct `CdpEvmWalletProvider(CdpEvmWalletProviderConfig())`.
- Fix the Across action provider README to refer to `CdpEvmWalletProvider`, the x402 README to import from `@coinbase/agentkit`, and the generator-script README example to use `CdpEvmWalletProvider`.

## Tests

- `pnpm exec jest scripts/generate-action-provider/constants.test.ts` in `typescript/agentkit`:

```
PASS scripts/generate-action-provider/constants.test.ts
  WALLET_PROVIDERS_BY_PROTOCOL
    ✓ only includes exported wallet providers
```

- `pnpm exec eslint -c .eslintrc.json scripts/generate-action-provider/constants.ts scripts/generate-action-provider/constants.test.ts` — clean.
- `pnpm exec prettier -c .prettierrc --check` on every touched `.md` and `.ts` file — all files use Prettier code style.
- `pnpm exec tsc --noEmit` in `typescript/agentkit` — no errors.

This PR does not change any action provider behavior or any runtime code paths exposed by the published packages, so there is no chatbot repro to attach. The generator-script change is covered by the new unit test, and the rest is documentation.

## Checklist

- [x] Added documentation to all relevant README.md files
- [ ] Added a changelog entry

No changeset / towncrier fragment is included: the changes are documentation plus a fix to `typescript/agentkit/scripts/`, which is not part of the published npm package (`package.json` `files` is `["dist"]`), so none of the published artifacts change.