### PR TITLE
test(x402): re-enable retry_with_x402 and direct request tests

### DIFF
--- a/python/coinbase-agentkit/tests/action_providers/x402/conftest.py
+++ b/python/coinbase-agentkit/tests/action_providers/x402/conftest.py
@@ -1,10 +1,13 @@
 """Test fixtures for x402 action provider tests."""
 
+import base64
+import json
 from unittest.mock import Mock, patch
 
 import pytest
 import requests
 
+from coinbase_agentkit.network import Network
 from coinbase_agentkit.wallet_providers.evm_wallet_provider import EvmWalletProvider
 
 # Mock data constants
@@ -28,17 +31,19 @@ MOCK_PAYMENT_PROOF = {
     "payer": MOCK_ADDRESS,
 }
 
+# Pre-encoded payment proof header matching the provider's base64+JSON decode path.
+MOCK_PAYMENT_PROOF_HEADER = base64.b64encode(json.dumps(MOCK_PAYMENT_PROOF).encode()).decode()
+
 
 @pytest.fixture
 def mock_wallet():
-    """Create a mock wallet provider."""
+    """Create a mock wallet provider with a base-sepolia network."""
     mock = Mock(spec=EvmWalletProvider)
     mock.get_address.return_value = MOCK_ADDRESS
-
-    # Mock the signer
-    mock_signer = Mock()
-    mock.to_signer.return_value = mock_signer
-
+    mock.get_network.return_value = Network(
+        chain_id="84532", network_id="base-sepolia", protocol_family="evm"
+    )
+    mock.to_signer.return_value = Mock()
     return mock
 
 
@@ -85,28 +90,29 @@ def mock_requests():
 
 
 @pytest.fixture
-def mock_x402_requests():
-    """Create a mock for x402_requests session."""
-    with patch("x402.clients.requests.x402_requests", autospec=True) as mock_x402:
+def mock_x402_session():
+    """Patch x402_requests at the provider module path and return the mock session.
+
+    Patching at the provider's own module is important: the provider imports
+    ``x402_requests`` directly (``from x402.http.clients.requests import x402_requests``),
+    so tests must patch the reference attached to the provider module rather than the
+    upstream package. Patching the upstream symbol would not affect the already-bound
+    reference and fails inconsistently across environments.
+    """
+    with patch(
+        "coinbase_agentkit.action_providers.x402.x402_action_provider.x402_requests"
+    ) as mock_factory:
         mock_session = Mock()
-        mock_x402.return_value = mock_session
-
-        # Create a successful paid response
-        paid_response = Mock(spec=requests.Response)
-        paid_response.status_code = 200
-        paid_response.headers = {
-            "content-type": "application/json",
-            "x-payment-response": "mock_payment_response",
-        }
-        paid_response.json.return_value = {"data": "paid_success"}
-        mock_session.request.return_value = paid_response
-
-        yield mock_x402
+        mock_factory.return_value = mock_session
+        yield mock_session
 
 
 @pytest.fixture
-def mock_decode_payment():
-    """Create a mock for decode_x_payment_response."""
-    with patch("x402.clients.base.decode_x_payment_response", autospec=True) as mock_decode:
-        mock_decode.return_value = MOCK_PAYMENT_PROOF
-        yield mock_decode
+def patch_x402_client():
+    """Bypass real x402 client construction (which needs a signable wallet)."""
+    with patch(
+        "coinbase_agentkit.action_providers.x402.x402_action_provider."
+        "x402ActionProvider._create_x402_client"
+    ) as patched:
+        patched.return_value = Mock()
+        yield patched

--- a/python/coinbase-agentkit/tests/action_providers/x402/test_x402_action_provider.py
+++ b/python/coinbase-agentkit/tests/action_providers/x402/test_x402_action_provider.py
@@ -10,16 +10,45 @@ from pydantic import ValidationError
 from coinbase_agentkit.action_providers.x402.schemas import (
     DirectX402RequestSchema,
     HttpRequestSchema,
+    PaymentOptionSchema,
     RetryWithX402Schema,
+    X402Config,
 )
 from coinbase_agentkit.action_providers.x402.x402_action_provider import x402_action_provider
 from coinbase_agentkit.network import Network
 
 from .conftest import (
-    # MOCK_PAYMENT_PROOF,
+    MOCK_PAYMENT_PROOF,
+    MOCK_PAYMENT_PROOF_HEADER,
     MOCK_PAYMENT_REQUIREMENTS,
     MOCK_URL,
 )
+
+
+def _build_paid_response(status_code: int = 200, include_payment_proof: bool = True):
+    """Build a fake `requests.Response` for an x402-handled session call."""
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    headers = {"content-type": "application/json"}
+    if include_payment_proof:
+        headers["x-payment-response"] = MOCK_PAYMENT_PROOF_HEADER
+    response.headers = headers
+    response.json.return_value = {"data": "paid_success"}
+    return response
+
+
+def _payment_option(**overrides):
+    """Build a valid PaymentOptionSchema populated with MOCK_PAYMENT_REQUIREMENTS."""
+    kwargs = {
+        "scheme": MOCK_PAYMENT_REQUIREMENTS["scheme"],
+        "network": MOCK_PAYMENT_REQUIREMENTS["network"],
+        "asset": MOCK_PAYMENT_REQUIREMENTS["asset"],
+        "max_amount_required": MOCK_PAYMENT_REQUIREMENTS["maxAmountRequired"],
+        "pay_to": MOCK_PAYMENT_REQUIREMENTS["payTo"],
+    }
+    kwargs.update(overrides)
+    return PaymentOptionSchema(**kwargs)
+
 
 # =========================================================
 # Schema Tests
@@ -60,15 +89,7 @@ def test_http_request_schema_invalid():
 
 def test_retry_schema_valid():
     """Test that the RetryWithX402Schema validates correctly."""
-    from coinbase_agentkit.action_providers.x402.schemas import PaymentOptionSchema
-
-    payment_option = PaymentOptionSchema(
-        scheme=MOCK_PAYMENT_REQUIREMENTS["scheme"],
-        network=MOCK_PAYMENT_REQUIREMENTS["network"],
-        asset=MOCK_PAYMENT_REQUIREMENTS["asset"],
-        max_amount_required=MOCK_PAYMENT_REQUIREMENTS["maxAmountRequired"],
-        pay_to=MOCK_PAYMENT_REQUIREMENTS["payTo"],
-    )
+    payment_option = _payment_option()
     valid_input = {
         "url": MOCK_URL,
         "selected_payment_option": payment_option,
@@ -104,8 +125,6 @@ def test_direct_schema_invalid():
 
 def test_make_http_request_success(mock_wallet, mock_requests):
     """Test successful HTTP request without payment requirement."""
-    from coinbase_agentkit.action_providers.x402.schemas import X402Config
-
     mock_requests.return_value = mock_requests.success_response
     config = X402Config(registered_services=[MOCK_URL])
     provider = x402_action_provider(config)
@@ -123,17 +142,9 @@ def test_make_http_request_success(mock_wallet, mock_requests):
 
 def test_make_http_request_402(mock_wallet, mock_requests):
     """Test HTTP request that returns 402 Payment Required."""
-    from coinbase_agentkit.action_providers.x402.schemas import X402Config
-    from coinbase_agentkit.network import Network
-
     mock_requests.return_value = mock_requests.payment_required_response
     config = X402Config(registered_services=[MOCK_URL])
     provider = x402_action_provider(config)
-
-    # Mock the wallet network
-    mock_wallet.get_network.return_value = Network(
-        chain_id="84532", network_id="base-sepolia", protocol_family="evm"
-    )
 
     response = json.loads(
         provider.make_http_request(mock_wallet, {"url": MOCK_URL, "method": "POST"})
@@ -162,114 +173,232 @@ def test_make_http_request_error(mock_wallet, mock_requests):
 
 
 # =========================================================
-# retry_http_request_with_x402 Tests
+# retry_with_x402 Tests
+#
+# Historical note: previous versions of these tests patched
+# ``decode_x_payment_response`` on the provider module, but that symbol is no
+# longer imported there — the provider inlines base64+JSON decoding of the
+# payment response header. The old patch raised AttributeError in CI, which is
+# why those tests were disabled. The tests below patch ``x402_requests`` at the
+# provider module (where it is actually bound) and stub ``_create_x402_client``
+# to avoid needing a real signer.
 # =========================================================
 
 
-# TODO: These tests are temporarily disabled due to inconsistent mock patching behavior between local and CI/CD environments.
-# The tests pass locally but fail in CI/CD with AttributeError. This is likely due to differences in how Python imports
-# and patches modules in different environments. These tests should be revisited and fixed with a more robust mocking strategy.
-# @patch("coinbase_agentkit.action_providers.x402.x402_action_provider.x402_requests")
-# @patch("coinbase_agentkit.action_providers.x402.x402_action_provider.decode_x_payment_response")
-# def test_retry_with_x402_success(mock_decode_payment, mock_x402_requests, mock_wallet):
-#     """Test successful retry with payment."""
-#     provider = x402_action_provider()
-#     args = {
-#         "url": MOCK_URL,
-#         "method": "GET",
-#         "scheme": MOCK_PAYMENT_REQUIREMENTS["scheme"],
-#         "network": MOCK_PAYMENT_REQUIREMENTS["network"],
-#         "max_amount_required": MOCK_PAYMENT_REQUIREMENTS["maxAmountRequired"],
-#         "resource": MOCK_PAYMENT_REQUIREMENTS["resource"],
-#         "pay_to": MOCK_PAYMENT_REQUIREMENTS["payTo"],
-#         "max_timeout_seconds": MOCK_PAYMENT_REQUIREMENTS["maxTimeoutSeconds"],
-#         "asset": MOCK_PAYMENT_REQUIREMENTS["asset"],
-#     }
-#
-#     # Configure mock response
-#     mock_session = Mock()
-#     mock_x402_requests.return_value = mock_session
-#     response = Mock(spec=requests.Response)
-#     response.status_code = 200
-#     response.headers = {
-#         "content-type": "application/json",
-#         "x-payment-response": "mock_payment_response",
-#     }
-#     response.json.return_value = {"data": "paid_success"}
-#     mock_session.request.return_value = response
-#
-#     # Configure mock payment proof
-#     mock_decode_payment.return_value = MOCK_PAYMENT_PROOF
-#
-#     response = json.loads(provider.retry_with_x402(mock_wallet, args))
-#
-#     assert response["success"] is True
-#     assert response["message"] == "Request completed successfully with payment"
-#     assert response["details"]["paymentProof"]["transaction"] == MOCK_PAYMENT_PROOF["transaction"]
+def test_retry_with_x402_success_with_payment_proof(
+    mock_wallet, mock_x402_session, patch_x402_client
+):
+    """Retry succeeds and surfaces decoded payment proof from response header."""
+    mock_x402_session.request.return_value = _build_paid_response(include_payment_proof=True)
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(
+        provider.retry_with_x402(
+            mock_wallet,
+            {"url": MOCK_URL, "method": "GET", "selected_payment_option": _payment_option()},
+        )
+    )
+
+    assert response["status"] == "success"
+    assert response["message"] == "Request completed successfully with payment"
+    assert response["data"] == {"data": "paid_success"}
+    assert response["details"]["paymentProof"]["transaction"] == MOCK_PAYMENT_PROOF["transaction"]
+    assert response["details"]["paymentUsed"]["network"] == MOCK_PAYMENT_REQUIREMENTS["network"]
 
 
-# @patch("coinbase_agentkit.action_providers.x402.x402_action_provider.x402_requests")
-# def test_retry_with_x402_no_payment_proof(mock_x402_requests, mock_wallet):
-#     """Test retry where payment proof is not in response headers."""
-#     mock_session = Mock()
-#     mock_x402_requests.return_value = mock_session
-#     response = Mock(spec=requests.Response)
-#     response.status_code = 200
-#     response.headers = {"content-type": "application/json"}
-#     response.json.return_value = {"data": "success"}
-#     mock_session.request.return_value = response
-#
-#     provider = x402_action_provider()
-#     args = {
-#         "url": MOCK_URL,
-#         "method": "GET",
-#         "scheme": MOCK_PAYMENT_REQUIREMENTS["scheme"],
-#         "network": MOCK_PAYMENT_REQUIREMENTS["network"],
-#         "max_amount_required": MOCK_PAYMENT_REQUIREMENTS["maxAmountRequired"],
-#         "resource": MOCK_PAYMENT_REQUIREMENTS["resource"],
-#         "pay_to": MOCK_PAYMENT_REQUIREMENTS["payTo"],
-#         "max_timeout_seconds": MOCK_PAYMENT_REQUIREMENTS["maxTimeoutSeconds"],
-#         "asset": MOCK_PAYMENT_REQUIREMENTS["asset"],
-#     }
-#
-#     response = json.loads(provider.retry_with_x402(mock_wallet, args))
-#
-#     assert response["success"] is True
-#     assert response["message"] == "Request completed successfully with payment"
-#     assert response["details"]["paymentProof"] is None
+def test_retry_with_x402_success_without_payment_proof(
+    mock_wallet, mock_x402_session, patch_x402_client
+):
+    """Retry succeeds with no payment-response header; paymentProof is None."""
+    mock_x402_session.request.return_value = _build_paid_response(include_payment_proof=False)
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(
+        provider.retry_with_x402(
+            mock_wallet,
+            {"url": MOCK_URL, "selected_payment_option": _payment_option()},
+        )
+    )
+
+    assert response["status"] == "success"
+    assert response["details"]["paymentProof"] is None
 
 
-# @patch("coinbase_agentkit.action_providers.x402.x402_action_provider.x402_requests")
-# @patch("coinbase_agentkit.action_providers.x402.x402_action_provider.decode_x_payment_response")
-# def test_make_http_request_with_x402_success(mock_decode_payment, mock_x402_requests, mock_wallet):
-#     """Test successful direct request with automatic payment."""
-#     provider = x402_action_provider()
-#
-#     # Configure mock response
-#     mock_session = Mock()
-#     mock_x402_requests.return_value = mock_session
-#     response = Mock(spec=requests.Response)
-#     response.status_code = 200
-#     response.headers = {
-#         "content-type": "application/json",
-#         "x-payment-response": "mock_payment_response",
-#     }
-#     response.json.return_value = {"data": "paid_success"}
-#     mock_session.request.return_value = response
-#
-#     # Configure mock payment proof
-#     mock_decode_payment.return_value = MOCK_PAYMENT_PROOF
-#
-#     response = json.loads(
-#         provider.make_http_request_with_x402(mock_wallet, {"url": MOCK_URL, "method": "GET"})
-#     )
-#
-#     assert response["success"] is True
-#     assert (
-#         response["message"]
-#         == "Request completed successfully (payment handled automatically if required)"
-#     )
-#     assert response["paymentProof"]["transaction"] == MOCK_PAYMENT_PROOF["transaction"]
+def test_retry_with_x402_non_200_does_not_claim_success(
+    mock_wallet, mock_x402_session, patch_x402_client
+):
+    """Retry returning a non-200 must surface error status, not success."""
+    mock_x402_session.request.return_value = _build_paid_response(
+        status_code=500, include_payment_proof=False
+    )
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(
+        provider.retry_with_x402(
+            mock_wallet,
+            {"url": MOCK_URL, "selected_payment_option": _payment_option()},
+        )
+    )
+
+    assert response["status"] == "error"
+    assert response["httpStatus"] == 500
+    assert "Payment was not settled" in response["message"]
+
+
+def test_retry_with_x402_service_not_registered(mock_wallet):
+    """Retrying an unregistered service returns a registration error."""
+    provider = x402_action_provider()  # no registered services
+
+    response = json.loads(
+        provider.retry_with_x402(
+            mock_wallet,
+            {"url": MOCK_URL, "selected_payment_option": _payment_option()},
+        )
+    )
+
+    assert response["error"] is True
+    assert response["message"] == "Service not registered"
+
+
+def test_retry_with_x402_rejects_non_usdc_asset(mock_wallet):
+    """Retry refuses non-USDC assets."""
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(
+        provider.retry_with_x402(
+            mock_wallet,
+            {
+                "url": MOCK_URL,
+                "selected_payment_option": _payment_option(
+                    asset="0x0000000000000000000000000000000000000001"
+                ),
+            },
+        )
+    )
+
+    assert response["error"] is True
+    assert response["message"] == "Only USDC payments are supported"
+
+
+def test_retry_with_x402_rejects_payment_over_limit(mock_wallet):
+    """Retry enforces the configured max_payment_usdc limit."""
+    # Default max_payment_usdc is 1.0 USDC. Request 2 USDC (2_000_000 atomic) to exceed it.
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(
+        provider.retry_with_x402(
+            mock_wallet,
+            {
+                "url": MOCK_URL,
+                "selected_payment_option": _payment_option(max_amount_required="2000000"),
+            },
+        )
+    )
+
+    assert response["error"] is True
+    assert response["message"] == "Payment exceeds limit"
+    assert response["maxPaymentUsdc"] == 1.0
+
+
+def test_retry_with_x402_network_mismatch(mock_wallet):
+    """Retry rejects when the payment option's network is not supported by the wallet.
+
+    The wallet stays on base-sepolia (so the base-sepolia USDC asset still passes
+    ``is_usdc_asset``) while the payment option requests a network the wallet does
+    not map to. This isolates the network-compatibility gate.
+    """
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(
+        provider.retry_with_x402(
+            mock_wallet,
+            {
+                "url": MOCK_URL,
+                "selected_payment_option": _payment_option(network="solana-mainnet"),
+            },
+        )
+    )
+
+    assert response["error"] is True
+    assert response["message"] == "Network mismatch"
+
+
+# =========================================================
+# make_http_request_with_x402 Tests
+# =========================================================
+
+
+def test_make_http_request_with_x402_success_with_payment_proof(
+    mock_wallet, mock_x402_session, patch_x402_client
+):
+    """Direct x402 call surfaces payment proof when present."""
+    mock_x402_session.request.return_value = _build_paid_response(include_payment_proof=True)
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(
+        provider.make_http_request_with_x402(mock_wallet, {"url": MOCK_URL, "method": "GET"})
+    )
+
+    assert response["success"] is True
+    assert (
+        response["message"]
+        == "Request completed successfully (payment handled automatically if required)"
+    )
+    assert response["status"] == 200
+    assert response["paymentProof"]["transaction"] == MOCK_PAYMENT_PROOF["transaction"]
+
+
+def test_make_http_request_with_x402_success_without_payment_proof(
+    mock_wallet, mock_x402_session, patch_x402_client
+):
+    """Direct x402 call with no payment header returns success and no proof."""
+    mock_x402_session.request.return_value = _build_paid_response(include_payment_proof=False)
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(provider.make_http_request_with_x402(mock_wallet, {"url": MOCK_URL}))
+
+    assert response["success"] is True
+    assert response["paymentProof"] is None
+
+
+def test_make_http_request_with_x402_non_200(mock_wallet, mock_x402_session, patch_x402_client):
+    """Non-200 upstream responses must not be reported as success."""
+    mock_x402_session.request.return_value = _build_paid_response(
+        status_code=502, include_payment_proof=False
+    )
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(provider.make_http_request_with_x402(mock_wallet, {"url": MOCK_URL}))
+
+    assert response["success"] is False
+    assert response["status"] == 502
+    assert "Payment was not settled" in response["message"]
+
+
+def test_make_http_request_with_x402_service_not_registered(mock_wallet):
+    """Direct x402 call refuses unregistered services and hints at registration."""
+    provider = x402_action_provider(
+        X402Config(registered_services=[], allow_dynamic_service_registration=True)
+    )
+
+    response = json.loads(provider.make_http_request_with_x402(mock_wallet, {"url": MOCK_URL}))
+
+    assert response["error"] is True
+    assert response["message"] == "Service not registered"
+    assert "register_x402_service" in response["suggestion"]
+
+
+def test_make_http_request_with_x402_unsupported_wallet_provider():
+    """Direct x402 call rejects non-EVM wallet providers."""
+    from coinbase_agentkit.wallet_providers.wallet_provider import WalletProvider
+
+    non_evm_wallet = Mock(spec=WalletProvider)
+    provider = x402_action_provider(X402Config(registered_services=[MOCK_URL]))
+
+    response = json.loads(provider.make_http_request_with_x402(non_evm_wallet, {"url": MOCK_URL}))
+
+    assert response["error"] is True
+    assert response["message"] == "Unsupported wallet provider"
 
 
 # =========================================================


### PR DESCRIPTION
## Summary

Re-enables the Python `x402` action provider tests for `retry_with_x402` and `make_http_request_with_x402` that were commented out in `python/coinbase-agentkit/tests/action_providers/x402/test_x402_action_provider.py` with the note:

> These tests are temporarily disabled due to inconsistent mock patching behavior between local and CI/CD environments. The tests pass locally but fail in CI/CD with AttributeError.

## Root cause

The disabled tests used:

```python
@patch("coinbase_agentkit.action_providers.x402.x402_action_provider.decode_x_payment_response")
```

but `decode_x_payment_response` is not imported in `x402_action_provider.py`. The current provider inlines `base64.b64decode` + `json.loads` on the `payment-response` / `x-payment-response` header, so there is no `decode_x_payment_response` attribute to patch. `mock.patch` raised `AttributeError` wherever it evaluated the target, which is why the tests failed in CI.

The obsolete `mock_x402_requests` fixture in `conftest.py` also patched `x402.clients.requests.x402_requests`, but the provider imports `x402_requests` from `x402.http.clients.requests` — another reason those old tests would not affect the provider's bound reference.

## What this PR does

1. **Deletes the three disabled test bodies and obsolete fixtures** (`mock_x402_requests`, `mock_decode_payment`).
2. **Adds two robust fixtures** in `conftest.py`:
   - `mock_x402_session` patches `x402_requests` at the provider module path — the location actually bound by the provider — so the patch is stable across environments.
   - `patch_x402_client` stubs `x402ActionProvider._create_x402_client` so tests don't need a real signable wallet.
3. **Adds coverage for the current provider API and response schema**:
   - `retry_with_x402`: success with payment proof, success without proof, non-200 upstream response, unregistered service, non-USDC asset, payment above `max_payment_usdc`, network mismatch.
   - `make_http_request_with_x402`: success with proof, success without proof, non-200 upstream, unregistered service (with dynamic registration hint), unsupported wallet provider.

No production code is changed — this PR is scoped to test infrastructure only.

## Verification

Run from `python/coinbase-agentkit/`:

```
uv sync
uv run pytest tests/action_providers/x402/ -v
uv run ruff format tests/action_providers/x402/ --check
uv run ruff check tests/action_providers/x402/
uv run pytest
```

Results on this branch:

- `tests/action_providers/x402/`: **22 passed** (was 10 passing + 3 commented-out).
- Full `python/coinbase-agentkit` suite: **675 passed, 35 deselected**.
- `ruff format --check` and `ruff check` both pass.

## Test plan

- [x] x402 action provider tests pass locally
- [x] Full `python/coinbase-agentkit` test suite passes locally
- [x] `ruff format --check` passes on touched files
- [x] `ruff check` passes on touched files
- [ ] CI passes on this PR