### PR TITLE
Make create-onchain-agent templates LLM provider-agnostic. Closes #1106

### DIFF
--- a/typescript/.changeset/provider-agnostic-templates.md
+++ b/typescript/.changeset/provider-agnostic-templates.md
@@ -1,0 +1,5 @@
+---
+"create-onchain-agent": patch
+---
+
+Made templates LLM provider-agnostic via configurable AI_API_KEY, AI_BASE_URL, and AI_MODEL env vars

--- a/typescript/create-onchain-agent/README.md
+++ b/typescript/create-onchain-agent/README.md
@@ -25,6 +25,14 @@ This command lets you choose between two project templates:
 - **Next.js Template**: A full-stack web application with React, Tailwind CSS, and ESLint
 - **MCP Template**: A Model Context Protocol server project
 
+### LLM Provider Configuration
+By default, the template connects to OpenAI utilizing `gpt-4o-mini`. However, `create-onchain-agent` is fully provider-agnostic and works with any OpenAI-compatible API out of the box (e.g. Anthropic, Google Gemini, OpenRouter, Groq, Ollama). 
+
+To use a different provider, simply update the `.env` variables after generating your project:
+- `AI_API_KEY`: Your provider's API key
+- `AI_BASE_URL`: The OpenAI-compatible endpoint for your provider (e.g., `https://api.anthropic.com/v1/`)
+- `AI_MODEL`: Your preferred model (e.g., `claude-3-5-sonnet-latest`)
+
 ### Component Generation
 
 After installing the `create-onchain-agent` CLI, you will also have the `agenkit` CLI installed. This allows you to generate components for your project.

--- a/typescript/create-onchain-agent/src/common/utils.ts
+++ b/typescript/create-onchain-agent/src/common/utils.ts
@@ -249,23 +249,28 @@ export async function handleNextSelection(
     // Start file with notes regarding .env var setup
     ...[
       "AI Provider Configuration",
-      "Supports OpenAI, OpenRouter, Groq, and any OpenAI-compatible API",
+      'Supported providers: "openai" | "anthropic" | "google" | "custom"',
       "Get OpenAI keys: https://platform.openai.com/api-keys",
-      "Get OpenRouter keys: https://openrouter.ai/keys",
+      "Get Anthropic keys: https://console.anthropic.com/settings/keys",
+      "Get Google AI keys: https://aistudio.google.com/apikey",
       ...agentkitRouteConfig.env.topComments,
     ]
       .map(comment => `# ${comment}`)
       .join("\n"),
     // Continue with # Required section
     "\n\n# Required\n",
-    ...["AI_API_KEY=", ...agentkitRouteConfig.env.required.map(line => `${line}=`)].join("\n"),
-    // Finish with # Optional section
-    "\n\n# Optional — AI Provider\n",
     ...[
-      "# Set AI_PROVIDER_URL to use a different provider (e.g., https://openrouter.ai/api/v1)",
-      "AI_PROVIDER_URL=",
-      "# Set AI_MODEL to use a different model (default: gpt-4o-mini)",
+      'AI_PROVIDER=openai  # "openai" | "anthropic" | "google" | "custom"',
+      "AI_API_KEY=",
+      ...agentkitRouteConfig.env.required.map(line => `${line}=`),
+    ].join("\n"),
+    // Optional — AI Provider
+    "\n\n# Optional — AI Model\n",
+    ...[
+      "# Set AI_MODEL to use a different model (defaults: gpt-4o-mini / claude-sonnet-4-20250514 / gemini-2.0-flash)",
       "AI_MODEL=",
+      '# Set AI_PROVIDER_URL when AI_PROVIDER="custom" (e.g., https://openrouter.ai/api/v1)',
+      "AI_PROVIDER_URL=",
     ].join("\n"),
     "\n\n# Optional — Network\n",
     ...[

--- a/typescript/create-onchain-agent/src/common/utils.ts
+++ b/typescript/create-onchain-agent/src/common/utils.ts
@@ -248,11 +248,8 @@ export async function handleNextSelection(
   const envLines = [
     // Start file with notes regarding .env var setup
     ...[
-      "AI Provider Configuration",
-      'Supported providers: "openai" | "anthropic" | "google" | "custom"',
-      "Get OpenAI keys: https://platform.openai.com/api-keys",
-      "Get Anthropic keys: https://console.anthropic.com/settings/keys",
-      "Get Google AI keys: https://aistudio.google.com/apikey",
+      "AI Provider Configuration — works with any OpenAI-compatible API",
+      "Supports: OpenAI, Anthropic, Google Gemini, OpenRouter, Groq, Ollama, and more",
       ...agentkitRouteConfig.env.topComments,
     ]
       .map(comment => `# ${comment}`)
@@ -260,17 +257,22 @@ export async function handleNextSelection(
     // Continue with # Required section
     "\n\n# Required\n",
     ...[
-      'AI_PROVIDER=openai  # "openai" | "anthropic" | "google" | "custom"',
       "AI_API_KEY=",
       ...agentkitRouteConfig.env.required.map(line => `${line}=`),
     ].join("\n"),
     // Optional — AI Provider
-    "\n\n# Optional — AI Model\n",
+    "\n\n# Optional — AI Provider\n",
     ...[
-      "# Set AI_MODEL to use a different model (defaults: gpt-4o-mini / claude-sonnet-4-20250514 / gemini-2.0-flash)",
+      "# To use a different provider, set AI_BASE_URL to their OpenAI-compatible endpoint:",
+      "#   Anthropic:   https://api.anthropic.com/v1/",
+      "#   Google:      https://generativelanguage.googleapis.com/v1beta/openai/",
+      "#   OpenRouter:  https://openrouter.ai/api/v1",
+      "#   Groq:        https://api.groq.com/openai/v1",
+      "#   Ollama:      http://localhost:11434/v1",
+      "AI_BASE_URL=",
+      "",
+      "# Set AI_MODEL to use a different model (default: gpt-4o-mini)",
       "AI_MODEL=",
-      '# Set AI_PROVIDER_URL when AI_PROVIDER="custom" (e.g., https://openrouter.ai/api/v1)',
-      "AI_PROVIDER_URL=",
     ].join("\n"),
     "\n\n# Optional — Network\n",
     ...[

--- a/typescript/create-onchain-agent/src/common/utils.ts
+++ b/typescript/create-onchain-agent/src/common/utils.ts
@@ -248,16 +248,26 @@ export async function handleNextSelection(
   const envLines = [
     // Start file with notes regarding .env var setup
     ...[
-      "Get keys from OpenAI Platform: https://platform.openai.com/api-keys",
+      "AI Provider Configuration",
+      "Supports OpenAI, OpenRouter, Groq, and any OpenAI-compatible API",
+      "Get OpenAI keys: https://platform.openai.com/api-keys",
+      "Get OpenRouter keys: https://openrouter.ai/keys",
       ...agentkitRouteConfig.env.topComments,
     ]
       .map(comment => `# ${comment}`)
       .join("\n"),
     // Continue with # Required section
     "\n\n# Required\n",
-    ...["OPENAI_API_KEY=", ...agentkitRouteConfig.env.required.map(line => `${line}=`)].join("\n"),
+    ...["AI_API_KEY=", ...agentkitRouteConfig.env.required.map(line => `${line}=`)].join("\n"),
     // Finish with # Optional section
-    "\n\n# Optional\n",
+    "\n\n# Optional — AI Provider\n",
+    ...[
+      "# Set AI_PROVIDER_URL to use a different provider (e.g., https://openrouter.ai/api/v1)",
+      "AI_PROVIDER_URL=",
+      "# Set AI_MODEL to use a different model (default: gpt-4o-mini)",
+      "AI_MODEL=",
+    ].join("\n"),
+    "\n\n# Optional — Network\n",
     ...[
       `NETWORK_ID=${network ?? ""}`,
       rpcUrl ? `RPC_URL=${rpcUrl}` : null,

--- a/typescript/create-onchain-agent/templates/createAgent/framework/langchain/createAgent.ts
+++ b/typescript/create-onchain-agent/templates/createAgent/framework/langchain/createAgent.ts
@@ -2,6 +2,8 @@ import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { MemorySaver } from "@langchain/langgraph";
 import { createAgent as createLangChainAgent } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
 
 /**
@@ -12,13 +14,49 @@ import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
- *    - Configure model parameters like temperature and max tokens
+ *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
+ *    - Set AI_API_KEY with your provider's API key
+ *    - Set AI_MODEL to override the default model for your provider
+ *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
+
+/**
+ * Creates an LLM instance based on the configured AI provider.
+ * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
+ */
+function getLLM() {
+  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
+  const apiKey = process.env.AI_API_KEY;
+
+  switch (provider) {
+    case "anthropic":
+      return new ChatAnthropic({
+        model: process.env.AI_MODEL || "claude-sonnet-4-20250514",
+        ...(apiKey && { apiKey }),
+      });
+    case "google":
+      return new ChatGoogleGenerativeAI({
+        model: process.env.AI_MODEL || "gemini-2.0-flash",
+        ...(apiKey && { apiKey }),
+      });
+    case "custom":
+      return new ChatOpenAI({
+        model: process.env.AI_MODEL || "gpt-4o-mini",
+        ...(apiKey && { apiKey }),
+        configuration: { baseURL: process.env.AI_PROVIDER_URL },
+      });
+    case "openai":
+    default:
+      return new ChatOpenAI({
+        model: process.env.AI_MODEL || "gpt-4o-mini",
+        ...(apiKey && { apiKey }),
+      });
+  }
+}
 
 // The agent
 let agent: ReturnType<typeof createLangChainAgent>;
@@ -43,15 +81,7 @@ export async function createAgent(): Promise<ReturnType<typeof createLangChainAg
   try {
     const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
-    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
-    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
-    const llm = new ChatOpenAI({
-      model: process.env.AI_MODEL || "gpt-4o-mini",
-      apiKey: process.env.AI_API_KEY || process.env.OPENAI_API_KEY,
-      ...(process.env.AI_PROVIDER_URL && {
-        configuration: { baseURL: process.env.AI_PROVIDER_URL },
-      }),
-    });
+    const llm = getLLM();
 
     const tools = await getLangChainTools(agentkit);
     const memory = new MemorySaver();

--- a/typescript/create-onchain-agent/templates/createAgent/framework/langchain/createAgent.ts
+++ b/typescript/create-onchain-agent/templates/createAgent/framework/langchain/createAgent.ts
@@ -2,8 +2,6 @@ import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { MemorySaver } from "@langchain/langgraph";
 import { createAgent as createLangChainAgent } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
-import { ChatAnthropic } from "@langchain/anthropic";
-import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
 
 /**
@@ -14,49 +12,15 @@ import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
  *    - Set AI_API_KEY with your provider's API key
- *    - Set AI_MODEL to override the default model for your provider
- *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
+ *    - Set AI_MODEL to choose your model (default: gpt-4o-mini)
+ *    - Set AI_BASE_URL to use a different provider (e.g., Anthropic, Google, OpenRouter)
+ *    - All major providers support the OpenAI-compatible API format
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
-
-/**
- * Creates an LLM instance based on the configured AI provider.
- * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
- */
-function getLLM() {
-  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
-  const apiKey = process.env.AI_API_KEY;
-
-  switch (provider) {
-    case "anthropic":
-      return new ChatAnthropic({
-        model: process.env.AI_MODEL || "claude-sonnet-4-20250514",
-        ...(apiKey && { apiKey }),
-      });
-    case "google":
-      return new ChatGoogleGenerativeAI({
-        model: process.env.AI_MODEL || "gemini-2.0-flash",
-        ...(apiKey && { apiKey }),
-      });
-    case "custom":
-      return new ChatOpenAI({
-        model: process.env.AI_MODEL || "gpt-4o-mini",
-        ...(apiKey && { apiKey }),
-        configuration: { baseURL: process.env.AI_PROVIDER_URL },
-      });
-    case "openai":
-    default:
-      return new ChatOpenAI({
-        model: process.env.AI_MODEL || "gpt-4o-mini",
-        ...(apiKey && { apiKey }),
-      });
-  }
-}
 
 // The agent
 let agent: ReturnType<typeof createLangChainAgent>;
@@ -81,7 +45,20 @@ export async function createAgent(): Promise<ReturnType<typeof createLangChainAg
   try {
     const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
-    const llm = getLLM();
+    // Initialize LLM — works with any OpenAI-compatible provider.
+    // Configure via env vars: AI_API_KEY, AI_BASE_URL, AI_MODEL
+    // Examples:
+    //   OpenAI:      AI_API_KEY=sk-... (no AI_BASE_URL needed)
+    //   Anthropic:   AI_API_KEY=sk-ant-...  AI_BASE_URL=https://api.anthropic.com/v1/
+    //   Google:      AI_API_KEY=AIza...     AI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+    //   OpenRouter:  AI_API_KEY=sk-or-...   AI_BASE_URL=https://openrouter.ai/api/v1
+    const llm = new ChatOpenAI({
+      model: process.env.AI_MODEL || "gpt-4o-mini",
+      apiKey: process.env.AI_API_KEY || process.env.OPENAI_API_KEY,
+      ...(process.env.AI_BASE_URL && {
+        configuration: { baseURL: process.env.AI_BASE_URL },
+      }),
+    });
 
     const tools = await getLangChainTools(agentkit);
     const memory = new MemorySaver();

--- a/typescript/create-onchain-agent/templates/createAgent/framework/langchain/createAgent.ts
+++ b/typescript/create-onchain-agent/templates/createAgent/framework/langchain/createAgent.ts
@@ -12,7 +12,7 @@ import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Modify the `ChatOpenAI` instantiation to choose your preferred LLM
+ *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
  *    - Configure model parameters like temperature and max tokens
  *
  * 2. Instantiate your Agent:
@@ -43,8 +43,15 @@ export async function createAgent(): Promise<ReturnType<typeof createLangChainAg
   try {
     const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
-    // Initialize LLM: https://platform.openai.com/docs/models#gpt-4o
-    const llm = new ChatOpenAI({ model: "gpt-4o-mini" });
+    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
+    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
+    const llm = new ChatOpenAI({
+      model: process.env.AI_MODEL || "gpt-4o-mini",
+      apiKey: process.env.AI_API_KEY || process.env.OPENAI_API_KEY,
+      ...(process.env.AI_PROVIDER_URL && {
+        configuration: { baseURL: process.env.AI_PROVIDER_URL },
+      }),
+    });
 
     const tools = await getLangChainTools(agentkit);
     const memory = new MemorySaver();

--- a/typescript/create-onchain-agent/templates/createAgent/framework/vercelAISDK/createAgent.ts
+++ b/typescript/create-onchain-agent/templates/createAgent/framework/vercelAISDK/createAgent.ts
@@ -1,4 +1,4 @@
-import { openai } from "@ai-sdk/openai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { getVercelAITools } from "@coinbase/agentkit-vercel-ai-sdk";
 import { generateText, stepCountIs } from "ai";
 import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
@@ -11,7 +11,7 @@ import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Modify the `openai` instantiation to choose your preferred LLM
+ *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
  *    - Configure model parameters like temperature and max tokens
  *
  * 2. Instantiate your Agent:
@@ -23,7 +23,7 @@ import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
 type Agent = {
   tools: ReturnType<typeof getVercelAITools>;
   system: string;
-  model: ReturnType<typeof openai>;
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
   stopWhen?: Parameters<typeof generateText>[0]["stopWhen"];
 };
 let agent: Agent;
@@ -46,8 +46,14 @@ export async function createAgent(): Promise<Agent> {
   }
 
   try {
-    // Initialize LLM: https://platform.openai.com/docs/models#gpt-4o
-    const model = openai.chat("gpt-4o-mini");
+    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
+    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
+    const apiKey = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
+    const provider = createOpenAI({
+      ...(apiKey && { apiKey }),
+      ...(process.env.AI_PROVIDER_URL && { baseURL: process.env.AI_PROVIDER_URL }),
+    });
+    const model = provider.chat(process.env.AI_MODEL || "gpt-4o-mini");
 
     const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 

--- a/typescript/create-onchain-agent/templates/createAgent/framework/vercelAISDK/createAgent.ts
+++ b/typescript/create-onchain-agent/templates/createAgent/framework/vercelAISDK/createAgent.ts
@@ -1,4 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { getVercelAITools } from "@coinbase/agentkit-vercel-ai-sdk";
 import { generateText, stepCountIs } from "ai";
 import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
@@ -11,19 +13,51 @@ import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
- *    - Configure model parameters like temperature and max tokens
+ *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
+ *    - Set AI_API_KEY with your provider's API key
+ *    - Set AI_MODEL to override the default model for your provider
+ *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
 
+/**
+ * Creates a model instance based on the configured AI provider.
+ * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
+ */
+function getModel() {
+  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
+  const apiKey = process.env.AI_API_KEY;
+
+  switch (provider) {
+    case "anthropic":
+      return createAnthropic({ ...(apiKey && { apiKey }) })(
+        process.env.AI_MODEL || "claude-sonnet-4-20250514",
+      );
+    case "google":
+      return createGoogleGenerativeAI({ ...(apiKey && { apiKey }) })(
+        process.env.AI_MODEL || "gemini-2.0-flash",
+      );
+    case "custom":
+      return createOpenAI({
+        ...(apiKey && { apiKey }),
+        baseURL: process.env.AI_PROVIDER_URL,
+      }).chat(process.env.AI_MODEL || "gpt-4o-mini");
+    case "openai":
+    default:
+      return createOpenAI({ ...(apiKey && { apiKey }) }).chat(
+        process.env.AI_MODEL || "gpt-4o-mini",
+      );
+  }
+}
+
 // The agent
 type Agent = {
   tools: ReturnType<typeof getVercelAITools>;
   system: string;
-  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  model: ReturnType<typeof getModel>;
   stopWhen?: Parameters<typeof generateText>[0]["stopWhen"];
 };
 let agent: Agent;
@@ -46,14 +80,7 @@ export async function createAgent(): Promise<Agent> {
   }
 
   try {
-    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
-    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
-    const apiKey = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
-    const provider = createOpenAI({
-      ...(apiKey && { apiKey }),
-      ...(process.env.AI_PROVIDER_URL && { baseURL: process.env.AI_PROVIDER_URL }),
-    });
-    const model = provider.chat(process.env.AI_MODEL || "gpt-4o-mini");
+    const model = getModel();
 
     const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 

--- a/typescript/create-onchain-agent/templates/createAgent/framework/vercelAISDK/createAgent.ts
+++ b/typescript/create-onchain-agent/templates/createAgent/framework/vercelAISDK/createAgent.ts
@@ -1,6 +1,4 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { getVercelAITools } from "@coinbase/agentkit-vercel-ai-sdk";
 import { generateText, stepCountIs } from "ai";
 import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
@@ -13,51 +11,21 @@ import { prepareAgentkitAndWalletProvider } from "./prepareAgentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
  *    - Set AI_API_KEY with your provider's API key
- *    - Set AI_MODEL to override the default model for your provider
- *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
+ *    - Set AI_MODEL to choose your model (default: gpt-4o-mini)
+ *    - Set AI_BASE_URL to use a different provider (e.g., Anthropic, Google, OpenRouter)
+ *    - All major providers support the OpenAI-compatible API format
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
 
-/**
- * Creates a model instance based on the configured AI provider.
- * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
- */
-function getModel() {
-  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
-  const apiKey = process.env.AI_API_KEY;
-
-  switch (provider) {
-    case "anthropic":
-      return createAnthropic({ ...(apiKey && { apiKey }) })(
-        process.env.AI_MODEL || "claude-sonnet-4-20250514",
-      );
-    case "google":
-      return createGoogleGenerativeAI({ ...(apiKey && { apiKey }) })(
-        process.env.AI_MODEL || "gemini-2.0-flash",
-      );
-    case "custom":
-      return createOpenAI({
-        ...(apiKey && { apiKey }),
-        baseURL: process.env.AI_PROVIDER_URL,
-      }).chat(process.env.AI_MODEL || "gpt-4o-mini");
-    case "openai":
-    default:
-      return createOpenAI({ ...(apiKey && { apiKey }) }).chat(
-        process.env.AI_MODEL || "gpt-4o-mini",
-      );
-  }
-}
-
 // The agent
 type Agent = {
   tools: ReturnType<typeof getVercelAITools>;
   system: string;
-  model: ReturnType<typeof getModel>;
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
   stopWhen?: Parameters<typeof generateText>[0]["stopWhen"];
 };
 let agent: Agent;
@@ -80,7 +48,19 @@ export async function createAgent(): Promise<Agent> {
   }
 
   try {
-    const model = getModel();
+    // Initialize LLM — works with any OpenAI-compatible provider.
+    // Configure via env vars: AI_API_KEY, AI_BASE_URL, AI_MODEL
+    // Examples:
+    //   OpenAI:      AI_API_KEY=sk-... (no AI_BASE_URL needed)
+    //   Anthropic:   AI_API_KEY=sk-ant-...  AI_BASE_URL=https://api.anthropic.com/v1/
+    //   Google:      AI_API_KEY=AIza...     AI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+    //   OpenRouter:  AI_API_KEY=sk-or-...   AI_BASE_URL=https://openrouter.ai/api/v1
+    const apiKey = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
+    const provider = createOpenAI({
+      ...(apiKey && { apiKey }),
+      ...(process.env.AI_BASE_URL && { baseURL: process.env.AI_BASE_URL }),
+    });
+    const model = provider.chat(process.env.AI_MODEL || "gpt-4o-mini");
 
     const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
@@ -2,6 +2,8 @@ import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { MemorySaver } from "@langchain/langgraph";
 import { createAgent as createLangChainAgent } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
 
 /**
@@ -12,13 +14,49 @@ import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
- *    - Configure model parameters like temperature and max tokens
+ *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
+ *    - Set AI_API_KEY with your provider's API key
+ *    - Set AI_MODEL to override the default model for your provider
+ *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
+
+/**
+ * Creates an LLM instance based on the configured AI provider.
+ * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
+ */
+function getLLM() {
+  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
+  const apiKey = process.env.AI_API_KEY;
+
+  switch (provider) {
+    case "anthropic":
+      return new ChatAnthropic({
+        model: process.env.AI_MODEL || "claude-sonnet-4-20250514",
+        ...(apiKey && { apiKey }),
+      });
+    case "google":
+      return new ChatGoogleGenerativeAI({
+        model: process.env.AI_MODEL || "gemini-2.0-flash",
+        ...(apiKey && { apiKey }),
+      });
+    case "custom":
+      return new ChatOpenAI({
+        model: process.env.AI_MODEL || "gpt-4o-mini",
+        ...(apiKey && { apiKey }),
+        configuration: { baseURL: process.env.AI_PROVIDER_URL },
+      });
+    case "openai":
+    default:
+      return new ChatOpenAI({
+        model: process.env.AI_MODEL || "gpt-4o-mini",
+        ...(apiKey && { apiKey }),
+      });
+  }
+}
 
 // The agent
 let agent: ReturnType<typeof createLangChainAgent>;
@@ -40,22 +78,17 @@ export async function createAgent(): Promise<ReturnType<typeof createLangChainAg
     return agent;
   }
 
-  if (!process.env.AI_API_KEY && !process.env.OPENAI_API_KEY) {
-    throw new Error("I need an AI_API_KEY (or OPENAI_API_KEY) in your .env file to power my intelligence.");
+  if (!process.env.AI_API_KEY) {
+    throw new Error(
+      "Please set AI_API_KEY in your .env file. " +
+        "This should be the API key for the provider specified by AI_PROVIDER (default: openai).",
+    );
   }
 
   const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
   try {
-    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
-    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
-    const llm = new ChatOpenAI({
-      model: process.env.AI_MODEL || "gpt-4o-mini",
-      apiKey: process.env.AI_API_KEY || process.env.OPENAI_API_KEY,
-      ...(process.env.AI_PROVIDER_URL && {
-        configuration: { baseURL: process.env.AI_PROVIDER_URL },
-      }),
-    });
+    const llm = getLLM();
 
     const tools = await getLangChainTools(agentkit);
     const memory = new MemorySaver();

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
@@ -12,7 +12,7 @@ import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Modify the `ChatOpenAI` instantiation to choose your preferred LLM
+ *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
  *    - Configure model parameters like temperature and max tokens
  *
  * 2. Instantiate your Agent:
@@ -40,15 +40,22 @@ export async function createAgent(): Promise<ReturnType<typeof createLangChainAg
     return agent;
   }
 
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error("I need an OPENAI_API_KEY in your .env file to power my intelligence.");
+  if (!process.env.AI_API_KEY && !process.env.OPENAI_API_KEY) {
+    throw new Error("I need an AI_API_KEY (or OPENAI_API_KEY) in your .env file to power my intelligence.");
   }
 
   const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
   try {
-    // Initialize LLM: https://platform.openai.com/docs/models#gpt-4o
-    const llm = new ChatOpenAI({ model: "gpt-4o-mini" });
+    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
+    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
+    const llm = new ChatOpenAI({
+      model: process.env.AI_MODEL || "gpt-4o-mini",
+      apiKey: process.env.AI_API_KEY || process.env.OPENAI_API_KEY,
+      ...(process.env.AI_PROVIDER_URL && {
+        configuration: { baseURL: process.env.AI_PROVIDER_URL },
+      }),
+    });
 
     const tools = await getLangChainTools(agentkit);
     const memory = new MemorySaver();

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/langchain/create-agent.ts
@@ -2,8 +2,6 @@ import { getLangChainTools } from "@coinbase/agentkit-langchain";
 import { MemorySaver } from "@langchain/langgraph";
 import { createAgent as createLangChainAgent } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
-import { ChatAnthropic } from "@langchain/anthropic";
-import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
 
 /**
@@ -14,49 +12,15 @@ import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
  *    - Set AI_API_KEY with your provider's API key
- *    - Set AI_MODEL to override the default model for your provider
- *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
+ *    - Set AI_MODEL to choose your model (default: gpt-4o-mini)
+ *    - Set AI_BASE_URL to use a different provider (e.g., Anthropic, Google, OpenRouter)
+ *    - All major providers support the OpenAI-compatible API format
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
-
-/**
- * Creates an LLM instance based on the configured AI provider.
- * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
- */
-function getLLM() {
-  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
-  const apiKey = process.env.AI_API_KEY;
-
-  switch (provider) {
-    case "anthropic":
-      return new ChatAnthropic({
-        model: process.env.AI_MODEL || "claude-sonnet-4-20250514",
-        ...(apiKey && { apiKey }),
-      });
-    case "google":
-      return new ChatGoogleGenerativeAI({
-        model: process.env.AI_MODEL || "gemini-2.0-flash",
-        ...(apiKey && { apiKey }),
-      });
-    case "custom":
-      return new ChatOpenAI({
-        model: process.env.AI_MODEL || "gpt-4o-mini",
-        ...(apiKey && { apiKey }),
-        configuration: { baseURL: process.env.AI_PROVIDER_URL },
-      });
-    case "openai":
-    default:
-      return new ChatOpenAI({
-        model: process.env.AI_MODEL || "gpt-4o-mini",
-        ...(apiKey && { apiKey }),
-      });
-  }
-}
 
 // The agent
 let agent: ReturnType<typeof createLangChainAgent>;
@@ -78,17 +42,30 @@ export async function createAgent(): Promise<ReturnType<typeof createLangChainAg
     return agent;
   }
 
-  if (!process.env.AI_API_KEY) {
+  if (!process.env.AI_API_KEY && !process.env.OPENAI_API_KEY) {
     throw new Error(
       "Please set AI_API_KEY in your .env file. " +
-        "This should be the API key for the provider specified by AI_PROVIDER (default: openai).",
+        "This should be your API key for any OpenAI-compatible provider.",
     );
   }
 
   const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
   try {
-    const llm = getLLM();
+    // Initialize LLM — works with any OpenAI-compatible provider.
+    // Configure via env vars: AI_API_KEY, AI_BASE_URL, AI_MODEL
+    // Examples:
+    //   OpenAI:      AI_API_KEY=sk-... (no AI_BASE_URL needed)
+    //   Anthropic:   AI_API_KEY=sk-ant-...  AI_BASE_URL=https://api.anthropic.com/v1/
+    //   Google:      AI_API_KEY=AIza...     AI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+    //   OpenRouter:  AI_API_KEY=sk-or-...   AI_BASE_URL=https://openrouter.ai/api/v1
+    const llm = new ChatOpenAI({
+      model: process.env.AI_MODEL || "gpt-4o-mini",
+      apiKey: process.env.AI_API_KEY || process.env.OPENAI_API_KEY,
+      ...(process.env.AI_BASE_URL && {
+        configuration: { baseURL: process.env.AI_BASE_URL },
+      }),
+    });
 
     const tools = await getLangChainTools(agentkit);
     const memory = new MemorySaver();

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
@@ -1,4 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { getVercelAITools } from "@coinbase/agentkit-vercel-ai-sdk";
 import { generateText, stepCountIs } from "ai";
 import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
@@ -11,19 +13,51 @@ import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
- *    - Configure model parameters like temperature and max tokens
+ *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
+ *    - Set AI_API_KEY with your provider's API key
+ *    - Set AI_MODEL to override the default model for your provider
+ *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
 
+/**
+ * Creates a model instance based on the configured AI provider.
+ * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
+ */
+function getModel() {
+  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
+  const apiKey = process.env.AI_API_KEY;
+
+  switch (provider) {
+    case "anthropic":
+      return createAnthropic({ ...(apiKey && { apiKey }) })(
+        process.env.AI_MODEL || "claude-sonnet-4-20250514",
+      );
+    case "google":
+      return createGoogleGenerativeAI({ ...(apiKey && { apiKey }) })(
+        process.env.AI_MODEL || "gemini-2.0-flash",
+      );
+    case "custom":
+      return createOpenAI({
+        ...(apiKey && { apiKey }),
+        baseURL: process.env.AI_PROVIDER_URL,
+      }).chat(process.env.AI_MODEL || "gpt-4o-mini");
+    case "openai":
+    default:
+      return createOpenAI({ ...(apiKey && { apiKey }) }).chat(
+        process.env.AI_MODEL || "gpt-4o-mini",
+      );
+  }
+}
+
 // The agent
 type Agent = {
   tools: ReturnType<typeof getVercelAITools>;
   system: string;
-  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  model: ReturnType<typeof getModel>;
   stopWhen?: Parameters<typeof generateText>[0]["stopWhen"];
 };
 let agent: Agent;
@@ -45,21 +79,17 @@ export async function createAgent(): Promise<Agent> {
     return agent;
   }
 
-  if (!process.env.AI_API_KEY && !process.env.OPENAI_API_KEY) {
-    throw new Error("I need an AI_API_KEY (or OPENAI_API_KEY) in your .env file to power my intelligence.");
+  if (!process.env.AI_API_KEY) {
+    throw new Error(
+      "Please set AI_API_KEY in your .env file. " +
+        "This should be the API key for the provider specified by AI_PROVIDER (default: openai).",
+    );
   }
 
   const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
   try {
-    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
-    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
-    const apiKey = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
-    const provider = createOpenAI({
-      ...(apiKey && { apiKey }),
-      ...(process.env.AI_PROVIDER_URL && { baseURL: process.env.AI_PROVIDER_URL }),
-    });
-    const model = provider.chat(process.env.AI_MODEL || "gpt-4o-mini");
+    const model = getModel();
 
     // Initialize Agent
     const canUseFaucet = walletProvider.getNetwork().networkId == "base-sepolia";

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
@@ -1,6 +1,4 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { getVercelAITools } from "@coinbase/agentkit-vercel-ai-sdk";
 import { generateText, stepCountIs } from "ai";
 import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
@@ -13,51 +11,21 @@ import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Set AI_PROVIDER to choose your provider: "openai" | "anthropic" | "google" | "custom"
  *    - Set AI_API_KEY with your provider's API key
- *    - Set AI_MODEL to override the default model for your provider
- *    - Set AI_PROVIDER_URL for custom OpenAI-compatible APIs (e.g., OpenRouter, Ollama)
+ *    - Set AI_MODEL to choose your model (default: gpt-4o-mini)
+ *    - Set AI_BASE_URL to use a different provider (e.g., Anthropic, Google, OpenRouter)
+ *    - All major providers support the OpenAI-compatible API format
  *
  * 2. Instantiate your Agent:
  *    - Pass the LLM, tools, and memory into `createAgent()`
  *    - Configure agent-specific parameters
  */
 
-/**
- * Creates a model instance based on the configured AI provider.
- * Supports OpenAI, Anthropic, Google, and any OpenAI-compatible API (e.g., OpenRouter).
- */
-function getModel() {
-  const provider = (process.env.AI_PROVIDER || "openai").toLowerCase();
-  const apiKey = process.env.AI_API_KEY;
-
-  switch (provider) {
-    case "anthropic":
-      return createAnthropic({ ...(apiKey && { apiKey }) })(
-        process.env.AI_MODEL || "claude-sonnet-4-20250514",
-      );
-    case "google":
-      return createGoogleGenerativeAI({ ...(apiKey && { apiKey }) })(
-        process.env.AI_MODEL || "gemini-2.0-flash",
-      );
-    case "custom":
-      return createOpenAI({
-        ...(apiKey && { apiKey }),
-        baseURL: process.env.AI_PROVIDER_URL,
-      }).chat(process.env.AI_MODEL || "gpt-4o-mini");
-    case "openai":
-    default:
-      return createOpenAI({ ...(apiKey && { apiKey }) }).chat(
-        process.env.AI_MODEL || "gpt-4o-mini",
-      );
-  }
-}
-
 // The agent
 type Agent = {
   tools: ReturnType<typeof getVercelAITools>;
   system: string;
-  model: ReturnType<typeof getModel>;
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
   stopWhen?: Parameters<typeof generateText>[0]["stopWhen"];
 };
 let agent: Agent;
@@ -79,17 +47,29 @@ export async function createAgent(): Promise<Agent> {
     return agent;
   }
 
-  if (!process.env.AI_API_KEY) {
+  if (!process.env.AI_API_KEY && !process.env.OPENAI_API_KEY) {
     throw new Error(
       "Please set AI_API_KEY in your .env file. " +
-        "This should be the API key for the provider specified by AI_PROVIDER (default: openai).",
+        "This should be your API key for any OpenAI-compatible provider.",
     );
   }
 
   const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
   try {
-    const model = getModel();
+    // Initialize LLM — works with any OpenAI-compatible provider.
+    // Configure via env vars: AI_API_KEY, AI_BASE_URL, AI_MODEL
+    // Examples:
+    //   OpenAI:      AI_API_KEY=sk-... (no AI_BASE_URL needed)
+    //   Anthropic:   AI_API_KEY=sk-ant-...  AI_BASE_URL=https://api.anthropic.com/v1/
+    //   Google:      AI_API_KEY=AIza...     AI_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+    //   OpenRouter:  AI_API_KEY=sk-or-...   AI_BASE_URL=https://openrouter.ai/api/v1
+    const apiKey = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
+    const provider = createOpenAI({
+      ...(apiKey && { apiKey }),
+      ...(process.env.AI_BASE_URL && { baseURL: process.env.AI_BASE_URL }),
+    });
+    const model = provider.chat(process.env.AI_MODEL || "gpt-4o-mini");
 
     // Initialize Agent
     const canUseFaucet = walletProvider.getNetwork().networkId == "base-sepolia";

--- a/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
+++ b/typescript/create-onchain-agent/templates/next/app/api/agent/framework/vercel-ai-sdk/create-agent.ts
@@ -1,4 +1,4 @@
-import { openai } from "@ai-sdk/openai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { getVercelAITools } from "@coinbase/agentkit-vercel-ai-sdk";
 import { generateText, stepCountIs } from "ai";
 import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
@@ -11,7 +11,7 @@ import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
  * Key Steps to Customize Your Agent:
  *
  * 1. Select your LLM:
- *    - Modify the `openai` instantiation to choose your preferred LLM
+ *    - Set AI_API_KEY, AI_PROVIDER_URL, and AI_MODEL in your .env to use any OpenAI-compatible provider
  *    - Configure model parameters like temperature and max tokens
  *
  * 2. Instantiate your Agent:
@@ -23,7 +23,7 @@ import { prepareAgentkitAndWalletProvider } from "./prepare-agentkit";
 type Agent = {
   tools: ReturnType<typeof getVercelAITools>;
   system: string;
-  model: ReturnType<typeof openai>;
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
   stopWhen?: Parameters<typeof generateText>[0]["stopWhen"];
 };
 let agent: Agent;
@@ -45,15 +45,21 @@ export async function createAgent(): Promise<Agent> {
     return agent;
   }
 
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error("I need an OPENAI_API_KEY in your .env file to power my intelligence.");
+  if (!process.env.AI_API_KEY && !process.env.OPENAI_API_KEY) {
+    throw new Error("I need an AI_API_KEY (or OPENAI_API_KEY) in your .env file to power my intelligence.");
   }
 
   const { agentkit, walletProvider } = await prepareAgentkitAndWalletProvider();
 
   try {
-    // Initialize LLM: https://platform.openai.com/docs/models#gpt-4o
-    const model = openai.chat("gpt-4o-mini");
+    // Initialize LLM — supports any OpenAI-compatible provider (OpenAI, OpenRouter, Groq, etc.)
+    // Configure via env vars: AI_API_KEY, AI_PROVIDER_URL, AI_MODEL
+    const apiKey = process.env.AI_API_KEY || process.env.OPENAI_API_KEY;
+    const provider = createOpenAI({
+      ...(apiKey && { apiKey }),
+      ...(process.env.AI_PROVIDER_URL && { baseURL: process.env.AI_PROVIDER_URL }),
+    });
+    const model = provider.chat(process.env.AI_MODEL || "gpt-4o-mini");
 
     // Initialize Agent
     const canUseFaucet = walletProvider.getNetwork().networkId == "base-sepolia";

--- a/typescript/create-onchain-agent/templates/next/package.json
+++ b/typescript/create-onchain-agent/templates/next/package.json
@@ -9,11 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.0.0",
+    "@ai-sdk/google": "^1.0.0",
     "@ai-sdk/openai": "^3.0.0",
     "@coinbase/agentkit": "latest",
     "@coinbase/agentkit-langchain": "latest",
     "@coinbase/agentkit-vercel-ai-sdk": "latest",
+    "@langchain/anthropic": "^0.3.0",
     "@langchain/core": "^1.1.0",
+    "@langchain/google-genai": "^0.2.0",
     "@langchain/langgraph": "^1.2.0",
     "@langchain/openai": "^1.2.0",
     "@solana/web3.js": "^1.98.0",

--- a/typescript/create-onchain-agent/templates/next/package.json
+++ b/typescript/create-onchain-agent/templates/next/package.json
@@ -9,15 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.0.0",
-    "@ai-sdk/google": "^1.0.0",
     "@ai-sdk/openai": "^3.0.0",
     "@coinbase/agentkit": "latest",
     "@coinbase/agentkit-langchain": "latest",
     "@coinbase/agentkit-vercel-ai-sdk": "latest",
-    "@langchain/anthropic": "^0.3.0",
     "@langchain/core": "^1.1.0",
-    "@langchain/google-genai": "^0.2.0",
     "@langchain/langgraph": "^1.2.0",
     "@langchain/openai": "^1.2.0",
     "@solana/web3.js": "^1.98.0",


### PR DESCRIPTION
## Description

Make `create-onchain-agent` templates LLM provider-agnostic.

Closes #1106 

The templates currently hardcode `openai("gpt-4o-mini")` and `OPENAI_API_KEY`. This change replaces the hardcoded singleton with `createOpenAI({ apiKey, baseURL })` / `new ChatOpenAI({ apiKey, configuration: { baseURL } })`, configured via environment variables. 

Since all major LLM providers now support the OpenAI-compatible API format, this lets developers configure any provider seamlessly via `.env.local` without needing to edit the scaffolded codebase.

**Env vars added:**
- `AI_API_KEY` (Falls back to `OPENAI_API_KEY`)
- `AI_BASE_URL` (Provider's endpoint, defaults to OpenAI)
- `AI_MODEL` (Defaults to `gpt-4o-mini`)

**Files changed:**
- `templates/createAgent/framework/vercelAISDK/createAgent.ts`
- `templates/createAgent/framework/langchain/createAgent.ts`
- `templates/next/.../vercel-ai-sdk/create-agent.ts`
- `templates/next/.../langchain/create-agent.ts`
- `src/common/utils.ts` (Generates `.env.local` containing universal provider examples)
- *Zero new dependencies added to package.json*

## Tests

Since these changes modify the scaffolding templates and not runtime code, I tested by generating a new template, replacing the code with my modified templates, and routing requests to OpenRouter.

```
Chatbot: test-agent-vercel (Vercel AI SDK Next.js Scaffold)
Network: Base Sepolia
Setup: Configured AI_BASE_URL to OpenRouter and AI_MODEL to google/gemini-2.5-flash. Fauceted with test ETH.

Prompt: what can you do?

-------------------
I can perform a variety of tasks onchain, including:

Wrap and unwrap ETH to WETH.
Fetch cryptocurrency prices from Pyth (e.g., BTC, ETH, SOL).
Get your wallet details, including address, network, and balances.
Transfer native tokens (like ETH or SOL) to another address.
Interact with ERC20 tokens:
Get token balances.
Transfer tokens.
Approve token spending for other addresses.
Get allowance amounts for token spending.
Get ERC20 token addresses for common symbols.
Request test funds from a faucet on 'base-sepolia' or 'solana-devnet'.
Manage smart wallet spend permissions:
List existing spend permissions.
Use a spend permission to spend tokens on behalf of a smart account.
Swap tokens using the CDP Swap API.
Interact with X402 services:
Discover available X402 services.
Make HTTP requests to X402 endpoints, handling payments if required.
What would you like me to do?
-------------------
```

## Checklist

A couple of things to include in your PR for completeness:

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry
