### PR TITLE
feat: add Radius Network to supported chains (eip155:723487)

### DIFF
--- a/python/coinbase-agentkit/changelog.d/add-radius-network.feature.md
+++ b/python/coinbase-agentkit/changelog.d/add-radius-network.feature.md
@@ -1,0 +1,1 @@
+Added Radius Network (chain ID 723487) and Radius Testnet (chain ID 72344) to the EVM network registry.

--- a/python/coinbase-agentkit/coinbase_agentkit/network/chain_definitions.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/network/chain_definitions.py
@@ -357,3 +357,50 @@ polygon = Chain(
         },
     },
 )
+
+radius = Chain(
+    id="723487",
+    name="Radius Network",
+    native_currency={"name": "Radius USD", "symbol": "RUSD", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://rpc.radiustech.xyz"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Radius Explorer",
+            "url": "https://network.radiustech.xyz",
+            "api_url": "https://network.radiustech.xyz/api",
+        },
+    },
+    contracts={
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+        },
+    },
+)
+
+radius_testnet = Chain(
+    id="72344",
+    name="Radius Testnet",
+    native_currency={"name": "Radius USD", "symbol": "RUSD", "decimals": 18},
+    rpc_urls={
+        "default": {
+            "http": ["https://rpc.testnet.radiustech.xyz"],
+        },
+    },
+    block_explorers={
+        "default": {
+            "name": "Radius Testnet Explorer",
+            "url": "https://testnet.radiustech.xyz",
+            "api_url": "https://testnet.radiustech.xyz/api",
+        },
+    },
+    contracts={
+        "multicall3": {
+            "address": "0xca11bde05977b3631167028862be2a173976ca11",
+        },
+    },
+    testnet=True,
+)

--- a/python/coinbase-agentkit/coinbase_agentkit/network/network.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/network/network.py
@@ -10,6 +10,8 @@ from .chain_definitions import (
     optimism_sepolia,
     polygon,
     polygon_amoy,
+    radius,
+    radius_testnet,
     sepolia,
 )
 
@@ -34,6 +36,8 @@ CHAIN_ID_TO_NETWORK_ID: dict[str, str] = {
     "421614": "arbitrum-sepolia",
     "10": "optimism-mainnet",
     "11155420": "optimism-sepolia",
+    "723487": "radius-mainnet",
+    "72344": "radius-testnet",
 }
 
 # Maps Coinbase network IDs to EVM chain IDs
@@ -53,4 +57,6 @@ NETWORK_ID_TO_CHAIN: dict[str, dict] = {
     "arbitrum-sepolia": arbitrum_sepolia,
     "optimism-mainnet": optimism,
     "optimism-sepolia": optimism_sepolia,
+    "radius-mainnet": radius,
+    "radius-testnet": radius_testnet,
 }

--- a/python/create-onchain-agent/changelog.d/add-radius-network.feature.md
+++ b/python/create-onchain-agent/changelog.d/add-radius-network.feature.md
@@ -1,0 +1,1 @@
+Added Radius Network and Radius Testnet to the EVM_NETWORKS choices so scaffolded agents can select Radius during setup.

--- a/python/create-onchain-agent/create_onchain_agent/cli.py
+++ b/python/create-onchain-agent/create_onchain_agent/cli.py
@@ -59,6 +59,8 @@ EVM_NETWORKS = [
     ("optimism-sepolia", "Optimism Sepolia"),
     ("polygon-mainnet", "Polygon Mainnet"),
     ("polygon-mumbai", "Polygon Mumbai"),
+    ("radius-mainnet", "Radius Mainnet"),
+    ("radius-testnet", "Radius Testnet"),
 ]
 
 SVM_NETWORKS = [

--- a/typescript/.changeset/add-radius-network.md
+++ b/typescript/.changeset/add-radius-network.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Added Radius Network (chain ID 723487) and Radius Testnet (chain ID 72344) to the EVM network registry. Agents using `ViemWalletProvider` can now target Radius for ERC-20 transfers and generic contract operations via standard AgentKit action providers.

--- a/typescript/agentkit/src/network/network.ts
+++ b/typescript/agentkit/src/network/network.ts
@@ -11,7 +11,35 @@ import {
   polygonAmoy,
   polygon,
 } from "viem/chains";
+import { defineChain } from "viem";
 import * as chains from "viem/chains";
+
+const radius = defineChain({
+  id: 723487,
+  name: "Radius Network",
+  nativeCurrency: { name: "Radius USD", symbol: "RUSD", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.radiustech.xyz"] } },
+  blockExplorers: {
+    default: { name: "Radius Explorer", url: "https://network.radiustech.xyz" },
+  },
+  contracts: {
+    multicall3: { address: "0xcA11bde05977b3631167028862bE2a173976CA11" },
+  },
+});
+
+const radiusTestnet = defineChain({
+  id: 72344,
+  name: "Radius Testnet",
+  nativeCurrency: { name: "Radius USD", symbol: "RUSD", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.testnet.radiustech.xyz"] } },
+  blockExplorers: {
+    default: { name: "Radius Testnet Explorer", url: "https://testnet.radiustech.xyz" },
+  },
+  contracts: {
+    multicall3: { address: "0xcA11bde05977b3631167028862bE2a173976CA11" },
+  },
+  testnet: true,
+});
 
 /**
  * Maps EVM chain IDs to Coinbase network IDs
@@ -27,6 +55,8 @@ export const CHAIN_ID_TO_NETWORK_ID: Record<number, string> = {
   421614: "arbitrum-sepolia",
   10: "optimism-mainnet",
   11155420: "optimism-sepolia",
+  723487: "radius-mainnet",
+  72344: "radius-testnet",
 };
 
 /**
@@ -56,6 +86,8 @@ export const NETWORK_ID_TO_VIEM_CHAIN: Record<string, Chain> = {
   "arbitrum-sepolia": arbitrumSepolia,
   "optimism-mainnet": optimism,
   "optimism-sepolia": optimismSepolia,
+  "radius-mainnet": radius,
+  "radius-testnet": radiusTestnet,
 };
 
 /**

--- a/typescript/create-onchain-agent/src/common/constants.ts
+++ b/typescript/create-onchain-agent/src/common/constants.ts
@@ -15,6 +15,8 @@ export const EVM_NETWORKS = [
   "optimism-sepolia",
   "polygon-mainnet",
   "polygon-mumbai",
+  "radius-mainnet",
+  "radius-testnet",
 ] as const;
 
 export type EVMNetwork = (typeof EVM_NETWORKS)[number];
@@ -50,6 +52,8 @@ export const NetworkToWalletProviders: Record<Network, readonly WalletProviderCh
   "optimism-sepolia": NON_CDP_SUPPORTED_EVM_WALLET_PROVIDERS,
   "polygon-mainnet": CDP_SUPPORTED_EVM_WALLET_PROVIDERS,
   "polygon-mumbai": NON_CDP_SUPPORTED_EVM_WALLET_PROVIDERS,
+  "radius-mainnet": NON_CDP_SUPPORTED_EVM_WALLET_PROVIDERS,
+  "radius-testnet": NON_CDP_SUPPORTED_EVM_WALLET_PROVIDERS,
   "solana-mainnet": SVM_WALLET_PROVIDERS,
   "solana-devnet": SVM_WALLET_PROVIDERS,
   "solana-testnet": SVM_WALLET_PROVIDERS,

--- a/typescript/create-onchain-agent/src/common/utils.ts
+++ b/typescript/create-onchain-agent/src/common/utils.ts
@@ -26,6 +26,8 @@ export const CHAIN_ID_TO_NETWORK_ID: Record<number, string> = {
   421614: "arbitrum-sepolia",
   10: "optimism-mainnet",
   11155420: "optimism-sepolia",
+  723487: "radius-mainnet",
+  72344: "radius-testnet",
 };
 
 /**


### PR DESCRIPTION
## Summary

Add Radius Network (chain ID `723487`) and its testnet (chain ID `72344`) to AgentKit's EVM network registry. This lets agents built with AgentKit use Radius via the ViemWalletProvider and CdpEvmWalletProvider paths for non-CDP operations (ERC-20 transfers, generic contract calls via viem).

[Radius Network](https://radiustech.xyz) is an EVM-compatible platform optimized for agentic micropayments — sub-penny costs (~$0.0001/tx), sub-second finality, and stablecoin-native gas (RUSD).

### Chain details

| | Chain ID | RPC | Explorer |
|-|---|---|---|
| Mainnet | 723487 | https://rpc.radiustech.xyz | https://network.radiustech.xyz |
| Testnet | 72344  | https://rpc.testnet.radiustech.xyz | https://testnet.radiustech.xyz |

Native currency: **RUSD** (Radius USD, 18 decimals). Registered in [ethereum-lists/chains](https://github.com/ethereum-lists/chains/pull/8168) and in viem 2.48.0+ as `radius` / `radiusTestnet`.

Multicall3 is deployed at the canonical `0xcA11bde05977b3631167028862bE2a173976CA11`.

### Scope

This PR covers the generic EVM chain registry (`src/network/network.ts` and `coinbase_agentkit/network/network.py`) and the `create-onchain-agent` scaffolder. The x402 action provider's `SUPPORTED_NETWORKS` list is intentionally not touched — Radius x402 support will follow once [x402-foundation/x402#2038](https://github.com/x402-foundation/x402/pull/2038) lands and AgentKit bumps its x402 dep.

ERC-20 token address registration for Radius (SBC stablecoin) is tracked as a follow-up PR.

### Implementation notes

- `defineChain` is used inline in `network.ts` rather than importing `radius` / `radiusTestnet` from `viem/chains`, to avoid bumping the exact-pinned `viem@2.47.4`. Happy to switch to the viem imports + version bump if preferred.
- Matches the PR #882 pattern: TS changeset + Python `changelog.d` fragments included for both `coinbase-agentkit` and `create-onchain-agent`.

### Links

- Website: https://radiustech.xyz
- Docs: https://docs.radiustech.xyz
