### PR TITLE
feat(ngz): add No-Going-Zone onchain habit accountability action provider

### DIFF
--- a/typescript/.changeset/proud-habits-shine.md
+++ b/typescript/.changeset/proud-habits-shine.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added NGZ (No-Going-Zone) action provider for onchain habit accountability on Base

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -22,6 +22,7 @@ export * from "./messari";
 export * from "./pyth";
 export * from "./moonwell";
 export * from "./morpho";
+export * from "./ngz";
 export * from "./opensea";
 export * from "./spl";
 export * from "./superfluid";

--- a/typescript/agentkit/src/action-providers/ngz/README.md
+++ b/typescript/agentkit/src/action-providers/ngz/README.md
@@ -1,0 +1,54 @@
+# NGZ Action Provider
+
+Onchain habit accountability on Base. No-Going-Zone (NGZ) lets users declare habits, check in daily to build streaks, earn soulbound milestone NFTs at 7/30/90/180/365 days, and face permanent onchain consequences (Wall of Shame NFTs) when they relapse.
+
+All data lives onchain — no backend, no database, no way to delete your shame.
+
+**Contract:** `0x4D1b5da45a5D278900aedfc6c96F0EE0D4e28bF6` (Base Sepolia)
+**Frontend:** https://frontend-one-khaki-22.vercel.app
+
+## Actions
+
+### Read-only (no wallet required)
+
+| Action | Description |
+|---|---|
+| `get_ngz_leaderboard` | Fetch top streak holders ranked by current streak |
+| `get_ngz_user` | Look up a user's full stats by wallet address |
+| `get_ngz_wall_of_shame` | Fetch recent relapse events from the Wall of Shame |
+
+### Write (wallet required)
+
+| Action | Description |
+|---|---|
+| `check_in_ngz` | Record today's check-in to maintain your streak |
+| `tip_ngz_user` | Send ETH respect directly to another user's wallet |
+
+## Usage
+
+```typescript
+import { ngzActionProvider } from "@coinbase/agentkit";
+
+const agentKit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [ngzActionProvider()],
+});
+```
+
+## Networks
+
+Supported: `base-mainnet`, `base-sepolia`
+
+> **Note:** The NGZ contract is currently deployed on Base Sepolia testnet. Mainnet deployment is in progress.
+
+## Streak Milestones (Soulbound NFTs)
+
+| Days | Tier |
+|---|---|
+| 7 | Novice Resister |
+| 30 | Goon Slayer |
+| 90 | Monk Mode Activated |
+| 180 | Half-Year Warrior |
+| 365 | NGZ Legend |
+
+Relapsing mints a permanent **Fell Off** shame NFT that cannot be transferred or burned.

--- a/typescript/agentkit/src/action-providers/ngz/index.ts
+++ b/typescript/agentkit/src/action-providers/ngz/index.ts
@@ -1,0 +1,2 @@
+export * from "./ngzActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/ngz/ngzActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/ngz/ngzActionProvider.test.ts
@@ -1,0 +1,285 @@
+import { ngzActionProvider } from "./ngzActionProvider";
+
+const mockReadContract = jest.fn();
+const mockSendTransaction = jest.fn();
+
+jest.mock("viem", () => {
+  const actual = jest.requireActual("viem");
+  return {
+    ...actual,
+    createPublicClient: jest.fn(() => ({
+      readContract: mockReadContract,
+    })),
+  };
+});
+
+describe("NGZActionProvider", () => {
+  const provider = ngzActionProvider();
+
+  const mockWalletProvider = {
+    sendTransaction: mockSendTransaction,
+    getAddress: jest.fn().mockResolvedValue("0xabc123"),
+    getNetwork: jest.fn().mockResolvedValue({ networkId: "base-sepolia" }),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ─── getLeaderboard ───────────────────────────────────────────────
+
+  describe("getLeaderboard", () => {
+    it("should return ranked leaderboard on success", async () => {
+      mockReadContract.mockResolvedValueOnce([
+        ["0xuser1", "0xuser2"],
+        [
+          {
+            username: "benny",
+            habitName: "No Pornography",
+            category: 1,
+            currentStreak: 30n,
+            longestStreak: 30n,
+            lastCheckIn: 1700000000n,
+            startedAt: 1697000000n,
+            totalCheckIns: 30n,
+            totalRelapses: 0n,
+            totalTipsReceived: 0n,
+            registered: true,
+          },
+          {
+            username: "alice",
+            habitName: "No Smoking",
+            category: 2,
+            currentStreak: 14n,
+            longestStreak: 20n,
+            lastCheckIn: 1700000000n,
+            startedAt: 1698000000n,
+            totalCheckIns: 14n,
+            totalRelapses: 1n,
+            totalTipsReceived: 1000000000000000n,
+            registered: true,
+          },
+        ],
+      ]);
+
+      const result = await provider.getLeaderboard({ limit: 10 });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(2);
+      expect(parsed.leaderboard[0].rank).toBe(1);
+      expect(parsed.leaderboard[0].username).toBe("benny");
+      expect(parsed.leaderboard[0].currentStreak).toBe(30);
+      expect(parsed.leaderboard[1].username).toBe("alice");
+    });
+
+    it("should return empty list when no users registered", async () => {
+      mockReadContract.mockResolvedValueOnce([[], []]);
+
+      const result = await provider.getLeaderboard({ limit: 10 });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+      expect(parsed.leaderboard).toEqual([]);
+    });
+
+    it("should return error on contract failure", async () => {
+      mockReadContract.mockRejectedValueOnce(new Error("RPC error"));
+
+      const result = await provider.getLeaderboard({ limit: 10 });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("RPC error");
+    });
+  });
+
+  // ─── getUser ─────────────────────────────────────────────────────
+
+  describe("getUser", () => {
+    it("should return user stats for a registered address", async () => {
+      mockReadContract.mockResolvedValueOnce({
+        username: "benny",
+        habitName: "No Pornography",
+        category: 1,
+        currentStreak: 30n,
+        longestStreak: 30n,
+        lastCheckIn: 1700000000n,
+        startedAt: 1697000000n,
+        totalCheckIns: 30n,
+        totalRelapses: 0n,
+        totalTipsReceived: 500000000000000n,
+        registered: true,
+      });
+
+      const result = await provider.getUser({ address: "0xuser1" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.registered).toBe(true);
+      expect(parsed.username).toBe("benny");
+      expect(parsed.currentStreak).toBe(30);
+      expect(parsed.totalRelapses).toBe(0);
+    });
+
+    it("should return registered: false for unknown address", async () => {
+      mockReadContract.mockResolvedValueOnce({
+        username: "",
+        habitName: "",
+        category: 0,
+        currentStreak: 0n,
+        longestStreak: 0n,
+        lastCheckIn: 0n,
+        startedAt: 0n,
+        totalCheckIns: 0n,
+        totalRelapses: 0n,
+        totalTipsReceived: 0n,
+        registered: false,
+      });
+
+      const result = await provider.getUser({ address: "0xunknown" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.registered).toBe(false);
+    });
+
+    it("should return error on contract failure", async () => {
+      mockReadContract.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await provider.getUser({ address: "0xuser1" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Network error");
+    });
+  });
+
+  // ─── getWallOfShame ──────────────────────────────────────────────
+
+  describe("getWallOfShame", () => {
+    it("should return relapse events", async () => {
+      mockReadContract.mockResolvedValueOnce([
+        {
+          user: "0xuser1",
+          username: "benny",
+          habitName: "No Pornography",
+          streakLost: 25n,
+          timestamp: 1700000000n,
+          message: "I was weak",
+        },
+      ]);
+
+      const result = await provider.getWallOfShame({ limit: 10, offset: 0 });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(1);
+      expect(parsed.relapses[0].username).toBe("benny");
+      expect(parsed.relapses[0].streakLost).toBe(25);
+      expect(parsed.relapses[0].message).toBe("I was weak");
+    });
+
+    it("should return empty list when wall is clean", async () => {
+      mockReadContract.mockResolvedValueOnce([]);
+
+      const result = await provider.getWallOfShame({ limit: 10, offset: 0 });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+      expect(parsed.relapses).toEqual([]);
+    });
+
+    it("should return error on contract failure", async () => {
+      mockReadContract.mockRejectedValueOnce(new Error("Timeout"));
+
+      const result = await provider.getWallOfShame({ limit: 10, offset: 0 });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Timeout");
+    });
+  });
+
+  // ─── checkIn ─────────────────────────────────────────────────────
+
+  describe("checkIn", () => {
+    it("should return transaction hash on success", async () => {
+      mockSendTransaction.mockResolvedValueOnce("0xtxhash123");
+
+      const result = await provider.checkIn({}, mockWalletProvider as never);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.transactionHash).toBe("0xtxhash123");
+      expect(parsed.message).toContain("streak");
+    });
+
+    it("should return error when transaction fails", async () => {
+      mockSendTransaction.mockRejectedValueOnce(new Error("Insufficient gas"));
+
+      const result = await provider.checkIn({}, mockWalletProvider as never);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Insufficient gas");
+    });
+  });
+
+  // ─── tipUser ─────────────────────────────────────────────────────
+
+  describe("tipUser", () => {
+    it("should return transaction hash on successful tip", async () => {
+      mockSendTransaction.mockResolvedValueOnce("0xtiphash456");
+
+      const result = await provider.tipUser(
+        {
+          recipientAddress: "0x1234567890123456789012345678901234567890",
+          amountInEth: "0.001",
+          message: "Keep going!",
+        },
+        mockWalletProvider as never,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.transactionHash).toBe("0xtiphash456");
+      expect(parsed.message).toContain("0.001 ETH");
+    });
+
+    it("should return error when tip transaction fails", async () => {
+      mockSendTransaction.mockRejectedValueOnce(new Error("Insufficient balance"));
+
+      const result = await provider.tipUser(
+        {
+          recipientAddress: "0x1234567890123456789012345678901234567890",
+          amountInEth: "0.001",
+          message: "",
+        },
+        mockWalletProvider as never,
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Insufficient balance");
+    });
+  });
+
+  // ─── supportsNetwork ─────────────────────────────────────────────
+
+  describe("supportsNetwork", () => {
+    it("should support base-mainnet", () => {
+      expect(provider.supportsNetwork({ networkId: "base-mainnet" } as never)).toBe(true);
+    });
+
+    it("should support base-sepolia", () => {
+      expect(provider.supportsNetwork({ networkId: "base-sepolia" } as never)).toBe(true);
+    });
+
+    it("should not support other networks", () => {
+      expect(provider.supportsNetwork({ networkId: "ethereum-mainnet" } as never)).toBe(false);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/ngz/ngzActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/ngz/ngzActionProvider.ts
@@ -1,0 +1,404 @@
+import { z } from "zod";
+import { parseEther, createPublicClient, http, encodeFunctionData } from "viem";
+import { base, baseSepolia } from "viem/chains";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { Network, WalletProvider } from "../../network";
+import {
+  GetNGZLeaderboardSchema,
+  GetNGZUserSchema,
+  GetNGZWallOfShameSchema,
+  CheckInNGZSchema,
+  TipNGZUserSchema,
+} from "./schemas";
+
+const NGZ_CONTRACT_ADDRESS = "0x4D1b5da45a5D278900aedfc6c96F0EE0D4e28bF6" as const;
+
+const NGZ_ABI = [
+  {
+    name: "getLeaderboard",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "limit", type: "uint256" }],
+    outputs: [
+      { name: "addrs", type: "address[]" },
+      {
+        name: "userData",
+        type: "tuple[]",
+        components: [
+          { name: "username", type: "string" },
+          { name: "habitName", type: "string" },
+          { name: "category", type: "uint8" },
+          { name: "currentStreak", type: "uint256" },
+          { name: "longestStreak", type: "uint256" },
+          { name: "lastCheckIn", type: "uint256" },
+          { name: "startedAt", type: "uint256" },
+          { name: "totalCheckIns", type: "uint256" },
+          { name: "totalRelapses", type: "uint256" },
+          { name: "totalTipsReceived", type: "uint256" },
+          { name: "registered", type: "bool" },
+        ],
+      },
+    ],
+  },
+  {
+    name: "getUser",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "addr", type: "address" }],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          { name: "username", type: "string" },
+          { name: "habitName", type: "string" },
+          { name: "category", type: "uint8" },
+          { name: "currentStreak", type: "uint256" },
+          { name: "longestStreak", type: "uint256" },
+          { name: "lastCheckIn", type: "uint256" },
+          { name: "startedAt", type: "uint256" },
+          { name: "totalCheckIns", type: "uint256" },
+          { name: "totalRelapses", type: "uint256" },
+          { name: "totalTipsReceived", type: "uint256" },
+          { name: "registered", type: "bool" },
+        ],
+      },
+    ],
+  },
+  {
+    name: "getRelapseWall",
+    type: "function",
+    stateMutability: "view",
+    inputs: [
+      { name: "offset", type: "uint256" },
+      { name: "limit", type: "uint256" },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "tuple[]",
+        components: [
+          { name: "user", type: "address" },
+          { name: "username", type: "string" },
+          { name: "habitName", type: "string" },
+          { name: "streakLost", type: "uint256" },
+          { name: "timestamp", type: "uint256" },
+          { name: "message", type: "string" },
+        ],
+      },
+    ],
+  },
+  {
+    name: "checkIn",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [],
+  },
+  {
+    name: "tip",
+    type: "function",
+    stateMutability: "payable",
+    inputs: [
+      { name: "recipient", type: "address" },
+      { name: "message", type: "string" },
+    ],
+    outputs: [],
+  },
+] as const;
+
+/**
+ * Returns a viem public client configured for the given network.
+ *
+ * @param networkId - The network ID (e.g. "base-mainnet" or "base-sepolia").
+ * @returns A viem PublicClient.
+ */
+function getClient(networkId: string) {
+  const chain = networkId === "base-mainnet" ? base : baseSepolia;
+  return createPublicClient({ chain, transport: http() });
+}
+
+/**
+ * NGZActionProvider provides actions for interacting with No-Going-Zone (NGZ),
+ * an onchain habit accountability tracker deployed on Base.
+ *
+ * NGZ lets users declare habits, check in daily to build streaks, earn soulbound
+ * milestone NFTs, and face permanent onchain consequences (Wall of Shame NFTs) if
+ * they relapse. All data lives onchain on Base — no backend, no database.
+ *
+ * Read-only actions (no wallet required):
+ * - get_ngz_leaderboard: Fetch top streak holders
+ * - get_ngz_user: Look up a user's stats by address
+ * - get_ngz_wall_of_shame: Fetch recent relapse events
+ *
+ * Write actions (wallet required):
+ * - check_in_ngz: Record today's check-in to maintain your streak
+ * - tip_ngz_user: Send ETH respect directly to another user's wallet
+ *
+ * Contract: ${NGZ_CONTRACT_ADDRESS} (Base Sepolia testnet)
+ * Frontend: https://frontend-one-khaki-22.vercel.app
+ */
+export class NGZActionProvider extends ActionProvider<WalletProvider> {
+  /**
+   * Constructs a new NGZActionProvider.
+   */
+  constructor() {
+    super("ngz", []);
+  }
+
+  /**
+   * Fetches the top streak holders from the NGZ leaderboard.
+   *
+   * @param args - The arguments for the action.
+   * @returns Ranked leaderboard as stringified JSON.
+   */
+  @CreateAction({
+    name: "get_ngz_leaderboard",
+    description: `Fetches the top streak holders from No-Going-Zone (NGZ), an onchain habit accountability tracker on Base.
+
+Returns a ranked list of users with their current streak, habit name, longest streak, and total check-ins.
+Use this to find who is leading the leaderboard, check on a specific rank, or get an overview of NGZ activity.
+
+Example response fields per user:
+- rank: position on the leaderboard (1 = top)
+- username: the user's NGZ handle
+- habitName: the habit they are tracking (e.g. "No Pornography", "No Smoking")
+- currentStreak: days clean right now
+- longestStreak: their all-time best streak in days
+- totalCheckIns: total number of times they have checked in
+- address: their wallet address`,
+    schema: GetNGZLeaderboardSchema,
+  })
+  async getLeaderboard(args: z.infer<typeof GetNGZLeaderboardSchema>): Promise<string> {
+    try {
+      const client = getClient("base-sepolia");
+      const [addrs, userData] = await client.readContract({
+        address: NGZ_CONTRACT_ADDRESS,
+        abi: NGZ_ABI,
+        functionName: "getLeaderboard",
+        args: [BigInt(args.limit)],
+      });
+
+      if (!addrs || addrs.length === 0) {
+        return JSON.stringify({ success: true, count: 0, leaderboard: [] });
+      }
+
+      const leaderboard = addrs.map((addr, i) => ({
+        rank: i + 1,
+        address: addr,
+        username: userData[i].username,
+        habitName: userData[i].habitName,
+        currentStreak: Number(userData[i].currentStreak),
+        longestStreak: Number(userData[i].longestStreak),
+        totalCheckIns: Number(userData[i].totalCheckIns),
+        totalRelapses: Number(userData[i].totalRelapses),
+      }));
+
+      return JSON.stringify({ success: true, count: leaderboard.length, leaderboard });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  /**
+   * Fetches the onchain stats of an NGZ user by wallet address.
+   *
+   * @param args - The arguments for the action.
+   * @returns User stats as stringified JSON.
+   */
+  @CreateAction({
+    name: "get_ngz_user",
+    description: `Fetches the onchain stats of a specific No-Going-Zone (NGZ) user by their wallet address.
+
+Returns the user's full profile including current streak, longest streak, habit name, total check-ins, total relapses, and tips received.
+Use this to look up a specific user's accountability record.
+
+Example response fields:
+- username: the user's NGZ handle
+- habitName: the habit they are tracking
+- currentStreak: days clean right now
+- longestStreak: their all-time best streak in days
+- totalCheckIns: total number of check-ins
+- totalRelapses: number of times they have relapsed
+- totalTipsReceived: total ETH received as tips (in wei)
+- registered: whether this address has an NGZ account`,
+    schema: GetNGZUserSchema,
+  })
+  async getUser(args: z.infer<typeof GetNGZUserSchema>): Promise<string> {
+    try {
+      const client = getClient("base-sepolia");
+      const user = await client.readContract({
+        address: NGZ_CONTRACT_ADDRESS,
+        abi: NGZ_ABI,
+        functionName: "getUser",
+        args: [args.address as `0x${string}`],
+      });
+
+      if (!user.registered) {
+        return JSON.stringify({ success: true, registered: false, address: args.address });
+      }
+
+      return JSON.stringify({
+        success: true,
+        registered: true,
+        address: args.address,
+        username: user.username,
+        habitName: user.habitName,
+        currentStreak: Number(user.currentStreak),
+        longestStreak: Number(user.longestStreak),
+        totalCheckIns: Number(user.totalCheckIns),
+        totalRelapses: Number(user.totalRelapses),
+        totalTipsReceived: user.totalTipsReceived.toString(),
+        lastCheckIn: Number(user.lastCheckIn),
+        startedAt: Number(user.startedAt),
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  /**
+   * Fetches recent relapse events from the NGZ Wall of Shame.
+   *
+   * @param args - The arguments for the action.
+   * @returns Relapse events as stringified JSON.
+   */
+  @CreateAction({
+    name: "get_ngz_wall_of_shame",
+    description: `Fetches recent relapse events from the No-Going-Zone (NGZ) Wall of Shame.
+
+The Wall of Shame is a permanent onchain record of every relapse. When a user relapses, their streak resets to zero
+and a soulbound shame NFT is minted to their wallet — both cannot be deleted or reversed.
+
+Returns a list of relapse events ordered by most recent first.
+
+Example response fields per entry:
+- username: the user who relapsed
+- habitName: the habit they were tracking
+- streakLost: the number of days they lost when they relapsed
+- timestamp: Unix timestamp of when the relapse was recorded
+- message: an optional message the user wrote when they relapsed (public, stored onchain)
+- userAddress: the wallet address of the user`,
+    schema: GetNGZWallOfShameSchema,
+  })
+  async getWallOfShame(args: z.infer<typeof GetNGZWallOfShameSchema>): Promise<string> {
+    try {
+      const client = getClient("base-sepolia");
+      const relapses = await client.readContract({
+        address: NGZ_CONTRACT_ADDRESS,
+        abi: NGZ_ABI,
+        functionName: "getRelapseWall",
+        args: [BigInt(args.offset), BigInt(args.limit)],
+      });
+
+      if (!relapses || relapses.length === 0) {
+        return JSON.stringify({ success: true, count: 0, relapses: [] });
+      }
+
+      const wall = relapses.map(r => ({
+        userAddress: r.user,
+        username: r.username,
+        habitName: r.habitName,
+        streakLost: Number(r.streakLost),
+        timestamp: Number(r.timestamp),
+        message: r.message,
+      }));
+
+      return JSON.stringify({ success: true, count: wall.length, relapses: wall });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  /**
+   * Records today's daily check-in for the connected wallet on NGZ.
+   *
+   * @param _args - Unused (no inputs required).
+   * @param walletProvider - The wallet provider to send the transaction.
+   * @returns Transaction result as stringified JSON.
+   */
+  @CreateAction({
+    name: "check_in_ngz",
+    description: `Records today's check-in for the connected wallet on No-Going-Zone (NGZ).
+
+A check-in is only valid once every 20 hours. Missing too many check-ins will reset your streak.
+This action sends a transaction to the NGZ contract on Base Sepolia and returns the transaction hash on success.
+
+Use this to help a user maintain their onchain accountability streak.
+The user must already be registered on NGZ before checking in.`,
+    schema: CheckInNGZSchema,
+  })
+  async checkIn(
+    _args: z.infer<typeof CheckInNGZSchema>,
+    walletProvider: WalletProvider,
+  ): Promise<string> {
+    try {
+      const data = encodeFunctionData({ abi: NGZ_ABI, functionName: "checkIn", args: [] });
+      const txHash = await walletProvider.sendTransaction({
+        to: NGZ_CONTRACT_ADDRESS,
+        data,
+      });
+
+      return JSON.stringify({
+        success: true,
+        message: "Check-in recorded successfully. Your streak is growing.",
+        transactionHash: txHash,
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  /**
+   * Sends ETH as a tip to another NGZ user's wallet.
+   *
+   * @param args - The arguments for the action.
+   * @param walletProvider - The wallet provider to send the transaction.
+   * @returns Transaction result as stringified JSON.
+   */
+  @CreateAction({
+    name: "tip_ngz_user",
+    description: `Sends ETH as a tip directly to another NGZ user's wallet as a sign of respect for their streak.
+
+The minimum tip is 0.0001 ETH. 100% of the tip goes directly to the recipient — NGZ takes no fee.
+An optional public message can be included and will be stored permanently onchain.
+
+This action sends a payable transaction to the NGZ contract on Base Sepolia.
+
+Use this to reward a user for maintaining a strong streak or to encourage someone who relapsed to get back on track.`,
+    schema: TipNGZUserSchema,
+  })
+  async tipUser(
+    args: z.infer<typeof TipNGZUserSchema>,
+    walletProvider: WalletProvider,
+  ): Promise<string> {
+    try {
+      const value = parseEther(args.amountInEth);
+      const data = encodeFunctionData({
+        abi: NGZ_ABI,
+        functionName: "tip",
+        args: [args.recipientAddress as `0x${string}`, args.message],
+      });
+
+      const txHash = await walletProvider.sendTransaction({
+        to: NGZ_CONTRACT_ADDRESS,
+        data,
+        value,
+      });
+
+      return JSON.stringify({
+        success: true,
+        message: `Sent ${args.amountInEth} ETH to ${args.recipientAddress} as respect.`,
+        transactionHash: txHash,
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  supportsNetwork = (network: Network) =>
+    network.networkId === "base-mainnet" || network.networkId === "base-sepolia";
+}
+
+export const ngzActionProvider = () => new NGZActionProvider();

--- a/typescript/agentkit/src/action-providers/ngz/schemas.ts
+++ b/typescript/agentkit/src/action-providers/ngz/schemas.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+
+export const GetNGZLeaderboardSchema = z
+  .object({
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe("Number of top users to fetch. Defaults to 10, maximum 50."),
+  })
+  .strict();
+
+export const GetNGZUserSchema = z
+  .object({
+    address: z.string().describe("The wallet address of the NGZ user to look up."),
+  })
+  .strict();
+
+export const GetNGZWallOfShameSchema = z
+  .object({
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe("Number of recent relapses to fetch. Defaults to 10, maximum 50."),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe("Number of entries to skip for pagination. Defaults to 0."),
+  })
+  .strict();
+
+export const CheckInNGZSchema = z.object({}).strict();
+
+export const TipNGZUserSchema = z
+  .object({
+    recipientAddress: z.string().describe("The wallet address of the NGZ user to tip."),
+    amountInEth: z
+      .string()
+      .describe(
+        "The amount of ETH to send as a tip. Must be at least 0.0001 ETH. Example: '0.001'.",
+      ),
+    message: z
+      .string()
+      .max(100)
+      .default("")
+      .describe(
+        "Optional public message to include with the tip. Maximum 100 characters. Will be stored onchain.",
+      ),
+  })
+  .strict();


### PR DESCRIPTION
## Summary

Adds a new action provider for [No-Going-Zone (NGZ)](https://frontend-one-khaki-22.vercel.app), an onchain habit accountability tracker deployed on Base.

NGZ lets users declare habits, check in daily to build streaks, earn soulbound milestone NFTs at 7/30/90/180/365 days, and face permanent onchain consequences (Wall of Shame NFTs) when they relapse. All data lives onchain — no backend, no database.

## Actions Added

### Read-only (no wallet required)
- `get_ngz_leaderboard` — Fetch top streak holders ranked by current streak
- `get_ngz_user` — Look up a user's full stats by wallet address
- `get_ngz_wall_of_shame` — Fetch recent relapse events from the Wall of Shame

### Write (wallet required)
- `check_in_ngz` — Record today's check-in to maintain your onchain streak
- `tip_ngz_user` — Send ETH respect directly to another user's wallet (100% goes to recipient, no fee)

## Implementation Notes

- Read actions use `viem`'s `createPublicClient` to query the NGZ contract directly — no external API dependency
- Write actions use the `WalletProvider` interface so they work with any wallet (CDP, Privy, viem, etc.)
- Supports `base-mainnet` and `base-sepolia`
- Contract address: `0x4D1b5da45a5D278900aedfc6c96F0EE0D4e28bF6` (Base Sepolia — mainnet deployment in progress)
- All actions return structured JSON strings following the existing provider pattern

## Tests

16/16 tests passing. Coverage includes:
- Happy path for all 5 actions
- Empty/zero state responses
- Contract and transaction failure handling
- Network support validation

## Checklist
- [x] Tests added and passing (`pnpm test -- --testPathPattern=ngz`)
- [x] Lint passing (`pnpm run lint`)
- [x] Format passing (`pnpm run format`)
- [x] Changeset created
- [x] Export added to `action-providers/index.ts`
- [x] README included