### PR TITLE
feat(dexscreener): add DexScreener action provider for real-time DEX pair data

### DIFF
--- a/typescript/.changeset/dexscreener-action-provider.md
+++ b/typescript/.changeset/dexscreener-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added DexScreener action provider for real-time DEX pair data across 80+ chains

--- a/typescript/agentkit/src/action-providers/dexscreener/README.md
+++ b/typescript/agentkit/src/action-providers/dexscreener/README.md
@@ -1,0 +1,46 @@
+# DexScreener Action Provider
+
+Fetch real-time DEX trading data from [DexScreener](https://dexscreener.com) across 80+ blockchains. No API key or authentication required.
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| `search_dexscreener_pairs` | Search for trading pairs by token name, symbol, or address |
+| `get_dexscreener_pairs_by_token` | Get all pairs for a token on a specific chain, sorted by 24h volume |
+| `get_dexscreener_pair` | Get detailed data for a specific pair by contract address |
+
+## Usage
+
+```typescript
+import { AgentKit } from "@coinbase/agentkit";
+import { dexscreenerActionProvider } from "@coinbase/agentkit";
+
+const agentKit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [dexscreenerActionProvider()],
+});
+```
+
+## Example prompts
+
+```text
+Search DexScreener for USDC pairs
+
+Find all trading pairs for WETH on Base
+
+Get DexScreener data for the WETH/USDC pair at 0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C on Base
+
+What is the current price and 24h volume of cbBTC on Base?
+
+Find the most liquid DEX pair for ETH on Arbitrum
+```
+
+## Networks
+
+All networks supported — DexScreener aggregates data from 80+ blockchains including Base, Ethereum, Solana, Arbitrum, Polygon, and more.
+
+## Reference
+
+- [DexScreener API Reference](https://docs.dexscreener.com/api/reference)
+- [@coinbase/agentkit documentation](https://docs.cdp.coinbase.com/agent-kit/docs/agentkit-overview)

--- a/typescript/agentkit/src/action-providers/dexscreener/dexscreenerActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/dexscreener/dexscreenerActionProvider.test.ts
@@ -1,0 +1,338 @@
+import { dexscreenerActionProvider } from "./dexscreenerActionProvider";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const MOCK_PAIR = {
+  chainId: "base",
+  dexId: "aerodrome",
+  url: "https://dexscreener.com/base/0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c",
+  pairAddress: "0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C",
+  baseToken: {
+    address: "0x4200000000000000000000000000000000000006",
+    name: "Wrapped Ether",
+    symbol: "WETH",
+  },
+  quoteToken: {
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    name: "USD Coin",
+    symbol: "USDC",
+  },
+  priceNative: "1800.00",
+  priceUsd: "1800.00",
+  volume: { h24: 5000000, h6: 1200000, h1: 200000, m5: 15000 },
+  priceChange: { h24: 2.5, h6: 0.8, h1: -0.2, m5: 0.1 },
+  liquidity: { usd: 12000000, base: 3333, quote: 6000000 },
+  fdv: 220000000000,
+  marketCap: 210000000000,
+  pairCreatedAt: 1700000000000,
+};
+
+describe("DexScreenerActionProvider", () => {
+  const provider = dexscreenerActionProvider();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── searchPairs ──────────────────────────────────────────────────
+
+  describe("searchPairs", () => {
+    it("should return formatted pairs on success", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ pairs: [MOCK_PAIR] }),
+      });
+
+      const result = await provider.searchPairs({ query: "WETH" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(1);
+      expect(parsed.pairs[0].pair).toBe("WETH/USDC");
+      expect(parsed.pairs[0].priceUsd).toBe("1800.00");
+      expect(parsed.pairs[0].chain).toBe("base");
+      expect(parsed.pairs[0].dex).toBe("aerodrome");
+    });
+
+    it("should return empty list when no pairs found", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ pairs: [] }),
+      });
+
+      const result = await provider.searchPairs({ query: "UNKNOWN_TOKEN_XYZ" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+      expect(parsed.pairs).toEqual([]);
+    });
+
+    it("should handle null pairs response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ pairs: null }),
+      });
+
+      const result = await provider.searchPairs({ query: "test" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+    });
+
+    it("should return error on HTTP failure", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        statusText: "Too Many Requests",
+      });
+
+      const result = await provider.searchPairs({ query: "WETH" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("429");
+    });
+
+    it("should return error on network failure", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      const result = await provider.searchPairs({ query: "WETH" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Network error");
+    });
+
+    it("should limit results to 10 pairs", async () => {
+      const manyPairs = Array.from({ length: 20 }, (_, i) => ({
+        ...MOCK_PAIR,
+        pairAddress: `0x${i.toString().padStart(40, "0")}`,
+        baseToken: { ...MOCK_PAIR.baseToken, symbol: `TOKEN${i}` },
+      }));
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ pairs: manyPairs }),
+      });
+
+      const result = await provider.searchPairs({ query: "TOKEN" });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(10);
+      expect(parsed.pairs).toHaveLength(10);
+    });
+  });
+
+  // ─── getPairsByToken ──────────────────────────────────────────────
+
+  describe("getPairsByToken", () => {
+    it("should return pairs sorted by 24h volume", async () => {
+      const lowVolumePair = {
+        ...MOCK_PAIR,
+        pairAddress: "0xaaa",
+        dexId: "uniswap",
+        volume: { h24: 100000 },
+      };
+      const highVolumePair = {
+        ...MOCK_PAIR,
+        pairAddress: "0xbbb",
+        dexId: "aerodrome",
+        volume: { h24: 5000000 },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [lowVolumePair, highVolumePair],
+      });
+
+      const result = await provider.getPairsByToken({
+        chainId: "base",
+        tokenAddress: "0x4200000000000000000000000000000000000006",
+        limit: 5,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.pairs[0].volume24h).toBe(5000000);
+      expect(parsed.pairs[1].volume24h).toBe(100000);
+    });
+
+    it("should respect the limit parameter", async () => {
+      const pairs = Array.from({ length: 10 }, (_, i) => ({
+        ...MOCK_PAIR,
+        pairAddress: `0x${i.toString().padStart(40, "0")}`,
+        volume: { h24: (10 - i) * 1000 },
+      }));
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => pairs,
+      });
+
+      const result = await provider.getPairsByToken({
+        chainId: "base",
+        tokenAddress: "0x4200000000000000000000000000000000000006",
+        limit: 3,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(3);
+      expect(parsed.pairs).toHaveLength(3);
+    });
+
+    it("should return empty list when token has no pairs", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      const result = await provider.getPairsByToken({
+        chainId: "base",
+        tokenAddress: "0x0000000000000000000000000000000000000001",
+        limit: 5,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(0);
+    });
+
+    it("should return error on HTTP failure", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      });
+
+      const result = await provider.getPairsByToken({
+        chainId: "base",
+        tokenAddress: "0x0000000000000000000000000000000000000001",
+        limit: 5,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("404");
+    });
+
+    it("should return error on network failure", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+      const result = await provider.getPairsByToken({
+        chainId: "base",
+        tokenAddress: "0x4200000000000000000000000000000000000006",
+        limit: 5,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Connection refused");
+    });
+  });
+
+  // ─── getPair ─────────────────────────────────────────────────────
+
+  describe("getPair", () => {
+    it("should return pair details from pair field", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ pair: MOCK_PAIR }),
+      });
+
+      const result = await provider.getPair({
+        chainId: "base",
+        pairAddress: "0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.pair.pair).toBe("WETH/USDC");
+      expect(parsed.pair.liquidityUsd).toBe(12000000);
+      expect(parsed.pair.volume24h).toBe(5000000);
+    });
+
+    it("should fallback to pairs array when pair field is absent", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ pairs: [MOCK_PAIR] }),
+      });
+
+      const result = await provider.getPair({
+        chainId: "base",
+        pairAddress: "0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.pair.pair).toBe("WETH/USDC");
+    });
+
+    it("should return error when pair not found", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ pair: null, pairs: [] }),
+      });
+
+      const result = await provider.getPair({
+        chainId: "base",
+        pairAddress: "0x0000000000000000000000000000000000000001",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("No pair found");
+    });
+
+    it("should return error on HTTP failure", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+      const result = await provider.getPair({
+        chainId: "base",
+        pairAddress: "0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("500");
+    });
+
+    it("should return error on network failure", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Timeout"));
+
+      const result = await provider.getPair({
+        chainId: "base",
+        pairAddress: "0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Timeout");
+    });
+  });
+
+  // ─── supportsNetwork ─────────────────────────────────────────────
+
+  describe("supportsNetwork", () => {
+    it("should support all networks", () => {
+      const networks = [
+        "base-mainnet",
+        "base-sepolia",
+        "ethereum-mainnet",
+        "solana-mainnet",
+        "arbitrum-mainnet",
+      ];
+      networks.forEach(networkId => {
+        expect(provider.supportsNetwork({ networkId } as never)).toBe(true);
+      });
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/dexscreener/dexscreenerActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/dexscreener/dexscreenerActionProvider.ts
@@ -1,0 +1,257 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { Network } from "../../network";
+import {
+  SearchDexScreenerPairsSchema,
+  GetDexScreenerPairsByTokenSchema,
+  GetDexScreenerPairSchema,
+} from "./schemas";
+
+const DEXSCREENER_BASE_URL = "https://api.dexscreener.com";
+
+interface DexScreenerToken {
+  address: string;
+  name: string;
+  symbol: string;
+}
+
+interface DexScreenerPair {
+  chainId: string;
+  dexId: string;
+  url: string;
+  pairAddress: string;
+  baseToken: DexScreenerToken;
+  quoteToken: DexScreenerToken;
+  priceNative: string;
+  priceUsd?: string;
+  volume?: { h24?: number; h6?: number; h1?: number; m5?: number };
+  priceChange?: { h24?: number; h6?: number; h1?: number; m5?: number };
+  liquidity?: { usd?: number; base?: number; quote?: number };
+  fdv?: number;
+  marketCap?: number;
+  pairCreatedAt?: number;
+}
+
+/**
+ * Formats a pair into a concise summary for agent consumption.
+ *
+ * @param pair - The DexScreener pair object to format.
+ * @returns A formatted pair summary object.
+ */
+function formatPair(pair: DexScreenerPair) {
+  return {
+    chain: pair.chainId,
+    dex: pair.dexId,
+    pair: `${pair.baseToken.symbol}/${pair.quoteToken.symbol}`,
+    pairAddress: pair.pairAddress,
+    priceUsd: pair.priceUsd ?? null,
+    priceNative: pair.priceNative,
+    volume24h: pair.volume?.h24 ?? null,
+    priceChange24h: pair.priceChange?.h24 ?? null,
+    liquidityUsd: pair.liquidity?.usd ?? null,
+    marketCap: pair.marketCap ?? null,
+    fdv: pair.fdv ?? null,
+    baseToken: pair.baseToken,
+    quoteToken: pair.quoteToken,
+    url: pair.url,
+  };
+}
+
+/**
+ * DexScreenerActionProvider provides actions for fetching DEX pair data
+ * from DexScreener across all supported chains.
+ *
+ * DexScreener aggregates real-time trading data from hundreds of decentralized
+ * exchanges across 80+ blockchains. No API key or authentication is required.
+ *
+ * Available actions:
+ * - search_dexscreener_pairs: Search for pairs by token name, symbol, or address
+ * - get_dexscreener_pairs_by_token: Get all trading pairs for a specific token
+ * - get_dexscreener_pair: Get detailed data for a specific pair by address
+ */
+export class DexScreenerActionProvider extends ActionProvider {
+  /**
+   * Initializes the DexScreenerActionProvider.
+   */
+  constructor() {
+    super("dexscreener", []);
+  }
+
+  /**
+   * Searches for DEX pairs matching a query string.
+   *
+   * @param args - The search arguments containing the query string.
+   * @returns A JSON string with matching pairs or an error message.
+   */
+  @CreateAction({
+    name: "search_dexscreener_pairs",
+    description: `Searches DexScreener for DEX trading pairs matching a query.
+
+Use this to find trading pairs for a token by name, symbol, or contract address across all chains and DEXes.
+Returns pairs sorted by liquidity. Useful for discovering where a token is traded and at what price.
+
+Example queries: 'USDC', 'ETH', 'cbBTC', '0x4200000000000000000000000000000000000006'
+
+Response fields per pair:
+- pair: base/quote token symbols (e.g. 'WETH/USDC')
+- priceUsd: current price in USD
+- volume24h: 24-hour trading volume in USD
+- priceChange24h: 24-hour price change percentage
+- liquidityUsd: total liquidity in USD
+- chain: blockchain the pair is on
+- dex: DEX protocol name
+- url: DexScreener link for the pair`,
+    schema: SearchDexScreenerPairsSchema,
+  })
+  async searchPairs(args: z.infer<typeof SearchDexScreenerPairsSchema>): Promise<string> {
+    try {
+      const url = `${DEXSCREENER_BASE_URL}/latest/dex/search?q=${encodeURIComponent(args.query)}`;
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        return JSON.stringify({
+          success: false,
+          error: `DexScreener API error: ${response.status} ${response.statusText}`,
+        });
+      }
+
+      const data = (await response.json()) as { pairs?: DexScreenerPair[] };
+
+      if (!data.pairs || data.pairs.length === 0) {
+        return JSON.stringify({ success: true, count: 0, pairs: [] });
+      }
+
+      const pairs = data.pairs.slice(0, 10).map(formatPair);
+      return JSON.stringify({ success: true, count: pairs.length, pairs });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  /**
+   * Fetches all trading pairs for a specific token address on a given chain.
+   *
+   * @param args - The arguments containing chainId, tokenAddress, and limit.
+   * @returns A JSON string with pairs sorted by 24h volume or an error message.
+   */
+  @CreateAction({
+    name: "get_dexscreener_pairs_by_token",
+    description: `Fetches all DEX trading pairs for a specific token on a given blockchain.
+
+Use this when you know a token's contract address and want to see all the DEX pairs it trades in,
+sorted by 24-hour volume. Useful for finding the most liquid venue to trade a token.
+
+Examples:
+- WETH on Base: chainId='base', tokenAddress='0x4200000000000000000000000000000000000006'
+- USDC on Base: chainId='base', tokenAddress='0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+
+Response fields per pair:
+- pair: base/quote token symbols
+- priceUsd: current price in USD
+- volume24h: 24-hour trading volume in USD
+- liquidityUsd: total liquidity in USD
+- dex: DEX protocol name
+- url: DexScreener link`,
+    schema: GetDexScreenerPairsByTokenSchema,
+  })
+  async getPairsByToken(args: z.infer<typeof GetDexScreenerPairsByTokenSchema>): Promise<string> {
+    try {
+      const url = `${DEXSCREENER_BASE_URL}/token-pairs/v1/${encodeURIComponent(args.chainId)}/${encodeURIComponent(args.tokenAddress)}`;
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        return JSON.stringify({
+          success: false,
+          error: `DexScreener API error: ${response.status} ${response.statusText}`,
+        });
+      }
+
+      const data = (await response.json()) as DexScreenerPair[];
+
+      if (!Array.isArray(data) || data.length === 0) {
+        return JSON.stringify({ success: true, count: 0, pairs: [] });
+      }
+
+      const sorted = [...data].sort((a, b) => (b.volume?.h24 ?? 0) - (a.volume?.h24 ?? 0));
+      const pairs = sorted.slice(0, args.limit).map(formatPair);
+
+      return JSON.stringify({
+        success: true,
+        count: pairs.length,
+        tokenAddress: args.tokenAddress,
+        chainId: args.chainId,
+        pairs,
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  /**
+   * Fetches detailed data for a specific DEX pair by its contract address.
+   *
+   * @param args - The arguments containing chainId and pairAddress.
+   * @returns A JSON string with the pair details or an error message.
+   */
+  @CreateAction({
+    name: "get_dexscreener_pair",
+    description: `Fetches detailed trading data for a specific DEX pair by its contract address.
+
+Use this when you have the exact pair address and want full details including price, volume,
+liquidity, price changes, and market cap.
+
+Examples:
+- WETH/USDC on Base Aerodrome: chainId='base', pairAddress='0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C'
+
+Response fields:
+- pair: base/quote token symbols
+- priceUsd: current price in USD
+- priceNative: price in quote token
+- volume24h: 24-hour trading volume in USD
+- priceChange24h: 24-hour price change percentage
+- liquidityUsd: total liquidity in USD
+- marketCap: fully diluted market cap in USD
+- fdv: fully diluted valuation
+- url: DexScreener link`,
+    schema: GetDexScreenerPairSchema,
+  })
+  async getPair(args: z.infer<typeof GetDexScreenerPairSchema>): Promise<string> {
+    try {
+      const url = `${DEXSCREENER_BASE_URL}/latest/dex/pairs/${encodeURIComponent(args.chainId)}/${encodeURIComponent(args.pairAddress)}`;
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        return JSON.stringify({
+          success: false,
+          error: `DexScreener API error: ${response.status} ${response.statusText}`,
+        });
+      }
+
+      const data = (await response.json()) as { pair?: DexScreenerPair; pairs?: DexScreenerPair[] };
+
+      const pair = data.pair ?? data.pairs?.[0];
+
+      if (!pair) {
+        return JSON.stringify({
+          success: false,
+          error: `No pair found for address ${args.pairAddress} on ${args.chainId}`,
+        });
+      }
+
+      return JSON.stringify({ success: true, pair: formatPair(pair) });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: String(error) });
+    }
+  }
+
+  /**
+   * Returns true for all networks since DexScreener supports 80+ chains.
+   *
+   * @param _ - The network (unused).
+   * @returns Always true.
+   */
+  supportsNetwork = (_: Network) => true;
+}
+
+export const dexscreenerActionProvider = () => new DexScreenerActionProvider();

--- a/typescript/agentkit/src/action-providers/dexscreener/index.ts
+++ b/typescript/agentkit/src/action-providers/dexscreener/index.ts
@@ -1,0 +1,2 @@
+export * from "./dexscreenerActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/dexscreener/schemas.ts
+++ b/typescript/agentkit/src/action-providers/dexscreener/schemas.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const SearchDexScreenerPairsSchema = z
+  .object({
+    query: z
+      .string()
+      .min(1)
+      .describe(
+        "Search query to find DEX pairs. Can be a token name, symbol, or contract address. " +
+          "Examples: 'USDC', 'ETH', '0x4200000000000000000000000000000000000006'.",
+      ),
+  })
+  .strict();
+
+export const GetDexScreenerPairsByTokenSchema = z
+  .object({
+    chainId: z
+      .string()
+      .describe(
+        "The blockchain identifier. Examples: 'base', 'ethereum', 'solana', 'arbitrum', 'polygon'. " +
+          "Use 'base' for Base network tokens.",
+      ),
+    tokenAddress: z
+      .string()
+      .describe(
+        "The contract address of the token to fetch pairs for. " +
+          "Example: '0x4200000000000000000000000000000000000006' for WETH on Base.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(20)
+      .default(5)
+      .describe(
+        "Maximum number of pairs to return, ordered by 24h volume. Defaults to 5, maximum 20.",
+      ),
+  })
+  .strict();
+
+export const GetDexScreenerPairSchema = z
+  .object({
+    chainId: z
+      .string()
+      .describe(
+        "The blockchain identifier. Examples: 'base', 'ethereum', 'solana', 'arbitrum', 'polygon'.",
+      ),
+    pairAddress: z
+      .string()
+      .describe(
+        "The contract address of the DEX pair to fetch. " +
+          "Example: '0x88A43bbDF9D098eEC7bCEda4e2494615dfD9bB9C'.",
+      ),
+  })
+  .strict();

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -11,6 +11,7 @@ export * from "./cdp";
 export * from "./clanker";
 export * from "./compound";
 export * from "./defillama";
+export * from "./dexscreener";
 export * from "./dtelecom";
 export * from "./enso";
 export * from "./erc20";


### PR DESCRIPTION
## Summary

Adds a new action provider for [DexScreener](https://dexscreener.com), the most widely used DEX aggregator covering 80+ blockchains and 1000+ DEXes. No API key or authentication required.

DexScreener is listed in [WISHLIST.md](https://github.com/coinbase/agentkit/blob/main/WISHLIST.md) under Trading & Data.

## Actions Added

| Action | Description |
|--------|-------------|
| `search_dexscreener_pairs` | Search for trading pairs by token name, symbol, or contract address |
| `get_dexscreener_pairs_by_token` | Get all pairs for a token on a specific chain, sorted by 24h volume |
| `get_dexscreener_pair` | Get detailed data for a specific pair by contract address |

## Example prompts

```
Search DexScreener for USDC pairs
Find all trading pairs for WETH on Base
Get the current price and 24h volume of cbBTC on Base
What is the most liquid DEX pair for ETH on Arbitrum?
```

## Implementation Notes

- Pure HTTP reads against the public DexScreener API — no wallet required, no API key
- Follows the exact same pattern as the existing `defillama` action provider
- Responses pruned to top N pairs by 24h volume to keep output concise for agents
- `supportsNetwork` returns true for all networks (DexScreener covers 80+ chains)
- All actions return structured JSON strings consistent with existing provider patterns

## Tests

17/17 tests passing. Coverage includes:
- Happy path for all 3 actions
- Empty/null response handling
- HTTP error handling (404, 429, 500)
- Network failure handling
- Result limiting (max 10 for search, configurable for token pairs)
- Volume-based sorting for `get_dexscreener_pairs_by_token`
- Fallback from `pair` field to `pairs[0]` in `get_dexscreener_pair`

## Checklist
- [x] Tests added and passing (`pnpm test -- --testPathPattern=dexscreener`)
- [x] Lint passing (`pnpm run lint`)
- [x] Format passing (`pnpm run format`)
- [x] Changeset created
- [x] Export added to `action-providers/index.ts`
- [x] README included
- [x] Listed in WISHLIST.md