### PR TITLE
feat: add FlipCoin action provider for prediction markets on Base

### DIFF
--- a/typescript/.changeset/flipcoin-action-provider.md
+++ b/typescript/.changeset/flipcoin-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added FlipCoin action provider for prediction markets on Base (list markets, fetch firm quotes, buy/sell YES/NO shares via EIP-712 intent/relay, read agent portfolio).

--- a/typescript/agentkit/src/action-providers/flipcoin/README.md
+++ b/typescript/agentkit/src/action-providers/flipcoin/README.md
@@ -24,9 +24,11 @@ flipcoin/
   - Returns `sharesOut`, `priceImpactBps`, `avgPriceBps`, `quoteId` (valid ~12s).
 - `buy_prediction_shares` — buy YES or NO shares with USDC from the agent's vault.
   - Intent → `EvmWalletProvider.signTypedData()` (EIP-712 TradeIntent) → relay broadcast on-chain.
-  - Supports `maxSlippageBps` (default 200 = 2%).
+  - Supports `maxSlippageBps` (default 100 = 1%) and `maxFeeBps` (default 200 = 2%).
 - `sell_prediction_shares` — sell YES or NO shares back into the LMSR pool.
-  - Requires prior `ShareToken.setApprovalForAll(router, true)` from the trader wallet.
+  - Requires prior `ShareToken.setApprovalForAll(operator, true)` from the trader wallet.
+    The operator address is returned in the intent response's `approvalRequired.operator`
+    when missing — the provider surfaces it as a structured error.
 - `get_agent_portfolio` — list the agent's open/resolved positions with net side, entry price
   and unrealized P&L.
 
@@ -80,10 +82,12 @@ flow:
 ## Prerequisites
 
 - **EVM wallet**: the agent's wallet must be funded with a small amount of USDC on Base, and the
-  FlipCoin vault must be seeded via `POST /api/agent/vault/deposit/intent` before trading. The
-  wallet is the FlipCoin **trader**, so its address must match the API key's `owner_addr`.
-- **Selling** requires the trader wallet to have called `ShareToken.setApprovalForAll(router, true)`
-  once per chain. The provider surfaces a structured `approvalRequired` error if it's missing.
+  FlipCoin vault must be seeded via `POST /api/agent/vault/deposit` (two-phase intent → relay on
+  the same endpoint with `{ "action": "intent" | "relay", ... }`) before trading. The wallet is
+  the FlipCoin **trader**, so its address must match the API key's owner address.
+- **Selling** requires the trader wallet to have called `ShareToken.setApprovalForAll(operator, true)`
+  once per chain. The provider surfaces a structured `approvalRequired` error (with the exact
+  `operator` address) if it's missing.
 
 ## Network Support
 

--- a/typescript/agentkit/src/action-providers/flipcoin/README.md
+++ b/typescript/agentkit/src/action-providers/flipcoin/README.md
@@ -1,0 +1,108 @@
+# FlipCoin Action Provider
+
+This directory contains the **FlipCoinActionProvider** implementation, which lets an agent trade
+on [FlipCoin](https://www.flipcoin.fun) — a LMSR-based prediction-market protocol on Base.
+
+## Directory Structure
+
+```
+flipcoin/
+├── flipcoinActionProvider.ts       # Main provider implementation
+├── flipcoinActionProvider.test.ts  # Jest unit tests
+├── constants.ts                    # Base URL, API version, network allow-list
+├── schemas.ts                      # Zod input schemas for all 5 actions
+├── types.ts                        # FlipCoin API response type definitions
+├── index.ts                        # Public exports
+└── README.md                       # This file
+```
+
+## Actions
+
+- `get_prediction_markets` — list tradable FlipCoin markets (title, conditionId, prices, volume).
+  - Filters: `status`, `category`, `limit`, `offset`.
+- `get_market_odds` — fetch current YES/NO prices (basis points) and a firm quote for a market.
+  - Returns `sharesOut`, `priceImpactBps`, `avgPriceBps`, `quoteId` (valid ~12s).
+- `buy_prediction_shares` — buy YES or NO shares with USDC from the agent's vault.
+  - Intent → `EvmWalletProvider.signTypedData()` (EIP-712 TradeIntent) → relay broadcast on-chain.
+  - Supports `maxSlippageBps` (default 200 = 2%).
+- `sell_prediction_shares` — sell YES or NO shares back into the LMSR pool.
+  - Requires prior `ShareToken.setApprovalForAll(router, true)` from the trader wallet.
+- `get_agent_portfolio` — list the agent's open/resolved positions with net side, entry price
+  and unrealized P&L.
+
+## Usage
+
+### 1. Create a FlipCoin API key
+
+Sign in at https://www.flipcoin.fun, open **Settings → Developers**, and generate an API key.
+Ensure the key has scopes `portfolio:read` and `trade`.
+
+### 2. Wire it up
+
+```typescript
+import {
+  AgentKit,
+  ViemWalletProvider,
+  flipcoinActionProvider,
+} from "@coinbase/agentkit";
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+
+const walletClient = createWalletClient({
+  account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
+  chain: base,
+  transport: http(),
+});
+
+const walletProvider = new ViemWalletProvider(walletClient);
+
+const agentKit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [
+    flipcoinActionProvider({
+      apiKey: process.env.FLIPCOIN_API_KEY!,
+    }),
+  ],
+});
+```
+
+### 3. Let the agent trade
+
+The LLM can now call actions like `get_prediction_markets` and `buy_prediction_shares`. A typical
+flow:
+
+1. `get_prediction_markets` → pick a market by `conditionId`.
+2. `get_market_odds` → preview price, fee, priceImpact for a given USDC amount.
+3. `buy_prediction_shares` → execute the trade (wallet signs EIP-712, FlipCoin relayer broadcasts).
+4. `get_agent_portfolio` → monitor P&L.
+
+## Prerequisites
+
+- **EVM wallet**: the agent's wallet must be funded with a small amount of USDC on Base, and the
+  FlipCoin vault must be seeded via `POST /api/agent/vault/deposit/intent` before trading. The
+  wallet is the FlipCoin **trader**, so its address must match the API key's `owner_addr`.
+- **Selling** requires the trader wallet to have called `ShareToken.setApprovalForAll(router, true)`
+  once per chain. The provider surfaces a structured `approvalRequired` error if it's missing.
+
+## Network Support
+
+- Base Mainnet (`base-mainnet`, chainId 8453)
+- Base Sepolia (`base-sepolia`, chainId 84532)
+
+## Configuration
+
+| Option     | Type     | Default                       | Description                                |
+| ---------- | -------- | ----------------------------- | ------------------------------------------ |
+| `apiKey`   | `string` | —                             | FlipCoin agent API key (required for trades + portfolio). |
+| `baseUrl`  | `string` | `https://www.flipcoin.fun`    | Override for staging / self-hosted deployments. |
+| `fetchImpl`| `fetch`  | `globalThis.fetch`            | Custom fetch implementation (tests, Node 16, etc.). |
+
+## Notes
+
+- Prices are in basis points: `5000 = 50%`, range `[0, 10000]`.
+- USDC uses 6 decimals. All on-wire amounts are integer strings; schemas accept human units
+  (e.g. `"5"` = $5).
+- The intent is signed with `EvmWalletProvider.signTypedData` (EIP-712). FlipCoin's relayer covers
+  gas and broadcasts the transaction.
+- Learn more: https://www.flipcoin.fun/docs/agents and https://www.flipcoin.fun/api/openapi.json.

--- a/typescript/agentkit/src/action-providers/flipcoin/constants.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Constants for the FlipCoin action provider.
+ */
+
+export const FLIPCOIN_API_BASE_URL = "https://www.flipcoin.fun";
+
+export const FLIPCOIN_API_VERSION = "2026-03-19";
+
+export const SUPPORTED_NETWORK_IDS = ["base-mainnet", "base-sepolia"] as const;
+
+export const SUPPORTED_CHAIN_IDS = {
+  "base-mainnet": 8453,
+  "base-sepolia": 84532,
+} as const;
+
+/**
+ * Default max slippage for LMSR trades (basis points).
+ * Aligned with FlipCoin's LMSR_SLIPPAGE_DEFAULT_BPS.
+ */
+export const DEFAULT_MAX_SLIPPAGE_BPS = 200;
+
+/**
+ * Default max fee for LMSR trades (basis points).
+ */
+export const DEFAULT_MAX_FEE_BPS = 300;

--- a/typescript/agentkit/src/action-providers/flipcoin/constants.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/constants.ts
@@ -15,11 +15,12 @@ export const SUPPORTED_CHAIN_IDS = {
 
 /**
  * Default max slippage for LMSR trades (basis points).
- * Aligned with FlipCoin's LMSR_SLIPPAGE_DEFAULT_BPS.
+ * Matches FlipCoin's documented default (100 = 1%).
  */
-export const DEFAULT_MAX_SLIPPAGE_BPS = 200;
+export const DEFAULT_MAX_SLIPPAGE_BPS = 100;
 
 /**
  * Default max fee for LMSR trades (basis points).
+ * Matches FlipCoin's documented default (200 = 2%).
  */
-export const DEFAULT_MAX_FEE_BPS = 300;
+export const DEFAULT_MAX_FEE_BPS = 200;

--- a/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.test.ts
@@ -1,0 +1,568 @@
+import { EvmWalletProvider } from "../../wallet-providers";
+import { FlipCoinActionProvider, flipcoinActionProvider } from "./flipcoinActionProvider";
+import { FLIPCOIN_API_BASE_URL, FLIPCOIN_API_VERSION } from "./constants";
+
+const MOCK_API_KEY = "fc_agent_live_testkey123456789";
+const MOCK_CONDITION_ID = "0x" + "a".repeat(64);
+const MOCK_MARKET_ADDR = "0x1234567890123456789012345678901234567890";
+const MOCK_TX_HASH = "0xdeadbeef" + "0".repeat(56);
+const MOCK_SIGNATURE = ("0x" + "b".repeat(130)) as `0x${string}`;
+
+/**
+ * Create a mocked fetch that returns the queued responses in order.
+ *
+ * @param responses - Queue of `{ status?, body }` entries returned for successive fetch calls.
+ * @returns A Jest mock function compatible with `fetch`.
+ */
+function createMockFetch(responses: Array<{ status?: number; body: unknown }>): jest.Mock {
+  const queue = [...responses];
+  return jest.fn(async () => {
+    const next = queue.shift();
+    if (!next) throw new Error("No more mock responses queued");
+    return new Response(JSON.stringify(next.body), {
+      status: next.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
+
+/**
+ * Build a lightweight `EvmWalletProvider` mock on Base mainnet.
+ *
+ * @returns A Jest-mocked wallet provider whose `signTypedData` returns `MOCK_SIGNATURE`.
+ */
+function createMockWallet(): jest.Mocked<EvmWalletProvider> {
+  return {
+    signTypedData: jest.fn().mockResolvedValue(MOCK_SIGNATURE),
+    getAddress: jest.fn().mockReturnValue("0xowner000000000000000000000000000000000001"),
+    getNetwork: jest.fn().mockReturnValue({
+      protocolFamily: "evm",
+      networkId: "base-mainnet",
+      chainId: "8453",
+    }),
+  } as unknown as jest.Mocked<EvmWalletProvider>;
+}
+
+describe("FlipCoinActionProvider", () => {
+  describe("supportsNetwork", () => {
+    const provider = new FlipCoinActionProvider();
+
+    it.each([
+      ["base-mainnet", true],
+      ["base-sepolia", true],
+      ["ethereum-mainnet", false],
+      ["arbitrum-mainnet", false],
+    ])("networkId=%s -> %s", (networkId, expected) => {
+      expect(provider.supportsNetwork({ protocolFamily: "evm", networkId, chainId: "1" })).toBe(
+        expected,
+      );
+    });
+
+    it("rejects non-EVM networks", () => {
+      expect(
+        provider.supportsNetwork({ protocolFamily: "svm", networkId: "solana-mainnet" } as never),
+      ).toBe(false);
+    });
+  });
+
+  describe("factory", () => {
+    it("creates a provider instance", () => {
+      const provider = flipcoinActionProvider({ apiKey: MOCK_API_KEY });
+      expect(provider).toBeInstanceOf(FlipCoinActionProvider);
+      expect(provider.name).toBe("flipcoin");
+    });
+  });
+
+  describe("get_prediction_markets", () => {
+    it("fetches markets and maps shape", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            markets: [
+              {
+                id: "m1",
+                condition_id: MOCK_CONDITION_ID,
+                market_addr: MOCK_MARKET_ADDR,
+                chain_id: "8453",
+                title: "Will Bitcoin hit $200k in 2026?",
+                description: "...",
+                status: "open",
+                resolved_outcome: null,
+                volume_usdc: 12345,
+                liquidity_usdc: 500,
+                trades_count: 42,
+                resolve_end_at: "2026-12-31T23:59:59Z",
+                category: "crypto",
+                market_version: 2,
+              },
+            ],
+            pagination: { offset: 0, limit: 25, total: 1 },
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const wallet = createMockWallet();
+
+      const result = JSON.parse(await provider.getPredictionMarkets(wallet, {}));
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+      expect(result.markets[0]).toMatchObject({
+        conditionId: MOCK_CONDITION_ID,
+        marketAddress: MOCK_MARKET_ADDR,
+        title: "Will Bitcoin hit $200k in 2026?",
+        volumeUsdc: 12345,
+        category: "crypto",
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${FLIPCOIN_API_BASE_URL}/api/markets?status=active&limit=25&offset=0`);
+      expect((init.headers as Record<string, string>)["X-API-Version"]).toBe(FLIPCOIN_API_VERSION);
+      expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
+    });
+
+    it("passes category and custom limit", async () => {
+      const mockFetch = createMockFetch([
+        { body: { markets: [], pagination: { offset: 10, limit: 5, total: 0 } } },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      await provider.getPredictionMarkets(createMockWallet(), {
+        category: "sports",
+        limit: 5,
+        offset: 10,
+      });
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("category=sports");
+      expect(url).toContain("limit=5");
+      expect(url).toContain("offset=10");
+    });
+
+    it("returns a structured error on fetch failure", async () => {
+      const mockFetch = createMockFetch([{ status: 500, body: { error: "boom" } }]);
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const result = JSON.parse(await provider.getPredictionMarkets(createMockWallet(), {}));
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("boom");
+    });
+  });
+
+  describe("get_market_odds", () => {
+    it("fetches a firm quote and exposes percent prices", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            quoteId: "q-1",
+            conditionId: MOCK_CONDITION_ID,
+            side: "yes",
+            action: "buy",
+            amount: "5000000",
+            venue: "lmsr",
+            validUntil: "2026-04-23T12:00:12Z",
+            lmsr: {
+              available: true,
+              sharesOut: "9000000",
+              amountOut: "0",
+              fee: "15000",
+              priceYesBps: 5500,
+              priceNoBps: 4500,
+              newPriceYesBps: 5600,
+              priceImpactBps: 100,
+              avgPriceBps: 5550,
+            },
+            clob: { available: false, canFillFull: false, bestBidBps: null, bestAskBps: null },
+            priceImpactGuard: { level: "ok", impactBps: 100, maxAllowedImpactBps: 1500 },
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+
+      const result = JSON.parse(
+        await provider.getMarketOdds(createMockWallet(), {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          action: "buy",
+          amountUsdc: "5",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.prices.yesPercent).toBe(55);
+      expect(result.prices.noPercent).toBe(45);
+      expect(result.lmsr.sharesOut).toBe("9000000");
+      expect(result.priceImpactGuard.level).toBe("ok");
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("amount=5000000");
+      expect(url).toContain("side=yes");
+      expect(url).toContain("action=buy");
+    });
+
+    it("defaults to $1 simulation when amountUsdc is omitted", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            quoteId: "q-2",
+            conditionId: MOCK_CONDITION_ID,
+            side: "yes",
+            action: "buy",
+            amount: "1000000",
+            venue: "lmsr",
+            validUntil: "2026-04-23T12:00:12Z",
+            lmsr: {
+              available: true,
+              sharesOut: "0",
+              amountOut: "0",
+              fee: "0",
+              priceYesBps: 5000,
+              priceNoBps: 5000,
+              newPriceYesBps: 5000,
+              priceImpactBps: 0,
+              avgPriceBps: 5000,
+            },
+            clob: { available: false, canFillFull: false, bestBidBps: null, bestAskBps: null },
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      await provider.getMarketOdds(createMockWallet(), { conditionId: MOCK_CONDITION_ID });
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("amount=1000000");
+    });
+  });
+
+  describe("buy_prediction_shares", () => {
+    const intentBody = {
+      intentId: "intent-123",
+      status: "awaiting_relay",
+      venue: "lmsr",
+      quote: {
+        quoteId: "q-1",
+        validUntil: "2026-04-23T12:00:12Z",
+        side: "yes",
+        action: "buy",
+        amount: "5000000",
+        sharesOut: "9000000",
+        amountOut: "0",
+        avgPriceBps: 5550,
+        priceImpactBps: 100,
+        fee: "15000",
+        minOut: "8910000",
+        maxFeeBps: 300,
+      },
+      typedData: {
+        domain: {
+          name: "FlipCoin BackstopRouter",
+          version: "1",
+          chainId: 8453,
+          verifyingContract: "0x0000000000000000000000000000000000000001",
+        },
+        types: {
+          TradeIntent: [
+            { name: "trader", type: "address" },
+            { name: "signer", type: "address" },
+            { name: "conditionId", type: "bytes32" },
+            { name: "side", type: "uint8" },
+            { name: "isBuy", type: "bool" },
+            { name: "amount", type: "uint256" },
+            { name: "minOut", type: "uint256" },
+            { name: "deadline", type: "uint256" },
+            { name: "nonce", type: "uint256" },
+            { name: "maxFeeBps", type: "uint256" },
+          ],
+        },
+        primaryType: "TradeIntent",
+        message: {
+          trader: "0xowner000000000000000000000000000000000001",
+          signer: "0xowner000000000000000000000000000000000001",
+          conditionId: MOCK_CONDITION_ID,
+          side: 0,
+          isBuy: true,
+          amount: "5000000",
+          minOut: "8910000",
+          deadline: "9999999999",
+          nonce: "1",
+          maxFeeBps: "300",
+        },
+      },
+      balanceCheck: { sufficient: true, required: "5000000", available: "10000000" },
+      priceImpactGuard: { level: "ok", impactBps: 100, maxAllowedImpactBps: 1500 },
+    };
+
+    it("signs typed data and returns confirmed tx on happy path", async () => {
+      const mockFetch = createMockFetch([
+        { body: intentBody },
+        {
+          body: {
+            intentId: "intent-123",
+            status: "confirmed",
+            venue: "lmsr",
+            txHash: MOCK_TX_HASH,
+            sharesOut: "9000000",
+            usdcOut: null,
+            feeUsdc: "15000",
+            error: null,
+            retryable: false,
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        apiKey: MOCK_API_KEY,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const wallet = createMockWallet();
+
+      const result = JSON.parse(
+        await provider.buyPredictionShares(wallet, {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          amountUsdc: "5",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.txHash).toBe(MOCK_TX_HASH);
+      expect(result.sharesOut).toBe("9000000");
+      expect(wallet.signTypedData).toHaveBeenCalledTimes(1);
+      expect(wallet.signTypedData).toHaveBeenCalledWith(intentBody.typedData);
+
+      const relayCall = mockFetch.mock.calls[1] as [string, RequestInit];
+      expect(relayCall[0]).toBe(`${FLIPCOIN_API_BASE_URL}/api/agent/trade/relay`);
+      const relayBody = JSON.parse(relayCall[1].body as string);
+      expect(relayBody).toEqual({ intentId: "intent-123", signature: MOCK_SIGNATURE });
+      expect((relayCall[1].headers as Record<string, string>).Authorization).toBe(
+        `Bearer ${MOCK_API_KEY}`,
+      );
+    });
+
+    it("returns structured error when approval required", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            ...intentBody,
+            approvalRequired: {
+              contract: "0xabc",
+              function: "setApprovalForAll",
+              operator: "0xrouter",
+              approved: false,
+              hint: "Approve router",
+            },
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        apiKey: MOCK_API_KEY,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const wallet = createMockWallet();
+      const result = JSON.parse(
+        await provider.buyPredictionShares(wallet, {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          amountUsdc: "5",
+        }),
+      );
+      expect(result.success).toBe(false);
+      expect(result.approvalRequired).toBeDefined();
+      expect(wallet.signTypedData).not.toHaveBeenCalled();
+    });
+
+    it("aborts when price impact guard is blocked", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            ...intentBody,
+            priceImpactGuard: { level: "blocked", impactBps: 5000, maxAllowedImpactBps: 3000 },
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        apiKey: MOCK_API_KEY,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const wallet = createMockWallet();
+      const result = JSON.parse(
+        await provider.buyPredictionShares(wallet, {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          amountUsdc: "5",
+        }),
+      );
+      expect(result.success).toBe(false);
+      expect(result.priceImpactBps).toBe(5000);
+      expect(wallet.signTypedData).not.toHaveBeenCalled();
+    });
+
+    it("requires an API key", async () => {
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: jest.fn() as unknown as typeof fetch,
+      });
+      const result = JSON.parse(
+        await provider.buyPredictionShares(createMockWallet(), {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          amountUsdc: "5",
+        }),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("API key required");
+    });
+
+    it("surfaces retryable relay errors", async () => {
+      const mockFetch = createMockFetch([
+        { body: intentBody },
+        {
+          status: 502,
+          body: {
+            intentId: "intent-123",
+            status: "awaiting_relay",
+            venue: "lmsr",
+            error: "RPC timeout",
+            retryable: true,
+            errorCode: "RPC_ERROR",
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        apiKey: MOCK_API_KEY,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const result = JSON.parse(
+        await provider.buyPredictionShares(createMockWallet(), {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          amountUsdc: "5",
+        }),
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("RPC timeout");
+    });
+  });
+
+  describe("sell_prediction_shares", () => {
+    it("sends action=sell to intent endpoint", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            intentId: "intent-sell",
+            status: "awaiting_relay",
+            venue: "lmsr",
+            quote: {
+              quoteId: "q",
+              validUntil: "2026-04-23T12:00:12Z",
+              side: "yes",
+              action: "sell",
+              amount: "5000000",
+              sharesOut: "0",
+              amountOut: "2500000",
+              avgPriceBps: 5000,
+              priceImpactBps: 10,
+              fee: "5000",
+              minOut: "2475000",
+              maxFeeBps: 300,
+            },
+            typedData: {
+              domain: {
+                name: "FlipCoin BackstopRouter",
+                version: "1",
+                chainId: 8453,
+                verifyingContract: "0x0000000000000000000000000000000000000001",
+              },
+              types: { TradeIntent: [{ name: "trader", type: "address" }] },
+              primaryType: "TradeIntent",
+              message: { trader: "0xowner" },
+            },
+            balanceCheck: { sufficient: true, required: "5000000", available: "10000000" },
+            priceImpactGuard: { level: "ok", impactBps: 10, maxAllowedImpactBps: 1500 },
+          },
+        },
+        {
+          body: {
+            intentId: "intent-sell",
+            status: "confirmed",
+            venue: "lmsr",
+            txHash: MOCK_TX_HASH,
+            sharesOut: null,
+            usdcOut: "2475000",
+            feeUsdc: "5000",
+            error: null,
+            retryable: false,
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        apiKey: MOCK_API_KEY,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const result = JSON.parse(
+        await provider.sellPredictionShares(createMockWallet(), {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          shares: "5",
+        }),
+      );
+      expect(result.success).toBe(true);
+      expect(result.usdcOut).toBe("2475000");
+      const intentCall = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(intentCall[1].body as string);
+      expect(body.action).toBe("sell");
+    });
+  });
+
+  describe("get_agent_portfolio", () => {
+    it("fetches positions with auth header", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            positions: [
+              {
+                marketAddr: MOCK_MARKET_ADDR,
+                title: "Market A",
+                status: "open",
+                yesShares: 10,
+                noShares: 0,
+                netSide: "yes",
+                netShares: 10,
+                avgEntryPriceUsdc: 0.5,
+                currentPriceBps: 6000,
+                currentValueUsdc: 6,
+                pnlUsdc: 1,
+                lastTradeAt: "2026-04-20T12:00:00Z",
+              },
+            ],
+            totals: { marketsActive: 1, marketsResolved: 0 },
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        apiKey: MOCK_API_KEY,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const result = JSON.parse(await provider.getAgentPortfolio(createMockWallet(), {}));
+      expect(result.success).toBe(true);
+      expect(result.positions).toHaveLength(1);
+      expect(result.totals.marketsActive).toBe(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("/api/agent/portfolio?status=all");
+      expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${MOCK_API_KEY}`);
+    });
+
+    it("requires an API key", async () => {
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: jest.fn() as unknown as typeof fetch,
+      });
+      const result = JSON.parse(await provider.getAgentPortfolio(createMockWallet(), {}));
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("API key required");
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.test.ts
@@ -189,7 +189,7 @@ describe("FlipCoinActionProvider", () => {
           conditionId: MOCK_CONDITION_ID,
           side: "yes",
           action: "buy",
-          amountUsdc: "5",
+          amount: "5",
         }),
       );
 
@@ -198,6 +198,7 @@ describe("FlipCoinActionProvider", () => {
       expect(result.prices.noPercent).toBe(45);
       expect(result.lmsr.sharesOut).toBe("9000000");
       expect(result.priceImpactGuard.level).toBe("ok");
+      expect(result.simulated.amountType).toBe("usdc");
 
       const [url] = mockFetch.mock.calls[0] as [string];
       expect(url).toContain("amount=5000000");
@@ -205,7 +206,50 @@ describe("FlipCoinActionProvider", () => {
       expect(url).toContain("action=buy");
     });
 
-    it("defaults to $1 simulation when amountUsdc is omitted", async () => {
+    it("treats amount as shares when action=sell", async () => {
+      const mockFetch = createMockFetch([
+        {
+          body: {
+            quoteId: "q-sell",
+            conditionId: MOCK_CONDITION_ID,
+            side: "yes",
+            action: "sell",
+            amount: "3000000",
+            venue: "lmsr",
+            validUntil: "2026-04-23T12:00:12Z",
+            lmsr: {
+              available: true,
+              sharesOut: "0",
+              amountOut: "1500000",
+              fee: "5000",
+              priceYesBps: 5000,
+              priceNoBps: 5000,
+              newPriceYesBps: 4900,
+              priceImpactBps: 20,
+              avgPriceBps: 4990,
+            },
+            clob: { available: false, canFillFull: false, bestBidBps: null, bestAskBps: null },
+          },
+        },
+      ]);
+      const provider = new FlipCoinActionProvider({
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+      const result = JSON.parse(
+        await provider.getMarketOdds(createMockWallet(), {
+          conditionId: MOCK_CONDITION_ID,
+          side: "yes",
+          action: "sell",
+          amount: "3",
+        }),
+      );
+      expect(result.simulated.amountType).toBe("shares");
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("action=sell");
+      expect(url).toContain("amount=3000000");
+    });
+
+    it("defaults to a 1-unit simulation when amount is omitted", async () => {
       const mockFetch = createMockFetch([
         {
           body: {
@@ -246,18 +290,10 @@ describe("FlipCoinActionProvider", () => {
       status: "awaiting_relay",
       venue: "lmsr",
       quote: {
-        quoteId: "q-1",
-        validUntil: "2026-04-23T12:00:12Z",
-        side: "yes",
-        action: "buy",
-        amount: "5000000",
         sharesOut: "9000000",
-        amountOut: "0",
         avgPriceBps: 5550,
         priceImpactBps: 100,
         fee: "15000",
-        minOut: "8910000",
-        maxFeeBps: 300,
       },
       typedData: {
         domain: {
@@ -335,6 +371,14 @@ describe("FlipCoinActionProvider", () => {
       expect(wallet.signTypedData).toHaveBeenCalledTimes(1);
       expect(wallet.signTypedData).toHaveBeenCalledWith(intentBody.typedData);
 
+      const intentCall = mockFetch.mock.calls[0] as [string, RequestInit];
+      const intentReq = JSON.parse(intentCall[1].body as string);
+      expect(intentReq.action).toBe("buy");
+      expect(intentReq.usdcAmount).toBe("5000000");
+      expect(intentReq.sharesAmount).toBeUndefined();
+      expect(intentReq.maxSlippageBps).toBe(100);
+      expect(intentReq.maxFeeBps).toBe(200);
+
       const relayCall = mockFetch.mock.calls[1] as [string, RequestInit];
       expect(relayCall[0]).toBe(`${FLIPCOIN_API_BASE_URL}/api/agent/trade/relay`);
       const relayBody = JSON.parse(relayCall[1].body as string);
@@ -344,16 +388,16 @@ describe("FlipCoinActionProvider", () => {
       );
     });
 
-    it("returns structured error when approval required", async () => {
+    it("returns structured error when approvalRequired is present on intent", async () => {
       const mockFetch = createMockFetch([
         {
           body: {
             ...intentBody,
             approvalRequired: {
               contract: "0xabc",
-              function: "setApprovalForAll",
+              function: "setApprovalForAll(address operator, bool approved)",
               operator: "0xrouter",
-              approved: false,
+              approved: true,
               hint: "Approve router",
             },
           },
@@ -365,14 +409,15 @@ describe("FlipCoinActionProvider", () => {
       });
       const wallet = createMockWallet();
       const result = JSON.parse(
-        await provider.buyPredictionShares(wallet, {
+        await provider.sellPredictionShares(wallet, {
           conditionId: MOCK_CONDITION_ID,
           side: "yes",
-          amountUsdc: "5",
+          shares: "5",
         }),
       );
       expect(result.success).toBe(false);
       expect(result.approvalRequired).toBeDefined();
+      expect(result.approvalRequired.operator).toBe("0xrouter");
       expect(wallet.signTypedData).not.toHaveBeenCalled();
     });
 
@@ -457,18 +502,10 @@ describe("FlipCoinActionProvider", () => {
             status: "awaiting_relay",
             venue: "lmsr",
             quote: {
-              quoteId: "q",
-              validUntil: "2026-04-23T12:00:12Z",
-              side: "yes",
-              action: "sell",
-              amount: "5000000",
               sharesOut: "0",
-              amountOut: "2500000",
               avgPriceBps: 5000,
               priceImpactBps: 10,
               fee: "5000",
-              minOut: "2475000",
-              maxFeeBps: 300,
             },
             typedData: {
               domain: {
@@ -515,6 +552,8 @@ describe("FlipCoinActionProvider", () => {
       const intentCall = mockFetch.mock.calls[0] as [string, RequestInit];
       const body = JSON.parse(intentCall[1].body as string);
       expect(body.action).toBe("sell");
+      expect(body.sharesAmount).toBe("5000000");
+      expect(body.usdcAmount).toBeUndefined();
     });
   });
 

--- a/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.ts
@@ -1,0 +1,505 @@
+import { z } from "zod";
+import { parseUnits } from "viem";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { Network } from "../../network";
+import {
+  DEFAULT_MAX_FEE_BPS,
+  DEFAULT_MAX_SLIPPAGE_BPS,
+  FLIPCOIN_API_BASE_URL,
+  FLIPCOIN_API_VERSION,
+  SUPPORTED_NETWORK_IDS,
+} from "./constants";
+import {
+  BuySharesSchema,
+  GetAgentPortfolioSchema,
+  GetMarketOddsSchema,
+  GetMarketsSchema,
+  SellSharesSchema,
+} from "./schemas";
+import {
+  ListMarketsResponse,
+  PortfolioResponse,
+  QuoteResponse,
+  TradeIntentResponse,
+  TradeRelayResponse,
+} from "./types";
+
+/**
+ * Configuration options for {@link FlipCoinActionProvider}.
+ */
+export interface FlipCoinActionProviderConfig {
+  /**
+   * FlipCoin agent API key (format: `fc_agent_live_...`). Required for portfolio and trade actions.
+   * Get one at https://www.flipcoin.fun/app/settings (Developers tab).
+   */
+  apiKey?: string;
+  /**
+   * Override the FlipCoin API base URL. Defaults to `https://www.flipcoin.fun`.
+   * Useful for staging / self-hosted deployments.
+   */
+  baseUrl?: string;
+  /**
+   * Custom `fetch` implementation. Defaults to the global `fetch`.
+   * Useful for testing or Node.js environments without global fetch.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+const FALLBACK_REASON = "Unknown error";
+
+/**
+ * Action provider for FlipCoin — prediction markets on Base.
+ *
+ * Provides 5 actions:
+ *  - `get_prediction_markets` — list tradable markets
+ *  - `get_market_odds` — firm quote (YES/NO price, sharesOut, priceImpact)
+ *  - `buy_prediction_shares` — buy YES or NO shares (EIP-712 signed by wallet)
+ *  - `sell_prediction_shares` — sell YES or NO shares (EIP-712 signed by wallet)
+ *  - `get_agent_portfolio` — agent's positions and P&L
+ *
+ * Trade actions use FlipCoin's two-phase intent/relay pattern: the provider requests
+ * an EIP-712 `TradeIntent` from `/api/agent/trade/intent`, signs it with the supplied
+ * {@link EvmWalletProvider}, and submits it to `/api/agent/trade/relay` where FlipCoin's
+ * relayer broadcasts the transaction on-chain.
+ */
+export class FlipCoinActionProvider extends ActionProvider<EvmWalletProvider> {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  /**
+   * Creates a new FlipCoin action provider.
+   *
+   * @param config - Provider configuration (api key, base url override, fetch override).
+   */
+  constructor(config: FlipCoinActionProviderConfig = {}) {
+    super("flipcoin", []);
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl ?? FLIPCOIN_API_BASE_URL).replace(/\/+$/, "");
+    this.fetchImpl = config.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /**
+   * Lists tradable prediction markets on FlipCoin.
+   *
+   * @param _walletProvider - Unused (public endpoint).
+   * @param args - Filters: status, category, limit, offset.
+   * @returns JSON string with markets array and pagination info.
+   */
+  @CreateAction({
+    name: "get_prediction_markets",
+    description: `
+Fetch a page of FlipCoin prediction markets on Base. Use this to discover markets to trade on.
+Returns each market's conditionId (needed for trading), title, current YES/NO prices (as basis
+points, 5000 = 50%), volume, trade count and resolution deadline. Filter by status
+('active' = tradable, 'resolved' = settled). Prices reflect crowd-sourced odds.
+`,
+    schema: GetMarketsSchema,
+  })
+  async getPredictionMarkets(
+    _walletProvider: EvmWalletProvider,
+    args: z.infer<typeof GetMarketsSchema>,
+  ): Promise<string> {
+    try {
+      const params = new URLSearchParams();
+      const status = args.status ?? "active";
+      if (status && status !== "all") params.set("status", status);
+      if (args.category) params.set("category", args.category);
+      params.set("limit", String(args.limit ?? 25));
+      params.set("offset", String(args.offset ?? 0));
+
+      const data = await this.request<ListMarketsResponse>(`/api/markets?${params.toString()}`, {
+        method: "GET",
+      });
+
+      const markets = data.markets.map(m => ({
+        conditionId: m.condition_id,
+        marketAddress: m.market_addr,
+        title: m.title,
+        status: m.status,
+        volumeUsdc: m.volume_usdc,
+        liquidityUsdc: m.liquidity_usdc,
+        tradesCount: m.trades_count,
+        resolvesAt: m.resolve_end_at,
+        category: m.category ?? null,
+      }));
+
+      return JSON.stringify({
+        success: true,
+        count: markets.length,
+        pagination: data.pagination,
+        markets,
+      });
+    } catch (error) {
+      return this.errorJson("Failed to fetch prediction markets", error);
+    }
+  }
+
+  /**
+   * Fetches the current odds and a firm quote for a specific market.
+   *
+   * @param _walletProvider - Unused (public endpoint).
+   * @param args - conditionId plus optional side / action / amount for simulation.
+   * @returns JSON string with current YES/NO prices (bps) and simulated trade result.
+   */
+  @CreateAction({
+    name: "get_market_odds",
+    description: `
+Fetch current odds (YES/NO prices) and a firm quote for a FlipCoin prediction market. If you pass
+amountUsdc, the response includes sharesOut, priceImpact, and a quoteId valid for ~12 seconds
+(useful to preview a trade before committing). Prices in basis points: 5000 = 50%.
+`,
+    schema: GetMarketOddsSchema,
+  })
+  async getMarketOdds(
+    _walletProvider: EvmWalletProvider,
+    args: z.infer<typeof GetMarketOddsSchema>,
+  ): Promise<string> {
+    try {
+      const side = args.side ?? "yes";
+      const action = args.action ?? "buy";
+      const amountRaw =
+        args.amountUsdc && args.amountUsdc.length > 0
+          ? parseUnits(args.amountUsdc, 6).toString()
+          : "1000000";
+
+      const params = new URLSearchParams({
+        conditionId: args.conditionId,
+        side,
+        action,
+        amount: amountRaw,
+      });
+
+      const quote = await this.request<QuoteResponse>(`/api/quote?${params.toString()}`, {
+        method: "GET",
+      });
+
+      return JSON.stringify({
+        success: true,
+        conditionId: args.conditionId,
+        quoteId: quote.quoteId,
+        validUntil: quote.validUntil,
+        venue: quote.venue,
+        simulated: { side, action, amountUsdc: args.amountUsdc ?? "1" },
+        prices: {
+          yesBps: quote.lmsr.priceYesBps,
+          noBps: quote.lmsr.priceNoBps,
+          yesPercent: quote.lmsr.priceYesBps / 100,
+          noPercent: quote.lmsr.priceNoBps / 100,
+        },
+        lmsr: {
+          sharesOut: quote.lmsr.sharesOut,
+          amountOut: quote.lmsr.amountOut,
+          fee: quote.lmsr.fee,
+          avgPriceBps: quote.lmsr.avgPriceBps,
+          priceImpactBps: quote.lmsr.priceImpactBps,
+        },
+        priceImpactGuard: quote.priceImpactGuard ?? null,
+      });
+    } catch (error) {
+      return this.errorJson("Failed to fetch market odds", error);
+    }
+  }
+
+  /**
+   * Buys YES or NO shares in a prediction market using the full intent → sign → relay flow.
+   *
+   * @param walletProvider - Wallet used to sign the EIP-712 TradeIntent.
+   * @param args - conditionId, side, amountUsdc, optional maxSlippageBps.
+   * @returns JSON string with txHash and resulting position on success.
+   */
+  @CreateAction({
+    name: "buy_prediction_shares",
+    description: `
+Buy YES or NO shares in a FlipCoin prediction market. Spends USDC from the agent's vault
+(must be pre-funded). The wallet signs an EIP-712 TradeIntent which FlipCoin's relayer broadcasts
+on-chain. Returns txHash and shares received. Pass maxSlippageBps (default 200 = 2%) to bound
+price impact. Use get_market_odds first to preview the trade.
+`,
+    schema: BuySharesSchema,
+  })
+  async buyPredictionShares(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof BuySharesSchema>,
+  ): Promise<string> {
+    return this.executeTrade(walletProvider, {
+      conditionId: args.conditionId,
+      side: args.side,
+      action: "buy",
+      amount: parseUnits(args.amountUsdc, 6).toString(),
+      humanAmount: args.amountUsdc,
+      maxSlippageBps: args.maxSlippageBps ?? DEFAULT_MAX_SLIPPAGE_BPS,
+    });
+  }
+
+  /**
+   * Sells YES or NO shares in a prediction market using the full intent → sign → relay flow.
+   *
+   * @param walletProvider - Wallet used to sign the EIP-712 TradeIntent.
+   * @param args - conditionId, side, shares amount, optional maxSlippageBps.
+   * @returns JSON string with txHash and USDC received on success.
+   */
+  @CreateAction({
+    name: "sell_prediction_shares",
+    description: `
+Sell YES or NO shares in a FlipCoin prediction market. Proceeds (USDC) go to the agent's vault.
+The wallet signs an EIP-712 TradeIntent which FlipCoin's relayer broadcasts on-chain.
+Returns txHash and USDC received. Requires prior approval of ShareToken transfers to the
+BackstopRouter — the response will include approvalRequired details if missing.
+`,
+    schema: SellSharesSchema,
+  })
+  async sellPredictionShares(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof SellSharesSchema>,
+  ): Promise<string> {
+    return this.executeTrade(walletProvider, {
+      conditionId: args.conditionId,
+      side: args.side,
+      action: "sell",
+      amount: parseUnits(args.shares, 6).toString(),
+      humanAmount: args.shares,
+      maxSlippageBps: args.maxSlippageBps ?? DEFAULT_MAX_SLIPPAGE_BPS,
+    });
+  }
+
+  /**
+   * Fetches the agent's current positions and P&L.
+   *
+   * @param _walletProvider - Unused (API-key authenticated).
+   * @param args - Optional status filter.
+   * @returns JSON string with positions array and totals.
+   */
+  @CreateAction({
+    name: "get_agent_portfolio",
+    description: `
+Fetch the FlipCoin agent's current positions and P&L. Returns an array of open/resolved positions
+with net side (yes/no), shares held, average entry price, current value and unrealized P&L (USDC).
+Requires an API key with scope 'portfolio:read'.
+`,
+    schema: GetAgentPortfolioSchema,
+  })
+  async getAgentPortfolio(
+    _walletProvider: EvmWalletProvider,
+    args: z.infer<typeof GetAgentPortfolioSchema>,
+  ): Promise<string> {
+    try {
+      this.requireApiKey("get_agent_portfolio");
+      const status = args.status ?? "all";
+      const params = new URLSearchParams({ status });
+      const data = await this.request<PortfolioResponse>(
+        `/api/agent/portfolio?${params.toString()}`,
+        { method: "GET", authenticated: true },
+      );
+
+      return JSON.stringify({
+        success: true,
+        totals: data.totals,
+        positions: data.positions,
+      });
+    } catch (error) {
+      return this.errorJson("Failed to fetch agent portfolio", error);
+    }
+  }
+
+  /**
+   * FlipCoin is deployed on Base (mainnet + sepolia).
+   *
+   * @param network - The target network.
+   * @returns True if the network is Base mainnet or Base Sepolia.
+   */
+  supportsNetwork(network: Network): boolean {
+    if (network.protocolFamily !== "evm") return false;
+    if (!network.networkId) return false;
+    return (SUPPORTED_NETWORK_IDS as readonly string[]).includes(network.networkId);
+  }
+
+  /**
+   * Shared intent → sign → relay flow for buy and sell actions.
+   *
+   * @param walletProvider - Wallet used to sign the EIP-712 TradeIntent.
+   * @param params - Trade parameters.
+   * @param params.conditionId - 0x-prefixed condition id of the target market.
+   * @param params.side - Outcome side being traded ('yes' or 'no').
+   * @param params.action - Trade direction ('buy' or 'sell').
+   * @param params.amount - On-wire amount (6 decimals, integer string).
+   * @param params.humanAmount - Human-readable amount for the success payload.
+   * @param params.maxSlippageBps - Caller-supplied slippage tolerance in bps.
+   * @returns JSON string describing the outcome (txHash on success, structured error otherwise).
+   */
+  private async executeTrade(
+    walletProvider: EvmWalletProvider,
+    params: {
+      conditionId: string;
+      side: "yes" | "no";
+      action: "buy" | "sell";
+      amount: string;
+      humanAmount: string;
+      maxSlippageBps: number;
+    },
+  ): Promise<string> {
+    try {
+      this.requireApiKey(`${params.action}_prediction_shares`);
+
+      const intent = await this.request<TradeIntentResponse>("/api/agent/trade/intent", {
+        method: "POST",
+        authenticated: true,
+        body: {
+          conditionId: params.conditionId,
+          side: params.side,
+          action: params.action,
+          amount: params.amount,
+          maxSlippageBps: params.maxSlippageBps,
+          maxFeeBps: DEFAULT_MAX_FEE_BPS,
+          venue: "auto",
+        },
+      });
+
+      if (intent.priceImpactGuard.level === "blocked") {
+        return JSON.stringify({
+          success: false,
+          error: "Price impact exceeds protocol limit — trade blocked.",
+          priceImpactBps: intent.priceImpactGuard.impactBps,
+          maxAllowedImpactBps: intent.priceImpactGuard.maxAllowedImpactBps,
+        });
+      }
+
+      if (intent.approvalRequired && !intent.approvalRequired.approved) {
+        return JSON.stringify({
+          success: false,
+          error: "Approval required before trading",
+          approvalRequired: intent.approvalRequired,
+          hint: "Call ShareToken.setApprovalForAll(operator, true) from the trader wallet, then retry.",
+        });
+      }
+
+      const signature = (await walletProvider.signTypedData(
+        intent.typedData as unknown as Parameters<EvmWalletProvider["signTypedData"]>[0],
+      )) as `0x${string}`;
+
+      const relay = await this.request<TradeRelayResponse>("/api/agent/trade/relay", {
+        method: "POST",
+        authenticated: true,
+        body: { intentId: intent.intentId, signature },
+      });
+
+      if (relay.status === "confirmed") {
+        return JSON.stringify({
+          success: true,
+          status: "confirmed",
+          action: params.action,
+          side: params.side,
+          humanAmount: params.humanAmount,
+          txHash: relay.txHash,
+          sharesOut: relay.sharesOut,
+          usdcOut: relay.usdcOut,
+          feeUsdc: relay.feeUsdc,
+          quote: intent.quote,
+        });
+      }
+
+      return JSON.stringify({
+        success: false,
+        status: relay.status,
+        error: relay.error ?? FALLBACK_REASON,
+        errorCode: relay.errorCode,
+        retryable: relay.retryable,
+        intentId: relay.intentId,
+      });
+    } catch (error) {
+      return this.errorJson(`Failed to ${params.action} prediction shares`, error);
+    }
+  }
+
+  /**
+   * Typed HTTP helper for the FlipCoin API. Adds version header and optional bearer auth.
+   *
+   * @param path - Request path (starting with `/`).
+   * @param options - Request options.
+   * @param options.method - HTTP method.
+   * @param options.body - JSON-serialisable request body (POST only).
+   * @param options.authenticated - If true, attaches the `Authorization: Bearer <apiKey>` header.
+   * @returns Parsed JSON response typed as `T`.
+   */
+  private async request<T>(
+    path: string,
+    options: {
+      method: "GET" | "POST";
+      body?: unknown;
+      authenticated?: boolean;
+    },
+  ): Promise<T> {
+    const headers: Record<string, string> = {
+      "X-API-Version": FLIPCOIN_API_VERSION,
+      Accept: "application/json",
+    };
+    if (options.body !== undefined) headers["Content-Type"] = "application/json";
+    if (options.authenticated) headers.Authorization = `Bearer ${this.apiKey}`;
+
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: options.method,
+      headers,
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+
+    const raw = await response.text();
+    let json: unknown;
+    try {
+      json = raw.length > 0 ? JSON.parse(raw) : {};
+    } catch {
+      throw new Error(
+        `FlipCoin API returned non-JSON response (status ${response.status}): ${raw.slice(0, 200)}`,
+      );
+    }
+
+    if (!response.ok) {
+      const message =
+        (json as { error?: string; message?: string })?.error ||
+        (json as { message?: string })?.message ||
+        `FlipCoin API error (status ${response.status})`;
+      const errorCode = (json as { errorCode?: string })?.errorCode;
+      const err = new Error(errorCode ? `${message} [${errorCode}]` : message);
+      (err as Error & { status?: number }).status = response.status;
+      throw err;
+    }
+
+    return json as T;
+  }
+
+  /**
+   * Throws a descriptive error when the provider was constructed without an API key.
+   *
+   * @param action - Name of the action that required the key (used in the error message).
+   */
+  private requireApiKey(action: string): void {
+    if (!this.apiKey) {
+      throw new Error(
+        `FlipCoin API key required for '${action}'. Pass it via flipcoinActionProvider({ apiKey }). ` +
+          `Create a key at https://www.flipcoin.fun/app/settings.`,
+      );
+    }
+  }
+
+  /**
+   * Formats an exception into the provider's standard JSON error envelope.
+   *
+   * @param message - Human-readable prefix describing what failed.
+   * @param error - The caught error or thrown value.
+   * @returns A JSON string `{ success: false, error: "<message>: <details>" }`.
+   */
+  private errorJson(message: string, error: unknown): string {
+    const details = error instanceof Error ? error.message : String(error);
+    return JSON.stringify({ success: false, error: `${message}: ${details}` });
+  }
+}
+
+/**
+ * Factory function for {@link FlipCoinActionProvider}.
+ *
+ * @param config - Provider configuration.
+ * @returns A new FlipCoin action provider instance.
+ */
+export const flipcoinActionProvider = (config: FlipCoinActionProviderConfig = {}) =>
+  new FlipCoinActionProvider(config);

--- a/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.ts
@@ -148,8 +148,9 @@ points, 5000 = 50%), volume, trade count and resolution deadline. Filter by stat
     name: "get_market_odds",
     description: `
 Fetch current odds (YES/NO prices) and a firm quote for a FlipCoin prediction market. If you pass
-amountUsdc, the response includes sharesOut, priceImpact, and a quoteId valid for ~12 seconds
-(useful to preview a trade before committing). Prices in basis points: 5000 = 50%.
+an amount, the response includes sharesOut, priceImpact, and a quoteId valid for ~12 seconds
+(useful to preview a trade before committing). The amount is interpreted as USDC for action='buy'
+and as shares for action='sell'. Prices in basis points: 5000 = 50%.
 `,
     schema: GetMarketOddsSchema,
   })
@@ -161,9 +162,7 @@ amountUsdc, the response includes sharesOut, priceImpact, and a quoteId valid fo
       const side = args.side ?? "yes";
       const action = args.action ?? "buy";
       const amountRaw =
-        args.amountUsdc && args.amountUsdc.length > 0
-          ? parseUnits(args.amountUsdc, 6).toString()
-          : "1000000";
+        args.amount && args.amount.length > 0 ? parseUnits(args.amount, 6).toString() : "1000000";
 
       const params = new URLSearchParams({
         conditionId: args.conditionId,
@@ -182,7 +181,12 @@ amountUsdc, the response includes sharesOut, priceImpact, and a quoteId valid fo
         quoteId: quote.quoteId,
         validUntil: quote.validUntil,
         venue: quote.venue,
-        simulated: { side, action, amountUsdc: args.amountUsdc ?? "1" },
+        simulated: {
+          side,
+          action,
+          amount: args.amount ?? "1",
+          amountType: action === "sell" ? "shares" : "usdc",
+        },
         prices: {
           yesBps: quote.lmsr.priceYesBps,
           noBps: quote.lmsr.priceNoBps,
@@ -215,7 +219,7 @@ amountUsdc, the response includes sharesOut, priceImpact, and a quoteId valid fo
     description: `
 Buy YES or NO shares in a FlipCoin prediction market. Spends USDC from the agent's vault
 (must be pre-funded). The wallet signs an EIP-712 TradeIntent which FlipCoin's relayer broadcasts
-on-chain. Returns txHash and shares received. Pass maxSlippageBps (default 200 = 2%) to bound
+on-chain. Returns txHash and shares received. Pass maxSlippageBps (default 100 = 1%) to bound
 price impact. Use get_market_odds first to preview the trade.
 `,
     schema: BuySharesSchema,
@@ -228,7 +232,7 @@ price impact. Use get_market_odds first to preview the trade.
       conditionId: args.conditionId,
       side: args.side,
       action: "buy",
-      amount: parseUnits(args.amountUsdc, 6).toString(),
+      usdcAmount: parseUnits(args.amountUsdc, 6).toString(),
       humanAmount: args.amountUsdc,
       maxSlippageBps: args.maxSlippageBps ?? DEFAULT_MAX_SLIPPAGE_BPS,
     });
@@ -259,7 +263,7 @@ BackstopRouter — the response will include approvalRequired details if missing
       conditionId: args.conditionId,
       side: args.side,
       action: "sell",
-      amount: parseUnits(args.shares, 6).toString(),
+      sharesAmount: parseUnits(args.shares, 6).toString(),
       humanAmount: args.shares,
       maxSlippageBps: args.maxSlippageBps ?? DEFAULT_MAX_SLIPPAGE_BPS,
     });
@@ -324,7 +328,8 @@ Requires an API key with scope 'portfolio:read'.
    * @param params.conditionId - 0x-prefixed condition id of the target market.
    * @param params.side - Outcome side being traded ('yes' or 'no').
    * @param params.action - Trade direction ('buy' or 'sell').
-   * @param params.amount - On-wire amount (6 decimals, integer string).
+   * @param params.usdcAmount - Raw USDC amount (6 decimals) when action='buy'.
+   * @param params.sharesAmount - Raw shares amount (6 decimals) when action='sell'.
    * @param params.humanAmount - Human-readable amount for the success payload.
    * @param params.maxSlippageBps - Caller-supplied slippage tolerance in bps.
    * @returns JSON string describing the outcome (txHash on success, structured error otherwise).
@@ -335,7 +340,8 @@ Requires an API key with scope 'portfolio:read'.
       conditionId: string;
       side: "yes" | "no";
       action: "buy" | "sell";
-      amount: string;
+      usdcAmount?: string;
+      sharesAmount?: string;
       humanAmount: string;
       maxSlippageBps: number;
     },
@@ -343,18 +349,24 @@ Requires an API key with scope 'portfolio:read'.
     try {
       this.requireApiKey(`${params.action}_prediction_shares`);
 
+      const body: Record<string, unknown> = {
+        conditionId: params.conditionId,
+        side: params.side,
+        action: params.action,
+        maxSlippageBps: params.maxSlippageBps,
+        maxFeeBps: DEFAULT_MAX_FEE_BPS,
+        venue: "auto",
+      };
+      if (params.action === "buy") {
+        body.usdcAmount = params.usdcAmount;
+      } else {
+        body.sharesAmount = params.sharesAmount;
+      }
+
       const intent = await this.request<TradeIntentResponse>("/api/agent/trade/intent", {
         method: "POST",
         authenticated: true,
-        body: {
-          conditionId: params.conditionId,
-          side: params.side,
-          action: params.action,
-          amount: params.amount,
-          maxSlippageBps: params.maxSlippageBps,
-          maxFeeBps: DEFAULT_MAX_FEE_BPS,
-          venue: "auto",
-        },
+        body,
       });
 
       if (intent.priceImpactGuard.level === "blocked") {
@@ -366,12 +378,14 @@ Requires an API key with scope 'portfolio:read'.
         });
       }
 
-      if (intent.approvalRequired && !intent.approvalRequired.approved) {
+      // `approvalRequired` is returned ONLY when ShareToken approval is missing.
+      // The nested `approved: true` is the TARGET value for setApprovalForAll, not current state.
+      if (intent.approvalRequired) {
         return JSON.stringify({
           success: false,
-          error: "Approval required before trading",
+          error: "Approval required before selling shares",
           approvalRequired: intent.approvalRequired,
-          hint: "Call ShareToken.setApprovalForAll(operator, true) from the trader wallet, then retry.",
+          hint: "Call ShareToken.setApprovalForAll(approvalRequired.operator, true) from the trader wallet, then retry.",
         });
       }
 

--- a/typescript/agentkit/src/action-providers/flipcoin/index.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/index.ts
@@ -1,0 +1,2 @@
+export * from "./flipcoinActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/flipcoin/schemas.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/schemas.ts
@@ -54,13 +54,13 @@ export const GetMarketOddsSchema = z
       .nullable()
       .optional()
       .describe("Whether to simulate a buy or sell. Defaults to 'buy'."),
-    amountUsdc: z
+    amount: z
       .string()
       .regex(/^\d+(\.\d+)?$/)
       .nullable()
       .optional()
       .describe(
-        "Optional human-readable USDC amount (e.g. '10' = $10) used for firm-quote simulation. Required when you want sharesOut / priceImpact.",
+        "Optional human-readable amount used for firm-quote simulation. Interpreted as USDC when action='buy' (e.g. '10' = $10) and as shares when action='sell' (e.g. '10' = 10 shares). Required when you want sharesOut / priceImpact.",
       ),
   })
   .describe("Parameters for fetching market odds / firm quote.");
@@ -86,7 +86,7 @@ export const BuySharesSchema = z
       .max(10000)
       .nullable()
       .optional()
-      .describe("Maximum slippage tolerance in basis points (10000 = 100%). Defaults to 200 (2%)."),
+      .describe("Maximum slippage tolerance in basis points (10000 = 100%). Defaults to 100 (1%)."),
   })
   .describe("Parameters for buying shares in a FlipCoin prediction market.");
 
@@ -111,7 +111,7 @@ export const SellSharesSchema = z
       .max(10000)
       .nullable()
       .optional()
-      .describe("Maximum slippage tolerance in basis points. Defaults to 200 (2%)."),
+      .describe("Maximum slippage tolerance in basis points. Defaults to 100 (1%)."),
   })
   .describe("Parameters for selling shares in a FlipCoin prediction market.");
 

--- a/typescript/agentkit/src/action-providers/flipcoin/schemas.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/schemas.ts
@@ -1,0 +1,129 @@
+import { z } from "zod";
+
+/**
+ * Schema for listing prediction markets.
+ */
+export const GetMarketsSchema = z
+  .object({
+    status: z
+      .enum(["active", "expired", "resolved", "all"])
+      .nullable()
+      .optional()
+      .describe("Filter by market status. Defaults to 'active' (tradable markets only)."),
+    category: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Optional category filter (e.g. 'crypto', 'sports', 'politics')."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .nullable()
+      .optional()
+      .describe("Maximum number of markets to return (1-100). Default 25."),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("Number of markets to skip, for pagination. Default 0."),
+  })
+  .describe("Parameters for listing FlipCoin prediction markets.");
+
+/**
+ * Schema for fetching current odds / firm quote for a market.
+ */
+export const GetMarketOddsSchema = z
+  .object({
+    conditionId: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{64}$/, "Must be a 0x-prefixed 32-byte condition id")
+      .describe(
+        "The market conditionId (0x-prefixed 32-byte hex). Get it from get_prediction_markets.",
+      ),
+    side: z
+      .enum(["yes", "no"])
+      .nullable()
+      .optional()
+      .describe("Outcome side to price. Defaults to 'yes'."),
+    action: z
+      .enum(["buy", "sell"])
+      .nullable()
+      .optional()
+      .describe("Whether to simulate a buy or sell. Defaults to 'buy'."),
+    amountUsdc: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/)
+      .nullable()
+      .optional()
+      .describe(
+        "Optional human-readable USDC amount (e.g. '10' = $10) used for firm-quote simulation. Required when you want sharesOut / priceImpact.",
+      ),
+  })
+  .describe("Parameters for fetching market odds / firm quote.");
+
+/**
+ * Schema for buying YES or NO shares in a market.
+ */
+export const BuySharesSchema = z
+  .object({
+    conditionId: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{64}$/, "Must be a 0x-prefixed 32-byte condition id")
+      .describe("The market conditionId (0x-prefixed 32-byte hex)."),
+    side: z.enum(["yes", "no"]).describe("Outcome to buy: 'yes' or 'no'."),
+    amountUsdc: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/)
+      .describe("USDC amount to spend (human units, e.g. '5' = $5)."),
+    maxSlippageBps: z
+      .number()
+      .int()
+      .min(1)
+      .max(10000)
+      .nullable()
+      .optional()
+      .describe("Maximum slippage tolerance in basis points (10000 = 100%). Defaults to 200 (2%)."),
+  })
+  .describe("Parameters for buying shares in a FlipCoin prediction market.");
+
+/**
+ * Schema for selling YES or NO shares in a market.
+ */
+export const SellSharesSchema = z
+  .object({
+    conditionId: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{64}$/, "Must be a 0x-prefixed 32-byte condition id")
+      .describe("The market conditionId (0x-prefixed 32-byte hex)."),
+    side: z.enum(["yes", "no"]).describe("Outcome side of the shares being sold."),
+    shares: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/)
+      .describe("Amount of shares to sell (human units, e.g. '10' = 10 shares)."),
+    maxSlippageBps: z
+      .number()
+      .int()
+      .min(1)
+      .max(10000)
+      .nullable()
+      .optional()
+      .describe("Maximum slippage tolerance in basis points. Defaults to 200 (2%)."),
+  })
+  .describe("Parameters for selling shares in a FlipCoin prediction market.");
+
+/**
+ * Schema for fetching the agent's portfolio. No args required.
+ */
+export const GetAgentPortfolioSchema = z
+  .object({
+    status: z
+      .enum(["open", "resolved", "all"])
+      .nullable()
+      .optional()
+      .describe("Filter positions by market status. Defaults to 'all'."),
+  })
+  .describe("Parameters for fetching the current agent's positions and P&L.");

--- a/typescript/agentkit/src/action-providers/flipcoin/types.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/types.ts
@@ -1,0 +1,152 @@
+/**
+ * Type definitions for the FlipCoin API responses.
+ *
+ * These mirror the OpenAPI spec exposed at https://www.flipcoin.fun/api/openapi.json.
+ * Only the fields used by the action provider are declared here.
+ */
+
+export interface FlipcoinMarket {
+  id: string;
+  chain_id: string;
+  market_addr: string;
+  condition_id: string;
+  title: string;
+  description: string;
+  status: "open" | "resolved";
+  resolved_outcome: string | null;
+  volume_usdc: number;
+  liquidity_usdc: number;
+  trades_count: number;
+  resolve_end_at: string;
+  category?: string;
+  market_version: number;
+}
+
+export interface ListMarketsResponse {
+  markets: FlipcoinMarket[];
+  pagination: { offset: number; limit: number; total: number | null };
+}
+
+export interface QuoteResponse {
+  quoteId: string;
+  conditionId: string;
+  side: "yes" | "no";
+  action: "buy" | "sell";
+  amount: string;
+  venue: "lmsr" | "clob";
+  validUntil: string;
+  lmsr: {
+    available: boolean;
+    sharesOut: string;
+    amountOut: string;
+    fee: string;
+    priceYesBps: number;
+    priceNoBps: number;
+    newPriceYesBps: number;
+    priceImpactBps: number;
+    avgPriceBps: number;
+  };
+  clob: {
+    available: boolean;
+    canFillFull: boolean;
+    bestBidBps: number | null;
+    bestAskBps: number | null;
+  };
+  priceImpactGuard?: {
+    level: "ok" | "warn" | "blocked";
+    impactBps: number;
+    maxAllowedImpactBps: number;
+  };
+}
+
+export interface TradeIntentTypedData {
+  domain: {
+    name: string;
+    version: string;
+    chainId: number;
+    verifyingContract: `0x${string}`;
+  };
+  types: Record<string, Array<{ name: string; type: string }>>;
+  primaryType: "TradeIntent";
+  message: Record<string, string | number | boolean>;
+}
+
+export interface TradeIntentResponse {
+  intentId: string;
+  status: "awaiting_relay";
+  venue: "lmsr";
+  quote: {
+    quoteId: string;
+    validUntil: string;
+    side: "yes" | "no";
+    action: "buy" | "sell";
+    amount: string;
+    sharesOut: string;
+    amountOut: string;
+    avgPriceBps: number;
+    priceImpactBps: number;
+    fee: string;
+    minOut: string;
+    maxFeeBps: number;
+  };
+  typedData: TradeIntentTypedData;
+  balanceCheck: {
+    sufficient: boolean;
+    required: string;
+    available: string;
+  };
+  approvalRequired?: {
+    contract: string;
+    function: string;
+    operator: string;
+    approved: boolean;
+    hint: string;
+  };
+  priceImpactGuard: {
+    level: "ok" | "warn" | "blocked";
+    impactBps: number;
+    maxAllowedImpactBps: number;
+  };
+}
+
+export interface TradeRelayResponse {
+  intentId: string;
+  status: "confirmed" | "awaiting_relay" | "failed";
+  venue: "lmsr";
+  txHash: string | null;
+  sharesOut: string | null;
+  usdcOut: string | null;
+  feeUsdc: string | null;
+  error: string | null;
+  retryable: boolean;
+  errorCode?: string;
+  approvalRequired?: {
+    contract: string;
+    function: string;
+    operator: string;
+    hint: string;
+  };
+}
+
+export interface PortfolioPosition {
+  marketAddr: string;
+  title: string | null;
+  status: "open" | "resolved" | null;
+  yesShares: number;
+  noShares: number;
+  netSide: "yes" | "no";
+  netShares: number;
+  avgEntryPriceUsdc: number;
+  currentPriceBps: number;
+  currentValueUsdc: number;
+  pnlUsdc: number;
+  lastTradeAt: string | null;
+}
+
+export interface PortfolioResponse {
+  positions: PortfolioPosition[];
+  totals: {
+    marketsActive: number;
+    marketsResolved: number;
+  };
+}

--- a/typescript/agentkit/src/action-providers/flipcoin/types.ts
+++ b/typescript/agentkit/src/action-providers/flipcoin/types.ts
@@ -76,18 +76,10 @@ export interface TradeIntentResponse {
   status: "awaiting_relay";
   venue: "lmsr";
   quote: {
-    quoteId: string;
-    validUntil: string;
-    side: "yes" | "no";
-    action: "buy" | "sell";
-    amount: string;
     sharesOut: string;
-    amountOut: string;
     avgPriceBps: number;
     priceImpactBps: number;
     fee: string;
-    minOut: string;
-    maxFeeBps: number;
   };
   typedData: TradeIntentTypedData;
   balanceCheck: {

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -17,6 +17,7 @@ export * from "./erc20";
 export * from "./erc721";
 export * from "./erc8004";
 export * from "./farcaster";
+export * from "./flipcoin";
 export * from "./jupiter";
 export * from "./messari";
 export * from "./pyth";


### PR DESCRIPTION
## Summary

Adds a new `@coinbase/agentkit` action provider for [**FlipCoin**](https://www.flipcoin.fun) — a LMSR-based prediction-market protocol on Base (mainnet + Sepolia). This is the first prediction-market provider in AgentKit.

FlipCoin agents can now:
- `get_prediction_markets` — list tradable markets with YES/NO prices, volume and deadlines.
- `get_market_odds` — fetch a firm quote: `priceYesBps`, `priceNoBps`, `sharesOut`, `priceImpact`, `avgPriceBps` (quote is valid ~12s).
- `buy_prediction_shares` — buy YES/NO shares with USDC from the agent's vault.
- `sell_prediction_shares` — sell YES/NO shares back into the LMSR pool.
- `get_agent_portfolio` — read the agent's open/resolved positions with net side, entry price and unrealized P&L.

Trades use FlipCoin's two-phase **intent → sign → relay** pattern:

1. The provider POSTs to `/api/agent/trade/intent` to get an EIP-712 `TradeIntent` typed-data payload + a firm quote.
2. The supplied `EvmWalletProvider.signTypedData()` signs it (so any AgentKit-compatible wallet works: CDP, Viem, Privy, ZeroDev, etc.).
3. The signature is POSTed to `/api/agent/trade/relay`; FlipCoin's relayer covers gas and broadcasts on-chain.

The provider also surfaces structured errors for: price-impact guard blocking the trade (`priceImpactGuard.level === "blocked"`), missing `ShareToken.setApprovalForAll(router, true)` approval (pre-flight, before signing), and retryable RPC failures during relay.

## Why this matters

Prediction markets are a natural fit for autonomous agents — they expose probabilistic claims about future events with pricing that reflects crowd wisdom. Until now there was no prediction-market provider in AgentKit. FlipCoin is fully open (contracts + Python/TS SDKs) and exposes a dedicated **Agent API** with API keys, EIP-712 trade intents, on-chain delegation for autonomous signing, and webhook streaming — perfect for AgentKit wallet providers.

## Files

- `typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.ts` — provider + 5 actions
- `typescript/agentkit/src/action-providers/flipcoin/schemas.ts` — Zod input schemas
- `typescript/agentkit/src/action-providers/flipcoin/constants.ts` — base URL, API version, supported networks
- `typescript/agentkit/src/action-providers/flipcoin/types.ts` — FlipCoin API response types
- `typescript/agentkit/src/action-providers/flipcoin/flipcoinActionProvider.test.ts` — 19 unit tests
- `typescript/agentkit/src/action-providers/flipcoin/README.md` — usage docs
- `typescript/agentkit/src/action-providers/index.ts` — registration
- `typescript/.changeset/flipcoin-action-provider.md` — changeset

## Test plan

- [x] `pnpm run lint` (no warnings/errors on flipcoin/)
- [x] `pnpm run build` (clean tsc)
- [x] `pnpm test` → **883/883 tests pass** (61 suites), 19 new tests for FlipCoin covering:
  - `supportsNetwork` (Base mainnet/sepolia allow, others reject, non-EVM reject)
  - `get_prediction_markets` happy path, filters, error path
  - `get_market_odds` firm quote + default $1 simulation
  - `buy_prediction_shares` intent→sign→relay happy path
  - `buy_prediction_shares` approval-required short-circuit (no sign)
  - `buy_prediction_shares` price-impact guard block (no sign)
  - `buy_prediction_shares` missing API key error
  - `buy_prediction_shares` retryable relay errors surfaced
  - `sell_prediction_shares` sends `action: "sell"` to intent
  - `get_agent_portfolio` auth header + shape

## Network support

- Base Mainnet (`base-mainnet`, chainId 8453)
- Base Sepolia (`base-sepolia`, chainId 84532)

## Links

- FlipCoin: https://www.flipcoin.fun
- OpenAPI spec: https://www.flipcoin.fun/api/openapi.json
- Agent API docs: https://www.flipcoin.fun/docs/agents
- Python SDK: https://pypi.org/project/flipcoin/
- Agent starter kit (TS): https://github.com/flipcoin-fun/flipcoin-agent-starter
- MCP server: https://github.com/flipcoin-fun/flipcoin-mcp

A follow-up PR will add an `autonomous-bettor` example under `typescript/examples/` that uses this provider end-to-end.