### PR TITLE
Add x402station action provider — pre-flight oracle for x402 endpoints

### DIFF
--- a/typescript/.changeset/add-x402station-action-provider.md
+++ b/typescript/.changeset/add-x402station-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added a new `x402station` action provider — a pre-flight oracle for the x402 agentic-commerce network. Six tools (preflight, forensics, catalog_decoys, watch_subscribe, watch_status, watch_unsubscribe) wrapping the public oracle at https://x402station.io. Four are paid via x402 ($0.001–$0.01 USDC, auto-signed via the agent's `EvmWalletProvider`); two are free + secret-gated for managing an existing webhook subscription. Networks: Base mainnet and Base Sepolia.

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -36,6 +36,7 @@ export * from "./flaunch";
 export * from "./onramp";
 export * from "./vaultsfyi";
 export * from "./x402";
+export * from "./x402station";
 export * from "./yelay";
 export * from "./zerion";
 export * from "./zerodev";

--- a/typescript/agentkit/src/action-providers/x402station/README.md
+++ b/typescript/agentkit/src/action-providers/x402station/README.md
@@ -1,0 +1,110 @@
+# X402station Action Provider
+
+The `x402station` action provider gives any AgentKit agent a pre-flight oracle for x402 endpoints. Four paid tools (`preflight`, `forensics`, `catalog_decoys`, `watch_subscribe`) auto-sign their own $0.001–$0.01 USDC payments through the agent's configured `EvmWalletProvider`; two free secret-gated tools (`watch_status`, `watch_unsubscribe`) manage an existing webhook subscription.
+
+This is a wrapper around the public oracle at [x402station.io](https://x402station.io) — same API + identical signal vocabulary used by the official `x402station-mcp` package on npm.
+
+## Why pre-flight?
+
+The agentic.market catalog has 25,000+ x402 endpoints. A non-trivial fraction are honeypots:
+
+- **Decoys** priced ≥ $1,000 USDC per call. An agent that pays one drains its wallet.
+- **Zombies** that 402-handshake fine but always 4xx after settlement (the call-side payment goes through, the agent gets nothing).
+- **Dead** endpoints that return network errors or 5xx every probe.
+- **Price-jacked** endpoints whose listed price drifted 10× past the provider's group median.
+
+x402station independently probes every endpoint every ~10 minutes (not facilitator-reported) so it catches what facilitator-only monitors miss. Calling `preflight` before each paid x402 request costs $0.001 — typically 20× cheaper than the request the agent would otherwise lose to a decoy.
+
+## Networks
+
+- Base mainnet (`base-mainnet` / `eip155:8453`) — production
+- Base Sepolia (`base-sepolia` / `eip155:84532`) — testing
+
+The oracle accepts USDC payments on both networks via Coinbase's CDP facilitator; the action provider's `supportsNetwork` returns `false` for any other network.
+
+## Actions
+
+| Action | Cost | Description |
+|---|---|---|
+| `preflight` | $0.001 | `{ok, warnings[], metadata}` for any URL — fast safety check |
+| `forensics` | $0.001 | 7-day uptime + latency p50/p90/p99 + decoy probability + concentration stats |
+| `catalog_decoys` | $0.005 | Every URL flagged dangerous, in one cacheable blob |
+| `watch_subscribe` | $0.01 | 30-day webhook subscription + 100 prepaid HMAC-signed alerts |
+| `watch_status` | free* | Read-back: active/expired, alerts remaining, recent deliveries |
+| `watch_unsubscribe` | free* | Soft-delete a watch |
+
+\* Free actions are secret-gated by the 64-char hex secret returned from `watch_subscribe`. Constant-time compare on the server; mismatched secret returns 404 (not 401) so an attacker scraping IDs can't distinguish "exists but wrong secret" from "doesn't exist".
+
+## Signal vocabulary
+
+Strings returned in `warnings[]` from `preflight` / `forensics`. **Bold** signals flip `ok` to `false` and an agent should refuse the target call:
+
+- **`dead`** — ≥3 unhealthy probes in the last 30 min
+- **`zombie`** — ≥3 probes in the last hour, zero healthy
+- **`decoy_price_extreme`** — listed price ≥ $1,000 USDC
+- **`dead_7d`** — ≥20 probes over 7 days, zero healthy (forensics-only)
+- **`mostly_dead`** — ≥20 probes over 7 days, uptime < 50% (forensics-only)
+- `unknown_endpoint` — URL not in the catalog (informational; still billed)
+- `no_history` — in catalog but no probes in the last hour
+- `suspicious_high_price` — price $10–$1,000 USDC
+- `slow` — avg latency ≥ 2,000 ms in the last hour
+- `new_provider` — service first seen < 24h ago
+- `slow_p99` — latency p99 ≥ 5,000 ms (forensics-only)
+- `price_outlier_high` — current price > 10× provider-group median
+- `high_concentration` — endpoint's provider owns ≥ 5% of the catalog
+
+The watch endpoint accepts a subset of these in its `signals` array — the worker fires when subscribed signals appear or clear vs the last computed state.
+
+## Example
+
+```typescript
+import {
+  AgentKit,
+  CdpEvmServerWalletProvider,
+  x402stationActionProvider,
+} from "@coinbase/agentkit";
+
+const walletProvider = await CdpEvmServerWalletProvider.configureWithWallet({
+  apiKeyId: process.env.CDP_API_KEY_ID!,
+  apiKeySecret: process.env.CDP_API_KEY_SECRET!,
+  walletSecret: process.env.CDP_WALLET_SECRET!,
+  networkId: "base-mainnet",
+});
+
+const agentKit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [x402stationActionProvider()],
+});
+
+// The LLM can now call preflight, forensics, etc. via getActions().
+// Pre-flight a target before the agent commits a paid call to it:
+const actions = agentKit.getActions();
+const preflight = actions.find((a) => a.name.endsWith("_preflight"))!;
+const result = await preflight.invoke({
+  url: "https://api.venice.ai/api/v1/chat/completions",
+});
+console.log(JSON.parse(result));
+//   { result: { ok: false, warnings: ["dead", "zombie"], metadata: {...} },
+//     paymentReceipt: { transaction: "0x…" } }
+```
+
+## Configuration
+
+```typescript
+x402stationActionProvider({
+  // Defaults to https://x402station.io. Only the canonical host or a
+  // localhost dev URL is accepted — refuses to start otherwise so a
+  // misconfigured agent can't sign x402 payments against an unknown host.
+  baseUrl: "https://x402station.io",
+});
+```
+
+## Links
+
+- Service: <https://x402station.io>
+- Manifest: <https://x402station.io/.well-known/x402>
+- OpenAPI: <https://x402station.io/api/openapi.json>
+- Agent skills (v0.2.0): <https://x402station.io/.well-known/agent-skills>
+- Skill description: <https://x402station.io/skill.md>
+- Source: <https://github.com/sF1nX/x402station>
+- npm (MCP adapter for non-AgentKit agents): <https://www.npmjs.com/package/x402station-mcp>

--- a/typescript/agentkit/src/action-providers/x402station/index.ts
+++ b/typescript/agentkit/src/action-providers/x402station/index.ts
@@ -1,0 +1,5 @@
+export {
+  X402stationActionProvider,
+  x402stationActionProvider,
+} from "./x402stationActionProvider";
+export type { X402stationConfig } from "./schemas";

--- a/typescript/agentkit/src/action-providers/x402station/schemas.ts
+++ b/typescript/agentkit/src/action-providers/x402station/schemas.ts
@@ -1,5 +1,89 @@
 import { z } from "zod";
 
+// Pure (no DNS) host check for `webhookUrl` on watch_subscribe. Fails
+// fast LOCAL when the operator passes a private/loopback/cloud-metadata
+// host, before the call reaches the x402station server (which has its
+// own SSRF guard at /api/v1/watch). Defense-in-depth, audit-2026-04-29
+// recon-7 HIGH-8.
+function isPrivateIPv4(ip: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(ip);
+  if (!m) return false;
+  const a = Number.parseInt(m[1]!, 10);
+  const b = Number.parseInt(m[2]!, 10);
+  const c = Number.parseInt(m[3]!, 10);
+  const d = Number.parseInt(m[4]!, 10);
+  if ([a, b, c, d].some((n) => Number.isNaN(n) || n < 0 || n > 255)) return true;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 192 && b === 0 && c === 0) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a >= 224) return true;
+  return false;
+}
+function isPrivateIPv6(host: string): boolean {
+  let h = host.toLowerCase();
+  if (h.startsWith("[") && h.endsWith("]")) h = h.slice(1, -1);
+  if (h === "::" || h === "::1") return true;
+  if (/^fe[89ab]/.test(h)) return true;
+  if (/^f[cd]/.test(h)) return true;
+  if (/^ff/.test(h)) return true;
+  if (h.startsWith("::ffff:")) return true;
+  if (h.startsWith("::") && h.length > 2 && /^::[0-9a-f]/.test(h)) return true;
+  if (h.startsWith("64:ff9b:")) return true;
+  if (h.startsWith("100:")) return true;
+  if (h.startsWith("2001:db8")) return true;
+  if (/^3fff/.test(h)) return true;
+  if (h.startsWith("2001:2:") || h.startsWith("2001:0002:")) return true;
+  if (h.startsWith("5f00:")) return true;
+  if (h.startsWith("2002:")) return true;
+  if (h.startsWith("2001::") || /^2001:0+:/.test(h)) return true;
+  return false;
+}
+const LOCALHOST_NAMES = new Set(["localhost", "localhost.localdomain"]);
+export function validateWebhookUrl(rawUrl: string): { ok: true } | { ok: false; reason: string } {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: "invalid URL" };
+  }
+  if (u.protocol !== "https:") {
+    return {
+      ok: false,
+      reason: "webhookUrl must use HTTPS — HMAC-signed alert payloads must not travel in clear text",
+    };
+  }
+  if (u.username !== "" || u.password !== "") {
+    return {
+      ok: false,
+      reason: "webhookUrl must not contain userinfo (user:pass@host) — known phishing/spoofing vector",
+    };
+  }
+  const hostname = u.hostname.toLowerCase();
+  if (LOCALHOST_NAMES.has(hostname)) {
+    return { ok: false, reason: `webhookUrl hostname is loopback (${hostname})` };
+  }
+  if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)) {
+    if (isPrivateIPv4(hostname)) {
+      return {
+        ok: false,
+        reason: `webhookUrl IPv4 ${hostname} is loopback / private / link-local / cloud-metadata`,
+      };
+    }
+  }
+  if (hostname.startsWith("[")) {
+    if (isPrivateIPv6(hostname)) {
+      return {
+        ok: false,
+        reason: `webhookUrl IPv6 ${hostname} is loopback / ULA / link-local / v4-mapped / NAT64`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
 /**
  * Configuration options for X402stationActionProvider.
  */
@@ -153,12 +237,14 @@ export const WatchSubscribeSchema = z.object({
   webhookUrl: z
     .string()
     .url()
-    .refine((u) => u.startsWith("https://"), {
-      message:
-        "webhookUrl must use HTTPS — HMAC-signed alert payloads must not travel in clear text",
+    .superRefine((u, ctx) => {
+      const r = validateWebhookUrl(u);
+      if (!r.ok) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: r.reason });
+      }
     })
     .describe(
-      "Where x402station will POST alert payloads. Must be HTTPS (HMAC-signed payloads must travel encrypted) and reachable from the public internet.",
+      "Where x402station will POST alert payloads. Must be HTTPS, reachable from the public internet, and contain no userinfo. Loopback / private / link-local / cloud-metadata / IPv6 ULA / NAT64 / 6to4 hosts are rejected client-side.",
     ),
   signals: z
     .array(SignalEnum)

--- a/typescript/agentkit/src/action-providers/x402station/schemas.ts
+++ b/typescript/agentkit/src/action-providers/x402station/schemas.ts
@@ -60,6 +60,27 @@ export const ForensicsSchema = PreflightSchema;
 export const CatalogDecoysSchema = z.object({}).describe("No parameters required");
 
 /**
+ * Input for the `buy_credits` action — buy a 1000-call preflight bundle for
+ * $0.50 USDC. No parameters; price + bundle size are fixed in v1.
+ */
+export const BuyCreditsSchema = z
+  .object({})
+  .describe(
+    "Buy 1000 prepaid /api/v1/preflight calls for $0.50 USDC. No parameters in v1.",
+  );
+
+/**
+ * Input for the `credits_status` action — read a credit's balance + expiry.
+ * UUID-only access; the creditId is the bearer token returned by buy_credits.
+ */
+export const CreditsStatusSchema = z.object({
+  creditId: z
+    .string()
+    .uuid()
+    .describe("The creditId UUID returned by buy_credits."),
+});
+
+/**
  * Input for the `whats_new` action — catalog diff polling. `since` is an ISO
  * 8601 timestamp (default = now() - 24h, cap 30 days back). `limit` caps each
  * of added_endpoints[] and removed_endpoints[] (1..500, default 200).

--- a/typescript/agentkit/src/action-providers/x402station/schemas.ts
+++ b/typescript/agentkit/src/action-providers/x402station/schemas.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+/**
+ * Configuration options for X402stationActionProvider.
+ */
+export interface X402stationConfig {
+  /**
+   * Override the default oracle base URL.
+   *
+   * Allowed values: `https://x402station.io` (canonical, default) or any
+   * `http(s)://localhost*` for development. Any other host is rejected at
+   * construction time so a misconfigured agent can't sign x402 payments
+   * against an attacker-controlled URL.
+   */
+  baseUrl?: string;
+}
+
+/**
+ * Signal vocabulary returned by the oracle. Whitelisted at the schema
+ * level so a typo in the agent's `signals` array doesn't silently never
+ * fire (the route would 400, but catching it earlier saves a wallet
+ * round-trip).
+ *
+ * Critical signals (those that flip preflight `ok` to `false`):
+ *   `dead`, `zombie`, `decoy_price_extreme`, `dead_7d`, `mostly_dead`
+ */
+export const SignalEnum = z.enum([
+  "unknown_endpoint",
+  "no_history",
+  "dead",
+  "zombie",
+  "decoy_price_extreme",
+  "suspicious_high_price",
+  "slow",
+  "new_provider",
+  "dead_7d",
+  "mostly_dead",
+  "slow_p99",
+  "price_outlier_high",
+  "high_concentration",
+]);
+
+/**
+ * Input schema for the `preflight` and `forensics` actions.
+ */
+export const PreflightSchema = z.object({
+  url: z
+    .string()
+    .url()
+    .describe(
+      "Full URL of the x402 endpoint the agent is about to pay (must be http(s)://, max 2048 chars).",
+    ),
+});
+
+export const ForensicsSchema = PreflightSchema;
+
+/**
+ * Empty input — no parameters needed.
+ */
+export const CatalogDecoysSchema = z.object({}).describe("No parameters required");
+
+/**
+ * Input for `watch_subscribe`. Pays $0.01 USDC, returns a watchId + a 64-char
+ * hex secret. The secret is the HMAC seed for verifying delivery payloads
+ * and is only returned once — store it.
+ */
+export const WatchSubscribeSchema = z.object({
+  url: z
+    .string()
+    .url()
+    .describe("The x402 endpoint URL to watch."),
+  webhookUrl: z
+    .string()
+    .url()
+    .refine((u) => u.startsWith("https://"), {
+      message:
+        "webhookUrl must use HTTPS — HMAC-signed alert payloads must not travel in clear text",
+    })
+    .describe(
+      "Where x402station will POST alert payloads. Must be HTTPS (HMAC-signed payloads must travel encrypted) and reachable from the public internet.",
+    ),
+  signals: z
+    .array(SignalEnum)
+    .min(1)
+    .max(20)
+    .optional()
+    .describe(
+      "Signal names to alert on. Defaults to ['dead', 'zombie', 'decoy_price_extreme'].",
+    ),
+});
+
+/**
+ * Input for `watch_status` and `watch_unsubscribe`. Both are free + secret-gated.
+ */
+export const WatchStatusSchema = z.object({
+  watchId: z.string().uuid().describe("The watchId UUID returned by watch_subscribe."),
+  secret: z
+    .string()
+    .length(64)
+    .regex(/^[0-9a-f]{64}$/i, "secret must be 64 hex chars")
+    .describe("The 64-char hex secret returned by watch_subscribe (store it; not retrievable later)."),
+});
+
+export const WatchUnsubscribeSchema = WatchStatusSchema;

--- a/typescript/agentkit/src/action-providers/x402station/schemas.ts
+++ b/typescript/agentkit/src/action-providers/x402station/schemas.ts
@@ -60,6 +60,30 @@ export const ForensicsSchema = PreflightSchema;
 export const CatalogDecoysSchema = z.object({}).describe("No parameters required");
 
 /**
+ * Input for the `whats_new` action — catalog diff polling. `since` is an ISO
+ * 8601 timestamp (default = now() - 24h, cap 30 days back). `limit` caps each
+ * of added_endpoints[] and removed_endpoints[] (1..500, default 200).
+ */
+export const WhatsNewSchema = z.object({
+  since: z
+    .string()
+    .datetime()
+    .optional()
+    .describe(
+      "ISO 8601 timestamp. Default = now() - 24h. Cannot be older than 30 days or in the future.",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      "Per-list cap (1..500, default 200). Applied independently to added_endpoints and removed_endpoints.",
+    ),
+});
+
+/**
  * Input for the `alternatives` action — given a flagged URL OR a taskClass
  * hint, returns up to `limit` (default 5, max 10) healthy sibling endpoints
  * in the same provider / domain / category / price-band. Filtered to those

--- a/typescript/agentkit/src/action-providers/x402station/schemas.ts
+++ b/typescript/agentkit/src/action-providers/x402station/schemas.ts
@@ -42,46 +42,38 @@ function isPrivateIPv6(host: string): boolean {
   return false;
 }
 const LOCALHOST_NAMES = new Set(["localhost", "localhost.localdomain"]);
-export function validateWebhookUrl(rawUrl: string): { ok: true } | { ok: false; reason: string } {
+/**
+ * Returns the rejection reason as a string when `rawUrl` should be refused,
+ * or `null` when the URL is acceptable for use as a webhookUrl.
+ */
+export function validateWebhookUrl(rawUrl: string): string | null {
   let u: URL;
   try {
     u = new URL(rawUrl);
   } catch {
-    return { ok: false, reason: "invalid URL" };
+    return "invalid URL";
   }
   if (u.protocol !== "https:") {
-    return {
-      ok: false,
-      reason: "webhookUrl must use HTTPS — HMAC-signed alert payloads must not travel in clear text",
-    };
+    return "webhookUrl must use HTTPS — HMAC-signed alert payloads must not travel in clear text";
   }
   if (u.username !== "" || u.password !== "") {
-    return {
-      ok: false,
-      reason: "webhookUrl must not contain userinfo (user:pass@host) — known phishing/spoofing vector",
-    };
+    return "webhookUrl must not contain userinfo (user:pass@host) — known phishing/spoofing vector";
   }
   const hostname = u.hostname.toLowerCase();
   if (LOCALHOST_NAMES.has(hostname)) {
-    return { ok: false, reason: `webhookUrl hostname is loopback (${hostname})` };
+    return `webhookUrl hostname is loopback (${hostname})`;
   }
   if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)) {
     if (isPrivateIPv4(hostname)) {
-      return {
-        ok: false,
-        reason: `webhookUrl IPv4 ${hostname} is loopback / private / link-local / cloud-metadata`,
-      };
+      return `webhookUrl IPv4 ${hostname} is loopback / private / link-local / cloud-metadata`;
     }
   }
   if (hostname.startsWith("[")) {
     if (isPrivateIPv6(hostname)) {
-      return {
-        ok: false,
-        reason: `webhookUrl IPv6 ${hostname} is loopback / ULA / link-local / v4-mapped / NAT64`,
-      };
+      return `webhookUrl IPv6 ${hostname} is loopback / ULA / link-local / v4-mapped / NAT64`;
     }
   }
-  return { ok: true };
+  return null;
 }
 
 /**
@@ -238,9 +230,9 @@ export const WatchSubscribeSchema = z.object({
     .string()
     .url()
     .superRefine((u, ctx) => {
-      const r = validateWebhookUrl(u);
-      if (!r.ok) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: r.reason });
+      const reason = validateWebhookUrl(u);
+      if (reason !== null) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: reason });
       }
     })
     .describe(

--- a/typescript/agentkit/src/action-providers/x402station/schemas.ts
+++ b/typescript/agentkit/src/action-providers/x402station/schemas.ts
@@ -60,6 +60,42 @@ export const ForensicsSchema = PreflightSchema;
 export const CatalogDecoysSchema = z.object({}).describe("No parameters required");
 
 /**
+ * Input for the `alternatives` action — given a flagged URL OR a taskClass
+ * hint, returns up to `limit` (default 5, max 10) healthy sibling endpoints
+ * in the same provider / domain / category / price-band. Filtered to those
+ * passing the same 1h + 7d health checks preflight uses; ranked by
+ * uptime_7d_pct DESC then avg_latency_1h_ms ASC. At least one of `url` or
+ * `taskClass` is required.
+ */
+export const AlternativesSchema = z
+  .object({
+    url: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "URL flagged by preflight (or otherwise rejected). Looked up in the catalog to extract provider / domain / category / price band as match keys.",
+      ),
+    taskClass: z
+      .string()
+      .max(80)
+      .optional()
+      .describe(
+        "Service category hint (e.g. 'llm-completions', 'Inference'). Used as a fallback match key when `url` is unknown to the catalog, OR alone for category-only discovery.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(10)
+      .optional()
+      .describe("Max alternatives to return (1..10, default 5)."),
+  })
+  .refine((v) => v.url !== undefined || v.taskClass !== undefined, {
+    message: "alternatives requires at least one of `url` or `taskClass`",
+  });
+
+/**
  * Input for `watch_subscribe`. Pays $0.01 USDC, returns a watchId + a 64-char
  * hex secret. The secret is the HMAC seed for verifying delivery payloads
  * and is only returned once — store it.

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
@@ -547,7 +547,8 @@ describe("X402stationActionProvider", () => {
       ["userinfo spoof — reject", "https://api.good.com@evil.com/hook", false],
       ["user:pass — reject", "https://user:pass@example.com/hook", false],
     ])("%s", (_label, url, expectOk) => {
-      expect(validateWebhookUrl(url as string).ok).toBe(expectOk);
+      // null = ok, string = rejection reason
+      expect(validateWebhookUrl(url as string) === null).toBe(expectOk);
     });
   });
 });

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
@@ -96,6 +96,26 @@ describe("X402stationActionProvider", () => {
       const provider = new X402stationActionProvider({ baseUrl: "http://[::1]:3002" });
       expect((provider as unknown as { baseUrl: string }).baseUrl).toBe("http://[::1]:3002");
     });
+
+    it("rejects localhost.attacker.com (CodeRabbit: prefix-match bypass)", () => {
+      // u.host.startsWith("localhost") would PASS this attacker domain.
+      // Implementation must use u.hostname exact-match.
+      expect(
+        () => new X402stationActionProvider({ baseUrl: "http://localhost.attacker.com" }),
+      ).toThrow(/baseUrl must be/i);
+    });
+
+    it("rejects 127.0.0.1.evil.example (CodeRabbit: prefix-match bypass)", () => {
+      expect(
+        () => new X402stationActionProvider({ baseUrl: "http://127.0.0.1.evil.example" }),
+      ).toThrow(/baseUrl must be/i);
+    });
+
+    it("rejects localhost-impersonation suffixes", () => {
+      expect(
+        () => new X402stationActionProvider({ baseUrl: "http://localhost-evil.example" }),
+      ).toThrow(/baseUrl must be/i);
+    });
   });
 
   describe("supportsNetwork", () => {

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
@@ -266,6 +266,45 @@ describe("X402stationActionProvider", () => {
       expect(call[1].body).toBe("{}");
     });
 
+    it("alternatives posts to /api/v1/alternatives with url body", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.alternatives(wallet, {
+        url: "https://api.venice.ai/api/v1/chat/completions",
+      });
+      const call = mockFetchWithPayment.mock.calls[0];
+      expect(call[0]).toBe("https://x402station.io/api/v1/alternatives");
+      expect(JSON.parse(call[1].body)).toEqual({
+        url: "https://api.venice.ai/api/v1/chat/completions",
+      });
+    });
+
+    it("alternatives accepts taskClass + limit, omits unset fields", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.alternatives(wallet, { taskClass: "llm-completions", limit: 3 });
+      const body = JSON.parse(mockFetchWithPayment.mock.calls[0][1].body);
+      expect(body).toEqual({ taskClass: "llm-completions", limit: 3 });
+      expect(body).not.toHaveProperty("url");
+    });
+
+    // Server-side rejects empty body with HTTP 400; schema-level refine over
+    // a fully-optional object can pass parse (depending on zod version
+    // handling of the empty-object case), so we rely on the route check
+    // rather than the schema for that edge.
+
     it("watch_subscribe omits signals when not provided", async () => {
       const provider = new X402stationActionProvider();
       const wallet = buildMockEvmWallet();

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
@@ -266,6 +266,38 @@ describe("X402stationActionProvider", () => {
       expect(call[1].body).toBe("{}");
     });
 
+    it("whats_new posts to /api/v1/whats-new with empty body when no args", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.whatsNew(wallet, {});
+      const call = mockFetchWithPayment.mock.calls[0];
+      expect(call[0]).toBe("https://x402station.io/api/v1/whats-new");
+      expect(call[1].body).toBe("{}");
+    });
+
+    it("whats_new threads since + limit through", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.whatsNew(wallet, {
+        since: "2026-04-27T00:00:00Z",
+        limit: 50,
+      });
+      const body = JSON.parse(mockFetchWithPayment.mock.calls[0][1].body);
+      expect(body).toEqual({ since: "2026-04-27T00:00:00Z", limit: 50 });
+    });
+
     it("alternatives posts to /api/v1/alternatives with url body", async () => {
       const provider = new X402stationActionProvider();
       const wallet = buildMockEvmWallet();

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
@@ -266,6 +266,42 @@ describe("X402stationActionProvider", () => {
       expect(call[1].body).toBe("{}");
     });
 
+    it("buy_credits posts to /api/v1/credits with empty body", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(
+          JSON.stringify({ creditId: "0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11", balance: 1000 }),
+        ),
+        headers: { get: () => null },
+      });
+      await provider.buyCredits(wallet, {});
+      const call = mockFetchWithPayment.mock.calls[0];
+      expect(call[0]).toBe("https://x402station.io/api/v1/credits");
+      expect(call[1].body).toBe("{}");
+    });
+
+    it("credits_status GETs /api/v1/credits/<id> without secret header", async () => {
+      const provider = new X402stationActionProvider();
+      const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{"balance":999}'),
+      } as unknown as Response);
+      await provider.creditsStatus({ creditId: "0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11" });
+      const [url, init] = fetchSpy.mock.calls[0]!;
+      expect(url).toBe(
+        "https://x402station.io/api/v1/credits/0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
+      );
+      expect((init as RequestInit).method).toBe("GET");
+      // Empty `secret` arg → no x-x402station-secret header attached.
+      const headers = (init as RequestInit).headers as Record<string, string> | undefined;
+      expect(headers?.["x-x402station-secret"]).toBeUndefined();
+      fetchSpy.mockRestore();
+    });
+
     it("whats_new posts to /api/v1/whats-new with empty body when no args", async () => {
       const provider = new X402stationActionProvider();
       const wallet = buildMockEvmWallet();

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
@@ -1,0 +1,400 @@
+import { X402stationActionProvider } from "./x402stationActionProvider";
+import { WatchSubscribeSchema } from "./schemas";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { Network } from "../../network";
+import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+
+jest.mock("@x402/fetch");
+jest.mock("@x402/evm/exact/client");
+
+const mockFetchWithPayment = jest.fn();
+const mockX402Client = { registerScheme: jest.fn() };
+
+jest
+  .mocked(x402Client)
+  .mockImplementation(() => mockX402Client as unknown as InstanceType<typeof x402Client>);
+jest.mocked(wrapFetchWithPayment).mockReturnValue(mockFetchWithPayment);
+jest
+  .mocked(registerExactEvmScheme)
+  .mockImplementation(() => mockX402Client as unknown as InstanceType<typeof x402Client>);
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const buildMockEvmWallet = (): EvmWalletProvider =>
+  ({
+    toSigner: () => ({
+      address: "0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de",
+      signTypedData: jest.fn(),
+    }),
+    readContract: jest.fn(),
+    getName: () => "mock",
+    getAddress: () => "0x30d2b1f9bcEdE5F13136b56Ff199A8ad6E4f50de",
+    getNetwork: (): Network => ({
+      protocolFamily: "evm",
+      networkId: "base-mainnet",
+      chainId: "8453",
+    }),
+  }) as unknown as EvmWalletProvider;
+
+describe("X402stationActionProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("uses the canonical x402station.io URL by default", () => {
+      const provider = new X402stationActionProvider();
+      expect((provider as unknown as { baseUrl: string }).baseUrl).toBe(
+        "https://x402station.io",
+      );
+    });
+
+    it("accepts an http(s)://localhost dev URL", () => {
+      const p1 = new X402stationActionProvider({ baseUrl: "http://localhost:3002" });
+      expect((p1 as unknown as { baseUrl: string }).baseUrl).toBe(
+        "http://localhost:3002",
+      );
+      const p2 = new X402stationActionProvider({ baseUrl: "http://127.0.0.1:9999" });
+      expect((p2 as unknown as { baseUrl: string }).baseUrl).toBe(
+        "http://127.0.0.1:9999",
+      );
+    });
+
+    it("strips trailing slashes from the configured URL", () => {
+      const provider = new X402stationActionProvider({
+        baseUrl: "https://x402station.io///",
+      });
+      expect((provider as unknown as { baseUrl: string }).baseUrl).toBe(
+        "https://x402station.io",
+      );
+    });
+
+    it("rejects a non-canonical, non-localhost URL", () => {
+      expect(() => new X402stationActionProvider({ baseUrl: "https://evil.example" })).toThrow(
+        /baseUrl must be/i,
+      );
+    });
+
+    it("rejects a malformed URL", () => {
+      expect(() => new X402stationActionProvider({ baseUrl: "not a url" })).toThrow(
+        /not a valid URL/i,
+      );
+    });
+
+    it("does not let a non-default port bypass the canonical check", () => {
+      // u.hostname strips ports, u.host keeps them — the implementation
+      // must use u.host so this case fails. (Mirrors the x402station-mcp
+      // 2026-04-26 audit finding M-2.)
+      expect(
+        () => new X402stationActionProvider({ baseUrl: "https://x402station.io:9999" }),
+      ).toThrow(/baseUrl must be/i);
+    });
+
+    it("accepts IPv6 loopback dev URL [::1] (Greptile P2)", () => {
+      const provider = new X402stationActionProvider({ baseUrl: "http://[::1]:3002" });
+      expect((provider as unknown as { baseUrl: string }).baseUrl).toBe("http://[::1]:3002");
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    const provider = new X402stationActionProvider();
+
+    it("returns true for Base mainnet", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "evm",
+          networkId: "base-mainnet",
+          chainId: "8453",
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true for Base Sepolia", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "evm",
+          networkId: "base-sepolia",
+          chainId: "84532",
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false for Ethereum mainnet", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "evm",
+          networkId: "ethereum-mainnet",
+          chainId: "1",
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false for non-EVM networks", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "svm",
+          networkId: "solana-mainnet",
+          chainId: "mainnet",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("preflight", () => {
+    it("posts to /api/v1/preflight with the URL and returns parsed JSON + receipt", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      const fakeBody = {
+        ok: false,
+        warnings: ["dead", "zombie"],
+        metadata: { url: "https://api.venice.ai/api/v1/chat/completions" },
+      };
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(JSON.stringify(fakeBody)),
+        headers: { get: () => null },
+      });
+
+      const result = await provider.preflight(wallet, {
+        url: "https://api.venice.ai/api/v1/chat/completions",
+      });
+
+      const parsed = JSON.parse(result);
+      expect(parsed.result).toEqual(fakeBody);
+      expect(parsed.paymentReceipt).toBeNull();
+      expect(mockFetchWithPayment).toHaveBeenCalledWith(
+        "https://x402station.io/api/v1/preflight",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            url: "https://api.venice.ai/api/v1/chat/completions",
+          }),
+        }),
+      );
+    });
+
+    it("decodes the x-payment-response header into paymentReceipt", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      const receipt = { transaction: "0xabc", network: "eip155:8453" };
+      const headerVal = btoa(JSON.stringify(receipt));
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(JSON.stringify({ ok: true })),
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === "x-payment-response" ? headerVal : null,
+        },
+      });
+
+      const result = await provider.preflight(wallet, { url: "https://x" });
+      expect(JSON.parse(result).paymentReceipt).toEqual(receipt);
+    });
+
+    it("returns an error envelope on non-2xx status", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: jest.fn().mockResolvedValue("upstream timeout"),
+        headers: { get: () => null },
+      });
+
+      const result = await provider.preflight(wallet, { url: "https://x" });
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toBe(true);
+      expect(parsed.status).toBe(503);
+      expect(parsed.details).toContain("upstream timeout");
+    });
+  });
+
+  describe("forensics + catalog_decoys + watch_subscribe", () => {
+    it("forensics posts to /api/v1/forensics", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.forensics(wallet, { url: "https://x" });
+      expect(mockFetchWithPayment).toHaveBeenCalledWith(
+        "https://x402station.io/api/v1/forensics",
+        expect.any(Object),
+      );
+    });
+
+    it("catalog_decoys posts to /api/v1/catalog/decoys with empty body", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.catalogDecoys(wallet, {});
+      const call = mockFetchWithPayment.mock.calls[0];
+      expect(call[0]).toBe("https://x402station.io/api/v1/catalog/decoys");
+      expect(call[1].body).toBe("{}");
+    });
+
+    it("watch_subscribe omits signals when not provided", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.watchSubscribe(wallet, {
+        url: "https://x",
+        webhookUrl: "https://hook",
+      });
+      const body = JSON.parse(mockFetchWithPayment.mock.calls[0][1].body);
+      expect(body).toEqual({ url: "https://x", webhookUrl: "https://hook" });
+      expect(body).not.toHaveProperty("signals");
+    });
+
+    it("watch_subscribe includes signals when provided", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue("{}"),
+        headers: { get: () => null },
+      });
+      await provider.watchSubscribe(wallet, {
+        url: "https://x",
+        webhookUrl: "https://hook",
+        signals: ["zombie", "decoy_price_extreme"],
+      });
+      const body = JSON.parse(mockFetchWithPayment.mock.calls[0][1].body);
+      expect(body.signals).toEqual(["zombie", "decoy_price_extreme"]);
+    });
+
+    it("watch_subscribe rejects http:// webhookUrl via zod (Greptile P1)", () => {
+      // Schema-level guard: HMAC-signed alert payloads must not travel
+      // unencrypted. Validator runs before any wallet round-trip so
+      // the agent never signs a $0.01 challenge for a doomed call.
+      expect(() =>
+        WatchSubscribeSchema.parse({
+          url: "https://endpoint.example",
+          webhookUrl: "http://insecure-webhook.example",
+        }),
+      ).toThrow(/HTTPS/i);
+      expect(mockFetchWithPayment).not.toHaveBeenCalled();
+      // Sanity: still accepts https://
+      expect(() =>
+        WatchSubscribeSchema.parse({
+          url: "https://endpoint.example",
+          webhookUrl: "https://secure-webhook.example",
+        }),
+      ).not.toThrow();
+    });
+
+    it("preflight surfaces a malformed payment-response header with malformed:true (Greptile P2)", async () => {
+      const provider = new X402stationActionProvider();
+      const wallet = buildMockEvmWallet();
+      mockFetchWithPayment.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(JSON.stringify({ ok: true })),
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === "x-payment-response"
+              ? "not-base64-and-not-json!!!"
+              : null,
+        },
+      });
+      const result = await provider.preflight(wallet, { url: "https://x" });
+      const parsed = JSON.parse(result);
+      expect(parsed.paymentReceipt).toEqual({
+        raw: "not-base64-and-not-json!!!",
+        malformed: true,
+      });
+    });
+  });
+
+  describe("watch_status (free, secret-gated)", () => {
+    it("does NOT use the paying-fetch wrapper", async () => {
+      const provider = new X402stationActionProvider();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(JSON.stringify({ isActive: true })),
+      });
+      await provider.watchStatus({
+        watchId: "0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
+        secret: "a".repeat(64),
+      });
+      expect(mockFetchWithPayment).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://x402station.io/api/v1/watch/0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
+        expect.objectContaining({
+          method: "GET",
+          headers: { "x-x402station-secret": "a".repeat(64) },
+        }),
+      );
+    });
+
+    it("returns the parsed body on 200", async () => {
+      const provider = new X402stationActionProvider();
+      const fakeBody = { isActive: true, alertsRemaining: 100 };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue(JSON.stringify(fakeBody)),
+      });
+      const result = await provider.watchStatus({
+        watchId: "0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
+        secret: "b".repeat(64),
+      });
+      expect(JSON.parse(result)).toEqual(fakeBody);
+    });
+
+    it("returns an error envelope on 404 (wrong secret OR missing watch)", async () => {
+      const provider = new X402stationActionProvider();
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: jest.fn().mockResolvedValue('{"error":"watch not found"}'),
+      });
+      const result = await provider.watchStatus({
+        watchId: "0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
+        secret: "c".repeat(64),
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.error).toBe(true);
+      expect(parsed.status).toBe(404);
+    });
+  });
+
+  describe("watch_unsubscribe (free, secret-gated)", () => {
+    it("issues DELETE", async () => {
+      const provider = new X402stationActionProvider();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: jest.fn().mockResolvedValue('{"isActive":false}'),
+      });
+      await provider.watchUnsubscribe({
+        watchId: "0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
+        secret: "d".repeat(64),
+      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://x402station.io/api/v1/watch/0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.test.ts
@@ -1,5 +1,5 @@
 import { X402stationActionProvider } from "./x402stationActionProvider";
-import { WatchSubscribeSchema } from "./schemas";
+import { WatchSubscribeSchema, validateWebhookUrl } from "./schemas";
 import { EvmWalletProvider } from "../../wallet-providers";
 import { Network } from "../../network";
 import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
@@ -522,6 +522,32 @@ describe("X402stationActionProvider", () => {
         "https://x402station.io/api/v1/watch/0a44f6b8-3b7d-4f2a-9e3a-2c5fd1b0aa11",
         expect.objectContaining({ method: "DELETE" }),
       );
+    });
+  });
+
+  // audit-2026-04-29 recon-7 HIGH-8 regression — webhookUrl SSRF guard.
+  // Pure (no DNS) host check rejects loopback / private / link-local /
+  // cloud-metadata / userinfo URLs client-side.
+  describe("validateWebhookUrl (SSRF guard)", () => {
+    it.each([
+      ["public HTTPS — ok", "https://my-agent.example.com/x402-alerts", true],
+      ["plain HTTP — reject", "http://example.com/x402-alerts", false],
+      ["localhost — reject", "https://localhost/hook", false],
+      ["127.0.0.1 — reject", "https://127.0.0.1/hook", false],
+      ["127.0.0.5 — reject (any 127/8)", "https://127.0.0.5:8443/hook", false],
+      ["cloud metadata 169.254.169.254 — reject", "https://169.254.169.254/hook", false],
+      ["link-local 169.254.5.5 — reject", "https://169.254.5.5/hook", false],
+      ["RFC1918 10.0.0.5 — reject", "https://10.0.0.5/hook", false],
+      ["RFC1918 192.168.1.1 — reject", "https://192.168.1.1/hook", false],
+      ["RFC1918 172.16.0.5 — reject", "https://172.16.0.5/hook", false],
+      ["CGNAT 100.64.0.1 — reject", "https://100.64.0.1/hook", false],
+      ["IPv6 loopback [::1] — reject", "https://[::1]/hook", false],
+      ["IPv6 ULA [fc00::1] — reject", "https://[fc00::1]/hook", false],
+      ["IPv6 link-local [fe80::1] — reject", "https://[fe80::1]/hook", false],
+      ["userinfo spoof — reject", "https://api.good.com@evil.com/hook", false],
+      ["user:pass — reject", "https://user:pass@example.com/hook", false],
+    ])("%s", (_label, url, expectOk) => {
+      expect(validateWebhookUrl(url as string).ok).toBe(expectOk);
     });
   });
 });

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
@@ -40,16 +40,17 @@ function resolveBaseUrl(raw: string | undefined): string {
   } catch {
     throw new Error(`x402station: baseUrl is not a valid URL: ${value}`);
   }
-  // u.host (NOT u.hostname) so a non-default port doesn't bypass the
-  // allowlist — `x402station.io:9999`.hostname === "x402station.io".
+  // Canonical: `u.host` (NOT `u.hostname`) so a non-default port can't
+  // bypass — `x402station.io:9999`.hostname is "x402station.io" but
+  // `.host` keeps the port.
   const isCanonical = u.host === "x402station.io" && u.protocol === "https:";
-  // IPv6 loopback `[::1]` is included so dual-stack dev machines that
-  // bind their oracle to `::1` work. Caught by Greptile review on the
-  // sibling Daydreams Lucid PR (2026-04-27).
+  // localDev: `u.hostname` exact-match (NOT `u.host.startsWith(...)`)
+  // so a host like `localhost.attacker.com` or `127.0.0.1.evil.example`
+  // can't pass the loopback check via prefix. WHATWG `URL.hostname`
+  // returns `[::1]` (with brackets per RFC 2732) for IPv6 literals.
+  // CodeRabbit (mastra-ai/mastra#15804, 2026-04-27).
   const isLocalDev =
-    (u.host.startsWith("localhost") ||
-      u.host.startsWith("127.0.0.1") ||
-      u.host.startsWith("[::1]")) &&
+    (u.hostname === "localhost" || u.hostname === "127.0.0.1" || u.hostname === "[::1]") &&
     (u.protocol === "http:" || u.protocol === "https:");
   if (!isCanonical && !isLocalDev) {
     throw new Error(

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
@@ -8,6 +8,7 @@ import { registerExactEvmScheme } from "@x402/evm/exact/client";
 import {
   CatalogDecoysSchema,
   AlternativesSchema,
+  WhatsNewSchema,
   ForensicsSchema,
   PreflightSchema,
   WatchStatusSchema,
@@ -359,6 +360,33 @@ export class X402stationActionProvider extends ActionProvider<EvmWalletProvider>
     _args: z.infer<typeof CatalogDecoysSchema>,
   ): Promise<string> {
     return this.callPaid(walletProvider, "/api/v1/catalog/decoys", {});
+  }
+
+  /**
+   * Catalog diff polling — what was added / removed since `since`.
+   *
+   * @param walletProvider - Agent's wallet (signs the $0.001 payment).
+   * @param args - { since?, limit? }. `since` defaults to now-24h on the
+   *               server side; `limit` caps each of added_endpoints[] and
+   *               removed_endpoints[] (1..500, default 200).
+   * @returns JSON-stringified `{ since, until, window_hours,
+   *          added_endpoints[], removed_endpoints[], summary,
+   *          truncated, limit }`.
+   */
+  @CreateAction({
+    name: "whats_new",
+    description:
+      "Catalog diff polling. Body { since?, limit? } (default since=now-24h, limit=200, max 500). Returns added_endpoints[] (first_seen_at >= since AND is_active=true), removed_endpoints[] (flipped to is_active=false since), service-level counts, polls_in_window, and current active totals. Costs $0.001 USDC. Designed for aggregator agents to poll hourly without breaking the bank — internal ingest cron runs every 5 min, so polling more often returns identical data.",
+    schema: WhatsNewSchema,
+  })
+  async whatsNew(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof WhatsNewSchema>,
+  ): Promise<string> {
+    const body: Record<string, unknown> = {};
+    if (args.since !== undefined) body.since = args.since;
+    if (args.limit !== undefined) body.limit = args.limit;
+    return this.callPaid(walletProvider, "/api/v1/whats-new", body);
   }
 
   /**

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
@@ -9,6 +9,8 @@ import {
   CatalogDecoysSchema,
   AlternativesSchema,
   WhatsNewSchema,
+  BuyCreditsSchema,
+  CreditsStatusSchema,
   ForensicsSchema,
   PreflightSchema,
   WatchStatusSchema,
@@ -249,10 +251,16 @@ export class X402stationActionProvider extends ActionProvider<EvmWalletProvider>
     secret: string,
   ): Promise<string> {
     let r: Response;
+    // Watch routes need x-x402station-secret. The credits-status route
+    // (id-gated, secret-less) doesn't — pass an empty `secret` and we
+    // skip the header so we don't ship "x-x402station-secret: "
+    // (could trip a future strict-validation check).
+    const headers: Record<string, string> = {};
+    if (secret) headers["x-x402station-secret"] = secret;
     try {
       r = await fetch(`${this.baseUrl}${path}`, {
         method,
-        headers: { "x-x402station-secret": secret },
+        headers,
         signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
       });
     } catch (err) {
@@ -387,6 +395,51 @@ export class X402stationActionProvider extends ActionProvider<EvmWalletProvider>
     if (args.since !== undefined) body.since = args.since;
     if (args.limit !== undefined) body.limit = args.limit;
     return this.callPaid(walletProvider, "/api/v1/whats-new", body);
+  }
+
+  /**
+   * Buy 1000 prepaid /api/v1/preflight calls.
+   *
+   * @param walletProvider - Agent's wallet (signs the $0.50 payment).
+   * @returns JSON-stringified `{ creditId, balance: 1000, initialBalance,
+   *          paidAmount, payerAddress, createdAt, expiresAt, usage }`.
+   *          STORE the creditId — bearer token, not retrievable later.
+   *          Pass via X-Credit-Id header on subsequent /api/v1/preflight
+   *          calls; on exhaustion/expiry the route falls through to
+   *          per-call x402 automatically.
+   */
+  @CreateAction({
+    name: "buy_credits",
+    description:
+      "Buy 1000 prepaid /api/v1/preflight calls for $0.50 USDC. Effective rate $0.0005/call (50% off the per-call $0.001 tier). Returns { creditId, balance, expiresAt }. STORE THE creditId — bearer token, not retrievable later. Pass via X-Credit-Id header on subsequent /api/v1/preflight calls; on exhaustion (balance=0) or expiry (90 days) the middleware falls through to per-call x402 automatically. Use this once you've decided to do high-volume preflight work.",
+    schema: BuyCreditsSchema,
+  })
+  async buyCredits(
+    walletProvider: EvmWalletProvider,
+    _args: z.infer<typeof BuyCreditsSchema>,
+  ): Promise<string> {
+    return this.callPaid(walletProvider, "/api/v1/credits", {});
+  }
+
+  /**
+   * Read a credit's balance + expiry. Free, id-gated.
+   *
+   * @param args - { creditId: uuid } returned by buy_credits.
+   * @returns JSON-stringified `{ creditId, balance, initialBalance, used,
+   *          paidAmount, createdAt, expiresAt, expired, paymentTx,
+   *          paymentNetwork }`. 404 covers both malformed UUID and
+   *          unknown credit (same body, anti-enumeration).
+   */
+  @CreateAction({
+    name: "credits_status",
+    description:
+      "Read a credit's current balance + expiry. Free, no payment required. UUID-only access — anyone holding the creditId can read state, same as decrement. Returns 404 for unknown / malformed UUIDs (same response so an attacker scraping random UUIDs can't tell them apart).",
+    schema: CreditsStatusSchema,
+  })
+  async creditsStatus(
+    args: z.infer<typeof CreditsStatusSchema>,
+  ): Promise<string> {
+    return this.callFree(`/api/v1/credits/${args.creditId}`, "GET", "");
   }
 
   /**

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
@@ -1,0 +1,434 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { Network } from "../../network";
+import { CreateAction } from "../actionDecorator";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+import {
+  CatalogDecoysSchema,
+  ForensicsSchema,
+  PreflightSchema,
+  WatchStatusSchema,
+  WatchSubscribeSchema,
+  WatchUnsubscribeSchema,
+  X402stationConfig,
+} from "./schemas";
+
+const DEFAULT_BASE_URL = "https://x402station.io";
+const SUPPORTED_NETWORK_IDS = new Set(["base-mainnet", "base-sepolia"]);
+// Per-call timeout so a stalled oracle doesn't hang the LLM step. 30s
+// covers x402's 402 → sign → settle → JSON round-trip with margin.
+// Greptile P2 (2026-04-27).
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Validates that the configured base URL points at the canonical
+ * x402station.io domain (or a localhost dev URL). Any other value would
+ * let a misconfigured agent sign x402 payments against an attacker-
+ * controlled host. Same allow-list logic the official x402station-mcp
+ * package uses.
+ *
+ * @param raw - User-supplied URL or undefined for the default.
+ * @returns The validated URL with no trailing slash.
+ */
+function resolveBaseUrl(raw: string | undefined): string {
+  const value = (raw ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  let u: URL;
+  try {
+    u = new URL(value);
+  } catch {
+    throw new Error(`x402station: baseUrl is not a valid URL: ${value}`);
+  }
+  // u.host (NOT u.hostname) so a non-default port doesn't bypass the
+  // allowlist — `x402station.io:9999`.hostname === "x402station.io".
+  const isCanonical = u.host === "x402station.io" && u.protocol === "https:";
+  // IPv6 loopback `[::1]` is included so dual-stack dev machines that
+  // bind their oracle to `::1` work. Caught by Greptile review on the
+  // sibling Daydreams Lucid PR (2026-04-27).
+  const isLocalDev =
+    (u.host.startsWith("localhost") ||
+      u.host.startsWith("127.0.0.1") ||
+      u.host.startsWith("[::1]")) &&
+    (u.protocol === "http:" || u.protocol === "https:");
+  if (!isCanonical && !isLocalDev) {
+    throw new Error(
+      `x402station: baseUrl must be https://x402station.io or a localhost dev URL; got "${value}". ` +
+        "Refusing to sign x402 payments against an unknown host.",
+    );
+  }
+  return value;
+}
+
+/**
+ * X402stationActionProvider — pre-flight oracle for x402 endpoints.
+ *
+ * Six tools wrapping the x402station.io oracle API. Four are paid via
+ * x402 (preflight $0.001, forensics $0.001, catalog_decoys $0.005,
+ * watch_subscribe $0.01) and signed automatically through the agent's
+ * configured EvmWalletProvider. Two are free + secret-gated and used
+ * to manage an existing watch (watch_status, watch_unsubscribe).
+ *
+ * The oracle independently probes every active endpoint on the
+ * agentic.market catalog every ~10 minutes and surfaces decoys, zombies,
+ * dead services, and price-trap signals an agent should refuse to pay.
+ *
+ * Networks: Base mainnet (eip155:8453) and Base Sepolia (eip155:84532).
+ *
+ * Spec: https://x402station.io/.well-known/agent-skills (+ /skill.md)
+ */
+export class X402stationActionProvider extends ActionProvider<EvmWalletProvider> {
+  private readonly baseUrl: string;
+
+  /**
+   * Creates a new instance of X402stationActionProvider.
+   *
+   * @param config - Optional configuration (custom base URL for dev).
+   */
+  constructor(config: X402stationConfig = {}) {
+    super("x402station", []);
+    this.baseUrl = resolveBaseUrl(config.baseUrl);
+  }
+
+  /**
+   * Returns true for Base mainnet and Base Sepolia. The oracle accepts
+   * USDC settlements on both; any other EVM network would 402-handshake
+   * fine but the agent's payment wouldn't settle.
+   *
+   * @param network - The wallet's current network.
+   * @returns Whether the oracle accepts payments on this network.
+   */
+  supportsNetwork(network: Network): boolean {
+    return (
+      network.protocolFamily === "evm" &&
+      typeof network.networkId === "string" &&
+      SUPPORTED_NETWORK_IDS.has(network.networkId)
+    );
+  }
+
+  /**
+   * Wraps `fetch` with the agent's wallet so a 402 from the oracle is
+   * auto-signed and retried with X-PAYMENT. Same pattern the official
+   * x402 ActionProvider in this repo uses — extracted so our actions
+   * can reuse it without depending on the x402 provider directly.
+   *
+   * @param walletProvider - Agent's wallet (must be EVM, on a supported network).
+   * @returns A fetch function that handles 402 → sign → retry transparently.
+   */
+  private async getPayingFetch(
+    walletProvider: EvmWalletProvider,
+  ): Promise<typeof fetch> {
+    const client = new x402Client();
+    const account = walletProvider.toSigner();
+    const signer = {
+      ...account,
+      // Mirror the readContract surface that registerExactEvmScheme
+      // uses to read the on-chain USDC contract for decimals/symbol.
+      // The viem account from toSigner() lacks readContract, so we
+      // delegate to the wallet provider's own implementation.
+      readContract: (args: {
+        address: `0x${string}`;
+        abi: readonly unknown[];
+        functionName: string;
+        args?: readonly unknown[];
+      }) =>
+        walletProvider.readContract({
+          address: args.address,
+          abi: args.abi as never,
+          functionName: args.functionName as never,
+          args: args.args as never,
+        }),
+    };
+    registerExactEvmScheme(client, { signer });
+    return wrapFetchWithPayment(fetch, client);
+  }
+
+  /**
+   * Issues a paid POST to the oracle. Reads response body as text first
+   * so we can build a clear error message when nginx returns a 502/504
+   * HTML body instead of JSON.
+   *
+   * @param walletProvider - Agent's wallet (will sign the 402 retry).
+   * @param path - Oracle endpoint path (e.g. "/api/v1/preflight").
+   * @param body - JSON body to POST.
+   * @returns A JSON-stringified response with the oracle's payload + a
+   *          `paymentReceipt` field decoded from the x-payment-response
+   *          header so the agent can audit on-chain spend.
+   */
+  private async callPaid(
+    walletProvider: EvmWalletProvider,
+    path: string,
+    body: unknown,
+  ): Promise<string> {
+    const fetchPay = await this.getPayingFetch(walletProvider);
+    let r: Response;
+    try {
+      r = await fetchPay(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body ?? {}),
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      });
+    } catch (err) {
+      const e = err as { name?: string };
+      if (e.name === "AbortError" || e.name === "TimeoutError") {
+        return JSON.stringify(
+          {
+            error: true,
+            message: `x402station ${path} timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+          },
+          null,
+          2,
+        );
+      }
+      throw err;
+    }
+
+    const receiptHeader =
+      r.headers.get("x-payment-response") ?? r.headers.get("payment-response");
+    let paymentReceipt: unknown = null;
+    if (receiptHeader) {
+      try {
+        paymentReceipt = JSON.parse(atob(receiptHeader));
+      } catch {
+        // Greptile P2 (2026-04-27): explicit malformed flag so audit
+        // code can branch on it instead of silently getting a stub
+        // object that satisfies the type but lacks transaction/network/
+        // payer fields.
+        paymentReceipt = { raw: receiptHeader, malformed: true };
+      }
+    }
+
+    const raw = await r.text();
+    if (!r.ok) {
+      const snippet = raw.length > 200 ? raw.slice(0, 200) + "…" : raw;
+      return JSON.stringify(
+        {
+          error: true,
+          status: r.status,
+          message: `x402station ${path} returned ${r.status}`,
+          details: snippet,
+        },
+        null,
+        2,
+      );
+    }
+    let data: unknown;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return JSON.stringify(
+        {
+          error: true,
+          message: `x402station ${path} returned 200 with non-JSON body`,
+          details: raw.slice(0, 200),
+        },
+        null,
+        2,
+      );
+    }
+
+    return JSON.stringify({ result: data, paymentReceipt }, null, 2);
+  }
+
+  /**
+   * Issues a free, secret-gated request (GET or DELETE) to the oracle.
+   * Used by watch_status and watch_unsubscribe.
+   *
+   * @param path - Oracle path (e.g. "/api/v1/watch/<uuid>").
+   * @param method - HTTP method (GET or DELETE).
+   * @param secret - 64-char hex secret returned by watch_subscribe.
+   * @returns A JSON-stringified response.
+   */
+  private async callFree(
+    path: string,
+    method: "GET" | "DELETE",
+    secret: string,
+  ): Promise<string> {
+    let r: Response;
+    try {
+      r = await fetch(`${this.baseUrl}${path}`, {
+        method,
+        headers: { "x-x402station-secret": secret },
+        signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+      });
+    } catch (err) {
+      const e = err as { name?: string };
+      if (e.name === "AbortError" || e.name === "TimeoutError") {
+        return JSON.stringify(
+          {
+            error: true,
+            message: `x402station ${method} ${path} timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+          },
+          null,
+          2,
+        );
+      }
+      throw err;
+    }
+    const raw = await r.text();
+    if (!r.ok) {
+      const snippet = raw.length > 200 ? raw.slice(0, 200) + "…" : raw;
+      return JSON.stringify(
+        {
+          error: true,
+          status: r.status,
+          message: `x402station ${path} returned ${r.status}`,
+          details: snippet,
+        },
+        null,
+        2,
+      );
+    }
+    let data: unknown;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      return JSON.stringify(
+        {
+          error: true,
+          message: `x402station ${path} returned 200 with non-JSON body`,
+          details: raw.slice(0, 200),
+        },
+        null,
+        2,
+      );
+    }
+    return JSON.stringify(data, null, 2);
+  }
+
+  /**
+   * Pre-flight safety check for a single x402 endpoint URL.
+   *
+   * @param walletProvider - Agent's wallet (signs the $0.001 payment).
+   * @param args - The target URL.
+   * @returns JSON-stringified `{ ok, warnings[], metadata }` plus payment receipt.
+   */
+  @CreateAction({
+    name: "preflight",
+    description:
+      "Ask x402station whether a given x402 URL is safe to pay. Returns {ok, warnings[], metadata}. Costs $0.001 USDC (auto-signed via the wallet provider). Call this BEFORE any other paid x402 request to avoid decoys (price ≥ $1k USDC), zombie services, dead endpoints, and price/latency anomalies. ok:true only when no critical warning fires.",
+    schema: PreflightSchema,
+  })
+  async preflight(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof PreflightSchema>,
+  ): Promise<string> {
+    return this.callPaid(walletProvider, "/api/v1/preflight", { url: args.url });
+  }
+
+  /**
+   * 7-day forensics report on one x402 endpoint.
+   *
+   * @param walletProvider - Agent's wallet (signs the $0.001 payment).
+   * @param args - The target URL.
+   * @returns JSON-stringified report with hourly uptime, latency p50/p90/p99,
+   *          status-code distribution, concentration-group stats, decoy probability.
+   */
+  @CreateAction({
+    name: "forensics",
+    description:
+      "Deep history report for one x402 endpoint: hourly uptime over 7 days, latency p50/p90/p99, status-code distribution, concentration-group stats (how crowded this provider's namespace is), and a decoy probability score [0, 1]. Costs $0.001 USDC. Superset of preflight — if you're running forensics you don't need preflight too.",
+    schema: ForensicsSchema,
+  })
+  async forensics(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof ForensicsSchema>,
+  ): Promise<string> {
+    return this.callPaid(walletProvider, "/api/v1/forensics", { url: args.url });
+  }
+
+  /**
+   * Full known-bad blacklist as one JSON payload.
+   *
+   * @param walletProvider - Agent's wallet (signs the $0.005 payment).
+   * @param _args - No parameters.
+   * @returns JSON-stringified blacklist of every active endpoint flagged
+   *          as decoy_price_extreme / zombie / dead_7d / mostly_dead.
+   */
+  @CreateAction({
+    name: "catalog_decoys",
+    description:
+      "Returns every active x402 endpoint currently flagged decoy_price_extreme / zombie / dead_7d / mostly_dead in one JSON payload, plus per-reason counts. Costs $0.005 USDC. Pull periodically (hourly is plenty — internal data refreshes every 10 min) and cache locally as a blacklist — cheaper than preflighting every URL.",
+    schema: CatalogDecoysSchema,
+  })
+  async catalogDecoys(
+    walletProvider: EvmWalletProvider,
+    _args: z.infer<typeof CatalogDecoysSchema>,
+  ): Promise<string> {
+    return this.callPaid(walletProvider, "/api/v1/catalog/decoys", {});
+  }
+
+  /**
+   * Subscribe to webhook alerts on x402 endpoint state changes.
+   *
+   * @param walletProvider - Agent's wallet (signs the $0.01 payment).
+   * @param args - URL to watch, webhook URL, optional signal subset.
+   * @returns JSON-stringified `{ watchId, secret, expiresAt, signals,
+   *          alertsPaid, alertsRemaining, endpointKnown, deliveryFormat }`.
+   *          The secret is the HMAC seed and is returned ONCE — store it.
+   */
+  @CreateAction({
+    name: "watch_subscribe",
+    description:
+      "Pay $0.01 USDC for a 30-day watch + 100 prepaid alerts on one x402 endpoint. When subscribed signals fire or clear (e.g. zombie, decoy_price_extreme), x402station POSTs an HMAC-SHA256-signed JSON payload to your webhookUrl. Returns watchId + secret — STORE THE SECRET, it's the HMAC seed for verifying delivery payloads and is not retrievable later.",
+    schema: WatchSubscribeSchema,
+  })
+  async watchSubscribe(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof WatchSubscribeSchema>,
+  ): Promise<string> {
+    const body: Record<string, unknown> = {
+      url: args.url,
+      webhookUrl: args.webhookUrl,
+    };
+    if (args.signals && args.signals.length > 0) body.signals = args.signals;
+    return this.callPaid(walletProvider, "/api/v1/watch", body);
+  }
+
+  /**
+   * Read-back the current state of a watch + recent alert deliveries.
+   *
+   * @param args - watchId UUID + 64-char hex secret.
+   * @returns JSON-stringified watch metadata. No payment required.
+   */
+  @CreateAction({
+    name: "watch_status",
+    description:
+      "Returns the current state of a watch: active/expired, alertsRemaining (out of 100 prepaid), last 10 alert deliveries with delivery_status, and the last computed signal snapshot. Free — no payment required, secret-gated by the secret returned from watch_subscribe.",
+    schema: WatchStatusSchema,
+  })
+  async watchStatus(args: z.infer<typeof WatchStatusSchema>): Promise<string> {
+    return this.callFree(`/api/v1/watch/${args.watchId}`, "GET", args.secret);
+  }
+
+  /**
+   * Deactivate a watch — no further alerts will be queued or delivered.
+   *
+   * @param args - watchId UUID + 64-char hex secret.
+   * @returns JSON-stringified `{ watchId, isActive: false, message }`.
+   */
+  @CreateAction({
+    name: "watch_unsubscribe",
+    description:
+      "Deactivate a watch — no further alerts will be queued or delivered. Free — no payment required, secret-gated by the secret returned from watch_subscribe. The watch row + alert history are retained for audit. There is no refund for unused prepaid alerts.",
+    schema: WatchUnsubscribeSchema,
+  })
+  async watchUnsubscribe(
+    args: z.infer<typeof WatchUnsubscribeSchema>,
+  ): Promise<string> {
+    return this.callFree(`/api/v1/watch/${args.watchId}`, "DELETE", args.secret);
+  }
+}
+
+/**
+ * Factory helper.
+ *
+ * @param config - Optional custom base URL.
+ * @returns A configured X402stationActionProvider.
+ */
+export function x402stationActionProvider(
+  config: X402stationConfig = {},
+): X402stationActionProvider {
+  return new X402stationActionProvider(config);
+}

--- a/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402station/x402stationActionProvider.ts
@@ -7,6 +7,7 @@ import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
 import { registerExactEvmScheme } from "@x402/evm/exact/client";
 import {
   CatalogDecoysSchema,
+  AlternativesSchema,
   ForensicsSchema,
   PreflightSchema,
   WatchStatusSchema,
@@ -358,6 +359,34 @@ export class X402stationActionProvider extends ActionProvider<EvmWalletProvider>
     _args: z.infer<typeof CatalogDecoysSchema>,
   ): Promise<string> {
     return this.callPaid(walletProvider, "/api/v1/catalog/decoys", {});
+  }
+
+  /**
+   * Routing fallback — siblings to a flagged endpoint.
+   *
+   * @param walletProvider - Agent's wallet (signs the $0.005 payment).
+   * @param args - { url?, taskClass?, limit? } — at least one of url/taskClass
+   *               required; limit is 1..10, default 5.
+   * @returns JSON-stringified `{ target, match_strategy, alternatives[],
+   *          candidate_count }`. Each alternative carries url, service,
+   *          provider, domain, category, price_usdc, uptime_1h_pct,
+   *          uptime_7d_pct, avg_latency_1h_ms, match_reason.
+   */
+  @CreateAction({
+    name: "alternatives",
+    description:
+      "Routing fallback. Given a URL flagged by preflight (or a taskClass hint), returns up to 5 healthy sibling endpoints in the same provider/domain/category/price-band. Filters out 7-day-dead and 1-hour-erroring candidates; ranks by uptime + latency. Costs $0.005 USDC. Use this immediately after preflight returns ok=false — it answers 'where do I go instead?'. Pass {url} when you have a specific URL the agent was about to pay; pass {taskClass} (e.g. 'llm-completions', 'Inference') when discovering by service category; or both for a richer match.",
+    schema: AlternativesSchema,
+  })
+  async alternatives(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof AlternativesSchema>,
+  ): Promise<string> {
+    const body: Record<string, unknown> = {};
+    if (args.url) body.url = args.url;
+    if (args.taskClass) body.taskClass = args.taskClass;
+    if (args.limit !== undefined) body.limit = args.limit;
+    return this.callPaid(walletProvider, "/api/v1/alternatives", body);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a new `x402station` action provider — a wrapper around the public oracle at [x402station.io](https://x402station.io) that gives any AgentKit-built agent six tools for safely paying x402 endpoints:

| Action | Cost | Purpose |
|---|---|---|
| `preflight` | $0.001 | `{ok, warnings[], metadata}` for any URL — fast safety check |
| `forensics` | $0.001 | 7-day uptime + latency p50/p90/p99 + decoy probability + concentration |
| `catalog_decoys` | $0.005 | Full known-bad blacklist as one cacheable JSON |
| `watch_subscribe` | $0.01 | 30-day webhook subscription + 100 prepaid HMAC-signed alerts on endpoint state changes |
| `watch_status` | free | Secret-gated read-back of an existing watch |
| `watch_unsubscribe` | free | Secret-gated soft-delete |

Networks: **Base mainnet** (`eip155:8453`) and **Base Sepolia** (`eip155:84532`). Payments auto-signed through whatever `EvmWalletProvider` the agent is already configured with.

## Why pre-flight?

The agentic.market catalog has 25,000+ x402 endpoints. A non-trivial fraction are honeypots or unreachable:

- **Decoys** priced ≥ $1,000 USDC per call. An agent that pays one drains its wallet on the first request.
- **Zombies** that 402-handshake fine but always 4xx after settlement (the call-side payment goes through, the agent gets nothing back).
- **Dead** endpoints that return network errors or 5xx every probe.

x402station independently probes every active catalog endpoint every ~10 minutes (not facilitator-reported) so it surfaces what facilitator-only monitors miss. Calling `preflight` before each paid x402 request costs $0.001 USDC — typically **20× cheaper than the request the agent would otherwise lose to a decoy**.

A recent independent run on the entire catalog ([blog post — methodology + raw JSONL](https://x402station.io/blog/cloudflare-x402-readiness)) found 53% of endpoints at Cloudflare-`isitagentready.com` level 0 and 1.5% with x402 actually detected — so the "is this a real endpoint?" filter is doing real work.

## Implementation

Mirrors the shape of the existing [`x402` action provider](https://github.com/coinbase/agentkit/tree/main/typescript/agentkit/src/action-providers/x402) and reuses its `EvmWalletProvider` signer-wrapping pattern, so the four paid actions auto-sign x402 challenges through the agent's existing wallet without extra plumbing.

The `baseUrl` is allow-listed: only `https://x402station.io` (canonical) or any `http(s)://localhost*` (development) is accepted. Any other host throws at construction time so a misconfigured agent can't sign x402 payments against an unknown host.

## Test coverage

`pnpm test src/action-providers/x402station/` — 21/21 passing locally.

- **constructor (6)**: default URL, localhost dev URL, trailing-slash handling, malformed URL rejection, non-canonical host rejection, port-bypass rejection (e.g. `https://x402station.io:9999` is rejected even though `.hostname` matches).
- **supportsNetwork (4)**: `base-mainnet` ✓, `base-sepolia` ✓, `ethereum-mainnet` ✗, non-EVM ✗.
- **preflight (3)**: POST + URL bound correctly, `paymentReceipt` decoded from `x-payment-response` header, error envelope on non-2xx.
- **forensics + catalog_decoys + watch_subscribe (4)**: correct paths, empty body for decoys, `signals` omitted-vs-included.
- **watch_status (3)**: does NOT use the paying-fetch wrapper, parses 200 body, error envelope on 404.
- **watch_unsubscribe (1)**: issues DELETE.

Manual end-to-end against the prod oracle ($0.018 USDC settled from a test wallet on Base mainnet) — 7/7 PASS via [the consumer-side demo agent in the public repo](https://github.com/sF1nX/x402station-mcp/blob/main/examples/demo-shielded-agent.ts).

## Quick start

```typescript
import {
  AgentKit,
  CdpEvmServerWalletProvider,
  x402stationActionProvider,
} from "@coinbase/agentkit";

const walletProvider = await CdpEvmServerWalletProvider.configureWithWallet({
  apiKeyId: process.env.CDP_API_KEY_ID!,
  apiKeySecret: process.env.CDP_API_KEY_SECRET!,
  walletSecret: process.env.CDP_WALLET_SECRET!,
  networkId: "base-mainnet",
});

const agentKit = await AgentKit.from({
  walletProvider,
  actionProviders: [x402stationActionProvider()],
});
```

The LLM can then call `preflight`, `forensics`, etc. via `agentKit.getActions()`.

## Existing alternatives

For agents that speak Model Context Protocol (Claude Code / Cursor / Windsurf / Continue), the same six tools are already available via the [`x402station-mcp`](https://www.npmjs.com/package/x402station-mcp) npm package and the [official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers/io.github.sF1nX/x402station). This PR is the AgentKit-native equivalent for the non-MCP path.

## Test plan

- [x] `pnpm test src/action-providers/x402station/` — 21/21 passing
- [x] `pnpm check` — 0 type errors in `x402station/` files (15 pre-existing errors elsewhere — `cdp/`, `opensea/`, `zora/` — are not from this PR)
- [x] Manual end-to-end on Base mainnet via the [demo agent in the public repo](https://github.com/sF1nX/x402station-mcp/blob/main/examples/demo-shielded-agent.ts) ($0.018 settled, 7/7 PASS)
- [ ] CI run against this PR

## Links

- Service: <https://x402station.io>
- Manifest: <https://x402station.io/.well-known/x402>
- OpenAPI: <https://x402station.io/api/openapi.json>
- Agent skills (v0.2.0): <https://x402station.io/.well-known/agent-skills>
- API catalog (RFC 9727): <https://x402station.io/.well-known/api-catalog>
- Public client SDKs (this provider snapshot + MCP adapter + demo agent): <https://github.com/sF1nX/x402station-mcp>
- npm (MCP adapter): <https://www.npmjs.com/package/x402station-mcp>

The oracle backend (probe pipeline, signal logic, ingest, internal stats history) lives in a private repo — by design. This PR's source is fully visible in the diff above and snapshotted at <https://github.com/sF1nX/x402station-mcp/tree/main/examples/agentkit-action-provider> for browseability.