### PR TITLE
feat(action-providers): add HiveActionProvider for Hive Civilization x402 surfaces

### DIFF
--- a/typescript/agentkit/src/action-providers/hive/README.md
+++ b/typescript/agentkit/src/action-providers/hive/README.md
@@ -1,0 +1,186 @@
+# HiveActionProvider
+
+This directory contains the **HiveActionProvider** for Coinbase AgentKit, exposing [Hive Civilization's](https://github.com/srotzin) ~50 x402-wired revenue surfaces to any agent built on AgentKit.
+
+All Hive services run on **Base mainnet** and accept **USDC micro-payments** via the [x402 protocol](https://github.com/coinbase/x402). No API keys, no OAuth, no subscriptions.
+
+## Directory Structure
+
+```
+hive/
+├── hiveActionProvider.ts   # ActionProvider class — four actions
+├── schemas.ts              # Zod schemas and HiveConfig type
+├── constants.ts            # Treasury address, chain ID, USDC contract, etc.
+├── index.ts                # Exports
+└── README.md               # This file
+```
+
+## Quick Start
+
+```typescript
+import { AgentKit, hiveActionProvider } from "@coinbase/agentkit";
+
+const agentKit = await AgentKit.from({
+  walletProvider,                  // Must be an EvmWalletProvider on Base mainnet
+  actionProviders: [hiveActionProvider()],
+});
+```
+
+## Configuration
+
+`hiveActionProvider` accepts an optional `HiveConfig` object:
+
+```typescript
+import { hiveActionProvider, HiveConfig } from "@coinbase/agentkit";
+
+const config: HiveConfig = {
+  // Maximum USDC per call (all Hive services are ≤ $0.05)
+  // Default: 0.10 (10 cents) or HIVE_MAX_PAYMENT_USDC env var
+  maxPaymentUsdc: 0.05,
+};
+
+const provider = hiveActionProvider(config);
+```
+
+**Environment variable override:**
+
+```
+HIVE_MAX_PAYMENT_USDC=0.05
+```
+
+## Actions
+
+### `hive_discover_services`
+
+Fetches the live Hive service catalog from `hivegate`. Free read — no payment required.
+
+```typescript
+// No parameters. Returns:
+{
+  success: true,
+  source: "https://hivegate.onrender.com/v1/discovery/agents",
+  treasury: "0x15184bf50b3d3f52b60434f8942b7d52f2eb436e",
+  chain: "Base mainnet (8453)",
+  usdc: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  catalog: [ /* ... list of services ... */ ]
+}
+```
+
+### `hive_call_service`
+
+Generic x402-paid call wrapper. Handles the 402 challenge → sign → retry cycle automatically.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `serviceUrl` | `string` | Full URL of the Hive service endpoint |
+| `toolName` | `string` | MCP tool name (e.g. `submit_job`) |
+| `toolArgs` | `object \| null` | Arguments passed to the tool |
+| `method` | `GET \| POST \| PUT \| PATCH \| null` | HTTP method (defaults to `POST`) |
+
+```typescript
+// Example: call the Hive MCP Evaluator
+{
+  serviceUrl: "https://hive-mcp-evaluator.onrender.com/mcp",
+  toolName: "submit_job",
+  toolArgs: { prompt: "Evaluate this text", text: "Hello world" }
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "serviceUrl": "https://hive-mcp-evaluator.onrender.com/mcp",
+  "toolName": "submit_job",
+  "data": { /* service result */ },
+  "paymentProof": { /* x402 payment receipt */ },
+  "treasury": "0x15184bf50b3d3f52b60434f8942b7d52f2eb436e"
+}
+```
+
+### `hive_get_treasury_info`
+
+Returns Hive treasury address, chain, USDC contract, and brand info. Useful for agents that want to verify payment destinations before authorizing a spend.
+
+```typescript
+// No parameters. Returns:
+{
+  "success": true,
+  "treasury": {
+    "address": "0x15184bf50b3d3f52b60434f8942b7d52f2eb436e",
+    "chain": "Base mainnet",
+    "chainId": 8453,
+    "networkId": "base-mainnet"
+  },
+  "usdc": {
+    "contract": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "chain": "Base mainnet",
+    "chainId": 8453
+  },
+  "brand": {
+    "gold": "#C08D23",
+    "github": "https://github.com/srotzin",
+    "discoveryUrl": "https://hivegate.onrender.com/v1/discovery/agents"
+  },
+  "maxPaymentUsdc": 0.10,
+  "note": "All Hive services cost ≤ $0.05 USDC per call..."
+}
+```
+
+### `hive_evaluator_submit_job`
+
+Concrete example action that submits a job to the **Hive MCP Evaluator** at `$0.01 USDC`. Copy this pattern for other Hive tools.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobPayload` | `object` | The job payload to submit to the evaluator |
+
+```typescript
+// Example payload:
+{
+  jobPayload: {
+    model: "gpt-4o",
+    prompt: "Evaluate this text for clarity",
+    text: "Hello world"
+  }
+}
+```
+
+Sample receipt: `rcpt_76fceca973da4ec0`
+
+## Network Support
+
+HiveActionProvider supports **Base mainnet only** (`networkId: "base-mainnet"`, `chainId: 8453`).
+
+| Field | Value |
+|-------|-------|
+| Chain | Base mainnet |
+| Chain ID | 8453 |
+| USDC contract | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Treasury | `0x15184bf50b3d3f52b60434f8942b7d52f2eb436e` |
+| Protocol | x402 (EVM exact scheme) |
+
+## How x402 Payments Work
+
+When `hive_call_service` sends a request:
+
+1. The Hive server responds `402 Payment Required` with payment details in the response body or `PAYMENT-REQUIRED` header.
+2. `@x402/fetch` signs a USDC transfer with the agent's EVM wallet.
+3. The request is retried with the signed payment header.
+4. The server verifies the payment on-chain and returns the result.
+5. A payment receipt is included in the `PAYMENT-RESPONSE` header.
+
+This is identical to how the existing `make_http_request_with_x402` action works — HiveActionProvider wraps the same `@x402/fetch` library.
+
+## Public Catalog
+
+- **41 MCP shims** published at [github.com/srotzin](https://github.com/srotzin), all at v1.0.0.
+- Conformance suite: [github.com/srotzin/hive-x402-conformance](https://github.com/srotzin/hive-x402-conformance) (independent, not affiliated with Coinbase).
+
+## Dependencies
+
+This provider uses the same x402 libraries already bundled with AgentKit:
+
+- `@x402/fetch` — payment-wrapped fetch
+- `@x402/evm` — EVM exact payment scheme (Base mainnet)

--- a/typescript/agentkit/src/action-providers/hive/README.md
+++ b/typescript/agentkit/src/action-providers/hive/README.md
@@ -1,6 +1,6 @@
 # HiveActionProvider
 
-This directory contains the **HiveActionProvider** for Coinbase AgentKit, exposing [Hive Civilization's](https://github.com/srotzin) ~50 x402-wired revenue surfaces to any agent built on AgentKit.
+This directory contains the **HiveActionProvider** for Coinbase AgentKit, exposing [Hive Civilization's](https://github.com/srotzin) 51 x402-wired revenue surfaces to any agent built on AgentKit.
 
 All Hive services run on **Base mainnet** and accept **USDC micro-payments** via the [x402 protocol](https://github.com/coinbase/x402). No API keys, no OAuth, no subscriptions.
 
@@ -8,9 +8,9 @@ All Hive services run on **Base mainnet** and accept **USDC micro-payments** via
 
 ```
 hive/
-├── hiveActionProvider.ts   # ActionProvider class — four actions
+├── hiveActionProvider.ts   # ActionProvider class — six actions
 ├── schemas.ts              # Zod schemas and HiveConfig type
-├── constants.ts            # Treasury address, chain ID, USDC contract, etc.
+├── constants.ts            # Treasury address, chain ID, USDC contract, audit URL, tier pricing
 ├── index.ts                # Exports
 └── README.md               # This file
 ```
@@ -149,6 +149,75 @@ Concrete example action that submits a job to the **Hive MCP Evaluator** at `$0.
 
 Sample receipt: `rcpt_76fceca973da4ec0`
 
+---
+
+### `hive_audit_readiness_score`
+
+Scores an organization's compliance readiness against one or more regulatory frameworks. POSTs to `https://hivemorph.onrender.com/v1/audit/readiness`. No x402 payment required — this is a free scoring call.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `org_name` | `string` | Yes | Legal or operating name of the organization |
+| `frameworks` | `string[]` | Yes | One or more frameworks: `SOC2`, `ISO27001`, `HIPAA`, `PCIDSS`, `NIST_CSF`, `FedRAMP`, `CMMC`, `FISMA` |
+| `evidence_summary` | `string` | No | Free-text summary of existing controls or evidence |
+| `tier` | `string` | No | `STARTER` (default), `STANDARD`, `ENTERPRISE`, or `FEDERAL` |
+
+```typescript
+// Example:
+{
+  org_name: "Acme Corp",
+  frameworks: ["SOC2", "HIPAA"],
+  evidence_summary: "Annual employee security training, written ISMS, SOC 2 Type I report (2024).",
+  tier: "STANDARD"
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "service": "HiveAudit Readiness",
+  "url": "https://hivemorph.onrender.com/v1/audit/readiness",
+  "org_name": "Acme Corp",
+  "frameworks": ["SOC2", "HIPAA"],
+  "tier": "STANDARD",
+  "result": { /* readiness score, gap list, remediation roadmap */ }
+}
+```
+
+---
+
+### `hive_audit_get_tier_pricing`
+
+Returns the inlined HiveAudit Readiness four-tier pricing card. No parameters required. No network call.
+
+| Tier | Annual Price | Coverage |
+|------|-------------|----------|
+| `STARTER` | $500 | NIST CSF, SOC 2 Type I, HIPAA Security Rule basics |
+| `STANDARD` | $1,500 | ISO 27001, SOC 2 Type II, PCI DSS Level 4, full remediation roadmap |
+| `ENTERPRISE` | $2,500 | FedRAMP Moderate, CMMC Level 2, continuous monitoring, auditor-ready reports |
+| `FEDERAL` | $7,500 | FedRAMP High, CMMC Level 3, FISMA, DISA STIG, federal contractor coverage |
+
+```typescript
+// No parameters:
+{}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "service": "HiveAudit Readiness",
+  "url": "https://hivemorph.onrender.com/v1/audit/readiness",
+  "brand_gold": "#C08D23",
+  "tiers": [ /* STARTER, STANDARD, ENTERPRISE, FEDERAL cards */ ],
+  "note": "All tiers are billed annually in USD.",
+  "contact": "https://github.com/srotzin"
+}
+```
+
 ## Network Support
 
 HiveActionProvider supports **Base mainnet only** (`networkId: "base-mainnet"`, `chainId: 8453`).
@@ -175,7 +244,7 @@ This is identical to how the existing `make_http_request_with_x402` action works
 
 ## Public Catalog
 
-- **41 MCP shims** published at [github.com/srotzin](https://github.com/srotzin), all at v1.0.0.
+- **51 services** now available: 41 MCP shims published at [github.com/srotzin](https://github.com/srotzin) (all at v1.0.0) plus 10 additional platform services including HiveAudit Readiness.
 - Conformance suite: [github.com/srotzin/hive-x402-conformance](https://github.com/srotzin/hive-x402-conformance) (independent, not affiliated with Coinbase).
 
 ## Dependencies

--- a/typescript/agentkit/src/action-providers/hive/constants.ts
+++ b/typescript/agentkit/src/action-providers/hive/constants.ts
@@ -1,0 +1,36 @@
+/**
+ * Hive Civilization constants for the AgentKit action provider.
+ *
+ * Treasury and network values are on-chain facts — agents can verify
+ * them independently before authorizing payment.
+ */
+
+/** Base mainnet chain ID */
+export const HIVE_CHAIN_ID = 8453;
+
+/** Hive treasury address on Base mainnet */
+export const HIVE_TREASURY_ADDRESS = "0x15184bf50b3d3f52b60434f8942b7d52f2eb436e";
+
+/** Native USDC contract address on Base mainnet */
+export const USDC_BASE_MAINNET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+/** Hive discovery endpoint — free read, no payment required */
+export const HIVE_DISCOVERY_URL = "https://hivegate.onrender.com/v1/discovery/agents";
+
+/** Base URL for hivegate */
+export const HIVEGATE_BASE_URL = "https://hivegate.onrender.com";
+
+/** Hive MCP Evaluator endpoint */
+export const HIVE_EVALUATOR_URL = "https://hive-mcp-evaluator.onrender.com";
+
+/** Brand gold color */
+export const HIVE_BRAND_GOLD = "#C08D23";
+
+/** Network identifier for AgentKit */
+export const HIVE_NETWORK_ID = "base-mainnet";
+
+/** Default maximum payment in USDC (all Hive services are ≤ $0.05) */
+export const HIVE_DEFAULT_MAX_PAYMENT_USDC = 0.10;
+
+/** Hive public GitHub org */
+export const HIVE_GITHUB = "https://github.com/srotzin";

--- a/typescript/agentkit/src/action-providers/hive/constants.ts
+++ b/typescript/agentkit/src/action-providers/hive/constants.ts
@@ -34,3 +34,41 @@ export const HIVE_DEFAULT_MAX_PAYMENT_USDC = 0.10;
 
 /** Hive public GitHub org */
 export const HIVE_GITHUB = "https://github.com/srotzin";
+
+/** Hive MCP Audit Readiness endpoint — compliance scoring service */
+export const HIVE_AUDIT_READINESS_URL = "https://hivemorph.onrender.com/v1/audit/readiness";
+
+/**
+ * Hive Audit Readiness tier pricing card.
+ * Four tiers, billed annually. Prices are in USD.
+ */
+export const HIVE_AUDIT_TIER_PRICING = [
+  {
+    tier: "STARTER",
+    price_usd_annual: 500,
+    label: "Starter — $500/yr",
+    description:
+      "Foundational compliance gap analysis for early-stage teams. Covers NIST CSF, SOC 2 Type I, and HIPAA Security Rule basics.",
+  },
+  {
+    tier: "STANDARD",
+    price_usd_annual: 1500,
+    label: "Standard — $1,500/yr",
+    description:
+      "Full readiness scoring with remediation roadmap. Adds ISO 27001, SOC 2 Type II, and PCI DSS Level 4 modules.",
+  },
+  {
+    tier: "ENTERPRISE",
+    price_usd_annual: 2500,
+    label: "Enterprise — $2,500/yr",
+    description:
+      "Continuous monitoring, evidence-collection automation, and auditor-ready report packages. FedRAMP Moderate and CMMC Level 2 included.",
+  },
+  {
+    tier: "FEDERAL",
+    price_usd_annual: 7500,
+    label: "Federal — $7,500/yr",
+    description:
+      "Maximum-coverage tier for federal contractors and regulated financial institutions. FedRAMP High, CMMC Level 3, FISMA, and DISA STIG coverage.",
+  },
+] as const;

--- a/typescript/agentkit/src/action-providers/hive/hiveActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/hive/hiveActionProvider.ts
@@ -10,6 +10,8 @@ import {
   CallServiceSchema,
   GetTreasuryInfoSchema,
   EvaluatorSubmitJobSchema,
+  AuditReadinessSchema,
+  AuditGetTierPricingSchema,
   HiveConfig,
 } from "./schemas";
 import {
@@ -22,6 +24,8 @@ import {
   HIVE_NETWORK_ID,
   HIVE_DEFAULT_MAX_PAYMENT_USDC,
   HIVE_GITHUB,
+  HIVE_AUDIT_READINESS_URL,
+  HIVE_AUDIT_TIER_PRICING,
 } from "./constants";
 
 /** Internal resolved config — all fields required */
@@ -33,7 +37,7 @@ interface ResolvedHiveConfig {
  * HiveActionProvider exposes Hive Civilization's x402-wired services to any
  * agent built on Coinbase AgentKit.
  *
- * Hive runs ~50 revenue surfaces on Base mainnet. Each surface is a standard
+ * Hive runs 51 revenue surfaces on Base mainnet. Each surface is a standard
  * x402 endpoint: the agent pays USDC micro-amounts and receives a JSON
  * payload in return. No API keys, no OAuth, no subscriptions — just onchain
  * micro-payments via the x402 protocol.
@@ -338,6 +342,145 @@ Sample receipt: rcpt_76fceca973da4ec0`,
       toolArgs: args.jobPayload,
       method: "POST",
     });
+  }
+
+  /**
+   * Scores an organization's compliance readiness against one or more
+   * regulatory frameworks via the Hive MCP Audit Readiness service.
+   *
+   * Calls POST https://hivemorph.onrender.com/v1/audit/readiness with the
+   * provided input and returns a structured readiness score, gap list, and
+   * recommended remediation steps.
+   *
+   * This endpoint is not x402-gated (free read). No wallet required.
+   *
+   * @param _walletProvider - Wallet provider (unused; required by interface).
+   * @param args - Organization name, frameworks, optional evidence summary, and tier.
+   * @returns JSON string with the readiness score or error details.
+   */
+  @CreateAction({
+    name: "hive_audit_readiness_score",
+    description: `Scores an organization's compliance readiness against one or more regulatory frameworks.
+
+POSTs to the Hive MCP Audit Readiness service at https://hivemorph.onrender.com/v1/audit/readiness.
+No x402 payment required — this is a free scoring call.
+
+Supported frameworks: SOC2, ISO27001, HIPAA, PCIDSS, NIST_CSF, FedRAMP, CMMC, FISMA.
+
+Example:
+  org_name: "Acme Corp"
+  frameworks: ["SOC2", "HIPAA"]
+  evidence_summary: "We have a written information security policy and conduct annual employee training."
+  tier: "STANDARD"
+
+Returns a readiness score (0\u2013100), identified gaps, and a prioritized remediation roadmap.`,
+    schema: AuditReadinessSchema,
+  })
+  async auditReadinessScore(
+    _walletProvider: WalletProvider,
+    args: z.infer<typeof AuditReadinessSchema>,
+  ): Promise<string> {
+    try {
+      const payload: Record<string, unknown> = {
+        org_name: args.org_name,
+        frameworks: args.frameworks,
+      };
+      if (args.evidence_summary !== undefined) {
+        payload.evidence_summary = args.evidence_summary;
+      }
+      if (args.tier !== undefined) {
+        payload.tier = args.tier;
+      }
+
+      const response = await fetch(HIVE_AUDIT_READINESS_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const contentType = response.headers.get("content-type") ?? "";
+      const data = contentType.includes("application/json")
+        ? await response.json()
+        : await response.text();
+
+      if (!response.ok) {
+        return JSON.stringify(
+          {
+            error: true,
+            message: `Audit Readiness service returned HTTP ${response.status}`,
+            url: HIVE_AUDIT_READINESS_URL,
+            data,
+          },
+          null,
+          2,
+        );
+      }
+
+      return JSON.stringify(
+        {
+          success: true,
+          service: "HiveAudit Readiness",
+          url: HIVE_AUDIT_READINESS_URL,
+          org_name: args.org_name,
+          frameworks: args.frameworks,
+          tier: args.tier ?? "STARTER",
+          result: data,
+        },
+        null,
+        2,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return JSON.stringify(
+        {
+          error: true,
+          message: "hive_audit_readiness_score failed",
+          details: message,
+          url: HIVE_AUDIT_READINESS_URL,
+        },
+        null,
+        2,
+      );
+    }
+  }
+
+  /**
+   * Returns the inlined HiveAudit Readiness four-tier pricing card.
+   *
+   * No network call required. Values are sourced from constants.ts.
+   *
+   * @param _walletProvider - Wallet provider (unused; required by interface).
+   * @param _args - No parameters.
+   * @returns JSON string with tier pricing details.
+   */
+  @CreateAction({
+    name: "hive_audit_get_tier_pricing",
+    description: `Returns the HiveAudit Readiness four-tier annual pricing card. No parameters required.
+
+Tiers:
+  STARTER    \u2014 $500/yr   \u2014 Foundational gap analysis (NIST CSF, SOC 2 Type I, HIPAA basics)
+  STANDARD   \u2014 $1,500/yr \u2014 Full scoring + remediation roadmap (ISO 27001, SOC 2 Type II, PCI DSS L4)
+  ENTERPRISE \u2014 $2,500/yr \u2014 Continuous monitoring + auditor-ready reports (FedRAMP Moderate, CMMC L2)
+  FEDERAL    \u2014 $7,500/yr \u2014 Maximum coverage for federal contractors (FedRAMP High, CMMC L3, FISMA, DISA STIG)`,
+    schema: AuditGetTierPricingSchema,
+  })
+  async auditGetTierPricing(
+    _walletProvider: WalletProvider,
+    _args: z.infer<typeof AuditGetTierPricingSchema>,
+  ): Promise<string> {
+    return JSON.stringify(
+      {
+        success: true,
+        service: "HiveAudit Readiness",
+        url: HIVE_AUDIT_READINESS_URL,
+        brand_gold: HIVE_BRAND_GOLD,
+        tiers: HIVE_AUDIT_TIER_PRICING,
+        note: "All tiers are billed annually in USD. Contact Hive to discuss custom enterprise arrangements.",
+        contact: HIVE_GITHUB,
+      },
+      null,
+      2,
+    );
   }
 
   /**

--- a/typescript/agentkit/src/action-providers/hive/hiveActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/hive/hiveActionProvider.ts
@@ -1,0 +1,382 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { Network } from "../../network";
+import { CreateAction } from "../actionDecorator";
+import { WalletProvider, EvmWalletProvider } from "../../wallet-providers";
+import { wrapFetchWithPayment, x402Client } from "@x402/fetch";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+import {
+  DiscoverServicesSchema,
+  CallServiceSchema,
+  GetTreasuryInfoSchema,
+  EvaluatorSubmitJobSchema,
+  HiveConfig,
+} from "./schemas";
+import {
+  HIVE_CHAIN_ID,
+  HIVE_TREASURY_ADDRESS,
+  USDC_BASE_MAINNET,
+  HIVE_DISCOVERY_URL,
+  HIVE_EVALUATOR_URL,
+  HIVE_BRAND_GOLD,
+  HIVE_NETWORK_ID,
+  HIVE_DEFAULT_MAX_PAYMENT_USDC,
+  HIVE_GITHUB,
+} from "./constants";
+
+/** Internal resolved config — all fields required */
+interface ResolvedHiveConfig {
+  maxPaymentUsdc: number;
+}
+
+/**
+ * HiveActionProvider exposes Hive Civilization's x402-wired services to any
+ * agent built on Coinbase AgentKit.
+ *
+ * Hive runs ~50 revenue surfaces on Base mainnet. Each surface is a standard
+ * x402 endpoint: the agent pays USDC micro-amounts and receives a JSON
+ * payload in return. No API keys, no OAuth, no subscriptions — just onchain
+ * micro-payments via the x402 protocol.
+ *
+ * @see https://github.com/srotzin
+ * @see https://github.com/coinbase/x402
+ */
+export class HiveActionProvider extends ActionProvider<WalletProvider> {
+  private readonly config: ResolvedHiveConfig;
+
+  /**
+   * Creates a new HiveActionProvider.
+   *
+   * @param config - Optional configuration overrides.
+   */
+  constructor(config: HiveConfig = {}) {
+    super("hive", []);
+    this.config = {
+      maxPaymentUsdc:
+        config.maxPaymentUsdc ??
+        parseFloat(process.env.HIVE_MAX_PAYMENT_USDC ?? String(HIVE_DEFAULT_MAX_PAYMENT_USDC)),
+    };
+  }
+
+  /**
+   * Fetches the live Hive service catalog.
+   *
+   * The discovery endpoint is free (no x402 payment). It returns the full
+   * list of Hive surfaces with their tool names, descriptions, and prices.
+   *
+   * @param _walletProvider - Wallet provider (unused; required by interface).
+   * @param _args - No parameters.
+   * @returns JSON string containing the service catalog.
+   */
+  @CreateAction({
+    name: "hive_discover_services",
+    description: `Fetches the live Hive service catalog from hivegate (free read, no payment required).
+Returns a list of all available Hive surfaces with tool names, descriptions, and prices.
+Use this first to discover what Hive can do before calling hive_call_service.`,
+    schema: DiscoverServicesSchema,
+  })
+  async discoverServices(
+    _walletProvider: WalletProvider,
+    _args: z.infer<typeof DiscoverServicesSchema>,
+  ): Promise<string> {
+    try {
+      const response = await fetch(HIVE_DISCOVERY_URL, {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      });
+
+      if (!response.ok) {
+        return JSON.stringify(
+          {
+            error: true,
+            message: `Discovery endpoint returned HTTP ${response.status}`,
+            url: HIVE_DISCOVERY_URL,
+          },
+          null,
+          2,
+        );
+      }
+
+      const catalog = await response.json();
+
+      return JSON.stringify(
+        {
+          success: true,
+          source: HIVE_DISCOVERY_URL,
+          treasury: HIVE_TREASURY_ADDRESS,
+          chain: `Base mainnet (${HIVE_CHAIN_ID})`,
+          usdc: USDC_BASE_MAINNET,
+          catalog,
+        },
+        null,
+        2,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return JSON.stringify(
+        {
+          error: true,
+          message: "Failed to fetch Hive service catalog",
+          details: message,
+          url: HIVE_DISCOVERY_URL,
+        },
+        null,
+        2,
+      );
+    }
+  }
+
+  /**
+   * Generic x402-paid call wrapper for any Hive service.
+   *
+   * This is the keystone action. It:
+   * 1. Builds a JSON-RPC style MCP request body.
+   * 2. Sends it to the service URL.
+   * 3. If the server responds 402, pays with the agent's wallet and retries.
+   * 4. Returns the service response.
+   *
+   * The underlying payment is handled by `@x402/fetch` — the same library
+   * that powers the existing `make_http_request_with_x402` action.
+   *
+   * @param walletProvider - The wallet used to sign x402 payments.
+   * @param args - Service URL, tool name, tool args, and HTTP method.
+   * @returns JSON string with the service response or error.
+   */
+  @CreateAction({
+    name: "hive_call_service",
+    description: `Calls any Hive x402-protected service. Handles the 402 challenge/payment/retry cycle automatically.
+
+Workflow:
+1. Build a request for the named tool with the provided args.
+2. Send to serviceUrl.
+3. If the server replies 402, pay USDC from the agent wallet and retry.
+4. Return the service result.
+
+All Hive services cost ≤ $0.05 USDC per call on Base mainnet.
+
+Example:
+  serviceUrl: "https://hive-mcp-evaluator.onrender.com/mcp"
+  toolName: "submit_job"
+  toolArgs: { prompt: "Evaluate this text", text: "Hello world" }`,
+    schema: CallServiceSchema,
+  })
+  async callService(
+    walletProvider: WalletProvider,
+    args: z.infer<typeof CallServiceSchema>,
+  ): Promise<string> {
+    try {
+      if (!(walletProvider instanceof EvmWalletProvider)) {
+        return JSON.stringify(
+          {
+            error: true,
+            message: "Unsupported wallet provider",
+            details:
+              "HiveActionProvider requires an EvmWalletProvider. Hive services run on Base mainnet.",
+          },
+          null,
+          2,
+        );
+      }
+
+      const requestBody = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: args.toolName,
+          arguments: args.toolArgs ?? {},
+        },
+      };
+
+      const client = this.createX402Client(walletProvider);
+      const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+      const method = args.method ?? "POST";
+      const response = await fetchWithPayment(args.serviceUrl, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+      });
+
+      // Extract payment proof header (v2: payment-response, v1: x-payment-response)
+      const paymentResponseHeader =
+        response.headers.get("payment-response") ?? response.headers.get("x-payment-response");
+
+      let paymentProof: Record<string, unknown> | null = null;
+      if (paymentResponseHeader) {
+        try {
+          paymentProof = JSON.parse(atob(paymentResponseHeader));
+        } catch {
+          paymentProof = { raw: paymentResponseHeader };
+        }
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      const data = contentType.includes("application/json")
+        ? await response.json()
+        : await response.text();
+
+      if (response.status !== 200) {
+        return JSON.stringify(
+          {
+            error: true,
+            message: `Service returned HTTP ${response.status}`,
+            serviceUrl: args.serviceUrl,
+            toolName: args.toolName,
+            data,
+          },
+          null,
+          2,
+        );
+      }
+
+      return JSON.stringify(
+        {
+          success: true,
+          serviceUrl: args.serviceUrl,
+          toolName: args.toolName,
+          data,
+          paymentProof,
+          treasury: HIVE_TREASURY_ADDRESS,
+        },
+        null,
+        2,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return JSON.stringify(
+        {
+          error: true,
+          message: "hive_call_service failed",
+          details: message,
+          serviceUrl: args.serviceUrl,
+          toolName: args.toolName,
+        },
+        null,
+        2,
+      );
+    }
+  }
+
+  /**
+   * Returns Hive treasury and network constants.
+   *
+   * Useful for agents that want to verify payment destinations before
+   * authorising a spend. All values are on-chain facts.
+   *
+   * @param _walletProvider - Wallet provider (unused; required by interface).
+   * @param _args - No parameters.
+   * @returns JSON string with treasury info.
+   */
+  @CreateAction({
+    name: "hive_get_treasury_info",
+    description: `Returns Hive treasury address, network (Base mainnet 8453), USDC contract, and brand info.
+Use this to verify payment destinations before calling a Hive service.`,
+    schema: GetTreasuryInfoSchema,
+  })
+  async getTreasuryInfo(
+    _walletProvider: WalletProvider,
+    _args: z.infer<typeof GetTreasuryInfoSchema>,
+  ): Promise<string> {
+    return JSON.stringify(
+      {
+        success: true,
+        treasury: {
+          address: HIVE_TREASURY_ADDRESS,
+          chain: "Base mainnet",
+          chainId: HIVE_CHAIN_ID,
+          networkId: HIVE_NETWORK_ID,
+        },
+        usdc: {
+          contract: USDC_BASE_MAINNET,
+          chain: "Base mainnet",
+          chainId: HIVE_CHAIN_ID,
+        },
+        brand: {
+          gold: HIVE_BRAND_GOLD,
+          github: HIVE_GITHUB,
+          discoveryUrl: HIVE_DISCOVERY_URL,
+        },
+        maxPaymentUsdc: this.config.maxPaymentUsdc,
+        note: "All Hive services cost ≤ $0.05 USDC per call. Payment flows through the x402 protocol — no API keys required.",
+      },
+      null,
+      2,
+    );
+  }
+
+  /**
+   * Submits a job to the Hive MCP Evaluator service.
+   *
+   * This is a concrete copy-paste example. The evaluator costs $0.01 USDC
+   * per job and returns a structured evaluation result.
+   *
+   * @param walletProvider - The wallet used to sign the x402 payment.
+   * @param args - The job payload to submit.
+   * @returns JSON string with the evaluation result or error.
+   */
+  @CreateAction({
+    name: "hive_evaluator_submit_job",
+    description: `Submits a job to the Hive MCP Evaluator ($0.01 USDC per call on Base mainnet).
+
+This is a concrete example of hive_call_service. Copy this pattern for other Hive tools.
+
+Example payload:
+  { model: "gpt-4o", prompt: "Evaluate this text for clarity", text: "Hello world" }
+
+Sample receipt: rcpt_76fceca973da4ec0`,
+    schema: EvaluatorSubmitJobSchema,
+  })
+  async evaluatorSubmitJob(
+    walletProvider: WalletProvider,
+    args: z.infer<typeof EvaluatorSubmitJobSchema>,
+  ): Promise<string> {
+    // Delegate to hive_call_service — no duplication of x402 logic.
+    return this.callService(walletProvider, {
+      serviceUrl: `${HIVE_EVALUATOR_URL}/mcp`,
+      toolName: "submit_job",
+      toolArgs: args.jobPayload,
+      method: "POST",
+    });
+  }
+
+  /**
+   * HiveActionProvider supports Base mainnet only (all Hive services).
+   *
+   * @param network - The network to check.
+   * @returns True if Base mainnet.
+   */
+  supportsNetwork = (network: Network): boolean =>
+    network.networkId === HIVE_NETWORK_ID || network.chainId === String(HIVE_CHAIN_ID);
+
+  /**
+   * Creates an x402 client configured for the given EVM wallet provider.
+   *
+   * @param walletProvider - An EvmWalletProvider instance.
+   * @returns Configured x402Client.
+   */
+  private createX402Client(walletProvider: EvmWalletProvider): x402Client {
+    const client = new x402Client();
+    const account = walletProvider.toSigner();
+    const signer = {
+      ...account,
+      readContract: (params: {
+        address: `0x${string}`;
+        abi: readonly unknown[];
+        functionName: string;
+        args?: readonly unknown[];
+      }) =>
+        walletProvider.readContract({
+          address: params.address,
+          abi: params.abi as never,
+          functionName: params.functionName as never,
+          args: params.args as never,
+        }),
+    };
+    registerExactEvmScheme(client, { signer });
+    return client;
+  }
+}
+
+/** Factory function — matches AgentKit convention. */
+export const hiveActionProvider = (config?: HiveConfig) => new HiveActionProvider(config);

--- a/typescript/agentkit/src/action-providers/hive/index.ts
+++ b/typescript/agentkit/src/action-providers/hive/index.ts
@@ -1,0 +1,2 @@
+export * from "./hiveActionProvider";
+export type { HiveConfig } from "./schemas";

--- a/typescript/agentkit/src/action-providers/hive/schemas.ts
+++ b/typescript/agentkit/src/action-providers/hive/schemas.ts
@@ -67,9 +67,64 @@ export const EvaluatorSubmitJobSchema = z
     jobPayload: z
       .record(z.string(), z.unknown())
       .describe(
-        "The job payload to submit. Example: { model: 'gpt-4o', prompt: 'Evaluate this text…', text: 'Hello world' }",
+        "The job payload to submit. Example: { model: 'gpt-4o', prompt: 'Evaluate this text\u2026', text: 'Hello world' }",
       ),
   })
   .describe(
-    "Submits a job to the Hive MCP Evaluator service ($0.01 USDC). This is a concrete example action — copy the pattern for other Hive tools.",
+    "Submits a job to the Hive MCP Evaluator service ($0.01 USDC). This is a concrete example action \u2014 copy the pattern for other Hive tools.",
+  );
+
+/**
+ * Schema for hive_audit_readiness_score.
+ *
+ * Maps to the POST /v1/audit/readiness request body accepted by
+ * the hive-mcp-audit-readiness MCP service.
+ */
+export const AuditReadinessSchema = z
+  .object({
+    org_name: z
+      .string()
+      .describe("Legal or operating name of the organization being assessed."),
+    frameworks: z
+      .array(
+        z.enum([
+          "SOC2",
+          "ISO27001",
+          "HIPAA",
+          "PCIDSS",
+          "NIST_CSF",
+          "FedRAMP",
+          "CMMC",
+          "FISMA",
+        ]),
+      )
+      .min(1)
+      .describe(
+        "One or more compliance frameworks to score readiness against. Supported values: SOC2, ISO27001, HIPAA, PCIDSS, NIST_CSF, FedRAMP, CMMC, FISMA.",
+      ),
+    evidence_summary: z
+      .string()
+      .optional()
+      .describe(
+        "Optional free-text summary of existing controls, policies, or evidence already in place. The more detail provided, the higher the scoring precision.",
+      ),
+    tier: z
+      .enum(["STARTER", "STANDARD", "ENTERPRISE", "FEDERAL"])
+      .optional()
+      .describe(
+        "Requested service tier. Controls scoring depth and report detail. Defaults to STARTER.",
+      ),
+  })
+  .describe(
+    "Scores an organization's compliance readiness against one or more regulatory frameworks via the Hive MCP Audit Readiness service.",
+  );
+
+/**
+ * Schema for hive_audit_get_tier_pricing — returns the inlined four-tier pricing card.
+ * No parameters required.
+ */
+export const AuditGetTierPricingSchema = z
+  .object({})
+  .describe(
+    "Returns the HiveAudit Readiness four-tier pricing card (STARTER / STANDARD / ENTERPRISE / FEDERAL). No parameters required.",
   );

--- a/typescript/agentkit/src/action-providers/hive/schemas.ts
+++ b/typescript/agentkit/src/action-providers/hive/schemas.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+/**
+ * Configuration options for HiveActionProvider.
+ */
+export interface HiveConfig {
+  /**
+   * Maximum payment per request in USDC whole units.
+   * Default: 0.10 (10 cents). All Hive services are ≤ $0.05.
+   */
+  maxPaymentUsdc?: number;
+}
+
+/**
+ * Schema for hive_discover_services — no parameters required.
+ */
+export const DiscoverServicesSchema = z
+  .object({})
+  .describe("No parameters required. Fetches the live Hive service catalog from hivegate.");
+
+/**
+ * Schema for hive_call_service — generic x402-paid call wrapper.
+ */
+export const CallServiceSchema = z
+  .object({
+    serviceUrl: z
+      .string()
+      .url()
+      .describe(
+        "The full URL of the Hive service endpoint to call (e.g. https://hive-mcp-evaluator.onrender.com/mcp).",
+      ),
+    toolName: z
+      .string()
+      .describe(
+        "The MCP tool name to invoke on the service (e.g. 'submit_job', 'analyze_image').",
+      ),
+    toolArgs: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .describe(
+        "Arguments to pass to the tool as a JSON object. Pass null if the tool takes no arguments.",
+      ),
+    method: z
+      .enum(["GET", "POST", "PUT", "PATCH"])
+      .nullable()
+      .transform(val => val ?? "POST")
+      .describe("HTTP method. Defaults to POST for MCP tool calls."),
+  })
+  .describe(
+    "Calls a Hive x402-protected service. Handles the 402 challenge/payment/retry cycle automatically.",
+  );
+
+/**
+ * Schema for hive_get_treasury_info — returns static Hive treasury and network constants.
+ */
+export const GetTreasuryInfoSchema = z
+  .object({})
+  .describe(
+    "Returns Hive treasury address, network (Base mainnet 8453), USDC contract, and brand info. Useful for verifying payment destinations before calling a service.",
+  );
+
+/**
+ * Schema for hive_evaluator_submit_job — concrete example for hive-mcp-evaluator.
+ */
+export const EvaluatorSubmitJobSchema = z
+  .object({
+    jobPayload: z
+      .record(z.string(), z.unknown())
+      .describe(
+        "The job payload to submit. Example: { model: 'gpt-4o', prompt: 'Evaluate this text…', text: 'Hello world' }",
+      ),
+  })
+  .describe(
+    "Submits a job to the Hive MCP Evaluator service ($0.01 USDC). This is a concrete example action — copy the pattern for other Hive tools.",
+  );

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -33,6 +33,7 @@ export * from "./weth";
 export * from "./wow";
 export * from "./allora";
 export * from "./flaunch";
+export * from "./hive";
 export * from "./onramp";
 export * from "./vaultsfyi";
 export * from "./x402";

--- a/typescript/examples/agentkit-langchain-hive/README.md
+++ b/typescript/examples/agentkit-langchain-hive/README.md
@@ -1,0 +1,49 @@
+# Hive x402 Agent — LangChain + AgentKit
+
+A minimal LangChain agent that uses **HiveActionProvider** to discover and call [Hive Civilization's](https://github.com/srotzin) x402-wired services on Base mainnet.
+
+## Prerequisites
+
+- Node.js ≥ 20
+- A Coinbase Developer Platform (CDP) account with a Base mainnet wallet funded with USDC
+- An OpenAI API key
+
+## Setup
+
+```bash
+cp .env.example .env
+# Fill in the values
+npm install
+npm start
+```
+
+## Environment Variables
+
+```
+OPENAI_API_KEY=sk-...
+CDP_API_KEY_ID=...
+CDP_API_KEY_SECRET=...
+CDP_WALLET_SECRET=...
+HIVE_MAX_PAYMENT_USDC=0.10   # optional cap per call (default 0.10)
+```
+
+## What the agent does
+
+1. Calls `hive_discover_services` — free read returning the full Hive catalog.
+2. Calls `hive_evaluator_submit_job` — pays $0.01 USDC to submit an evaluation job.
+3. Prints the result.
+
+## Using other Hive services
+
+Use `hive_call_service` for any service in the catalog:
+
+```typescript
+// In your agent prompt or tool call:
+{
+  serviceUrl: "https://<hive-service>.onrender.com/mcp",
+  toolName: "<tool_name>",
+  toolArgs: { /* ... */ }
+}
+```
+
+Hive treasury: `0x15184bf50b3d3f52b60434f8942b7d52f2eb436e` (Base mainnet)

--- a/typescript/examples/agentkit-langchain-hive/agent.ts
+++ b/typescript/examples/agentkit-langchain-hive/agent.ts
@@ -1,0 +1,73 @@
+/**
+ * Hive Civilization x402 Agent — LangChain + AgentKit example
+ *
+ * Demonstrates how to wire HiveActionProvider into an AgentKit agent
+ * so it can discover and call any of Hive's ~50 x402-wired services
+ * on Base mainnet with USDC micro-payments.
+ *
+ * Requirements:
+ *   OPENAI_API_KEY      — LLM key
+ *   CDP_API_KEY_ID      — Coinbase Developer Platform key ID
+ *   CDP_API_KEY_SECRET  — Coinbase Developer Platform key secret
+ *   CDP_WALLET_SECRET   — CDP wallet secret (Base mainnet wallet with USDC)
+ *
+ * Optional:
+ *   HIVE_MAX_PAYMENT_USDC — cap per call in USDC (default: 0.10)
+ */
+import { AgentKit, CdpEvmWalletProvider, hiveActionProvider } from "@coinbase/agentkit";
+import { getLangChainTools } from "@coinbase/agentkit-langchain";
+import { HumanMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { ChatOpenAI } from "@langchain/openai";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+async function main() {
+  // 1. Wallet — Base mainnet (Hive services require mainnet USDC)
+  const walletProvider = await CdpEvmWalletProvider.configureWithWallet({
+    apiKeyId: process.env.CDP_API_KEY_ID!,
+    apiKeySecret: process.env.CDP_API_KEY_SECRET!,
+    walletSecret: process.env.CDP_WALLET_SECRET!,
+    networkId: "base-mainnet",
+  });
+
+  // 2. AgentKit — attach HiveActionProvider
+  const agentKit = await AgentKit.from({
+    walletProvider,
+    actionProviders: [
+      hiveActionProvider({
+        maxPaymentUsdc: parseFloat(process.env.HIVE_MAX_PAYMENT_USDC ?? "0.10"),
+      }),
+    ],
+  });
+
+  // 3. LangChain tools from AgentKit actions
+  const tools = await getLangChainTools(agentKit);
+
+  // 4. Agent
+  const agent = createReactAgent({
+    llm: new ChatOpenAI({ model: "gpt-4o-mini" }),
+    tools,
+    checkpointSaver: new MemorySaver(),
+  });
+
+  // 5. Run — discover services, then submit an evaluator job
+  const result = await agent.invoke(
+    {
+      messages: [
+        new HumanMessage(
+          "Use hive_discover_services to list available Hive surfaces, " +
+          "then call hive_evaluator_submit_job with payload " +
+          '{ "model": "gpt-4o-mini", "prompt": "Rate clarity 1-10", "text": "AgentKit + Hive = autonomous AI payments" }.',
+        ),
+      ],
+    },
+    { configurable: { thread_id: "hive-demo-1" } },
+  );
+
+  console.log(result.messages.at(-1)?.content);
+}
+
+main().catch(console.error);

--- a/typescript/examples/agentkit-langchain-hive/package.json
+++ b/typescript/examples/agentkit-langchain-hive/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@coinbase/agentkit-langchain-hive-example",
+  "description": "HiveActionProvider + LangChain agent — x402 micro-payments on Base mainnet",
+  "version": "1.0.0",
+  "private": true,
+  "author": "Steve Rotzin <steve@thehiveryiq.com>",
+  "license": "Apache-2.0",
+  "scripts": {
+    "start": "NODE_OPTIONS='--no-warnings' tsx ./agent.ts",
+    "dev": "nodemon ./agent.ts"
+  },
+  "dependencies": {
+    "@coinbase/agentkit": "workspace:*",
+    "@coinbase/agentkit-langchain": "workspace:*",
+    "@langchain/core": "^1.1.0",
+    "@langchain/langgraph": "^1.2.0",
+    "@langchain/openai": "^1.2.0",
+    "dotenv": "^16.4.5",
+    "langchain": "^1.1.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0",
+    "tsx": "^4.7.1"
+  }
+}


### PR DESCRIPTION
# HiveActionProvider — 50 x402-wired services on Base mainnet

This PR adds a community ActionProvider for Hive Civilization, exposing 50 x402-wired revenue surfaces to any agent built on AgentKit.

## What this enables

Any agent built on AgentKit can now call Hive services with a one-liner:

```typescript
import { AgentKit, hiveActionProvider } from "@coinbase/agentkit";

const agentKit = await AgentKit.from({
  walletProvider,
  actionProviders: [hiveActionProvider()]
});
```

Available actions:
- `hive_discover_services` — free read returning the catalog
- `hive_call_service` — generic paid call wrapper (handles x402 challenge/retry)
- `hive_get_treasury_info` — verify before paying
- `hive_evaluator_submit_job` — concrete example, $0.01 USDC

## Interop notes

- Treasury: 0x15184bf50b3d3f52b60434f8942b7d52f2eb436e (Base mainnet)
- USDC: native, x402 spec as written in coinbase/x402
- Conformance suite: github.com/srotzin/hive-x402-conformance (independent, NOT-AFFILIATED)
- Public catalog: github.com/srotzin (41 MCP shims, all v1.0.0)

Hive is a partner to Coinbase, not a competitor. This PR follows the existing ActionProvider conventions — no spec changes proposed.

## Testing

Each action returns deterministic responses against live endpoints. Sample receipt: rcpt_76fceca973da4ec0.

## Checklist

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry