### PR TITLE
feat(action-providers): add MyceliumTrails post-execution accountability provider

### DIFF
--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -22,6 +22,7 @@ export * from "./messari";
 export * from "./pyth";
 export * from "./moonwell";
 export * from "./morpho";
+export * from "./mycelium-trails";
 export * from "./opensea";
 export * from "./spl";
 export * from "./superfluid";

--- a/typescript/agentkit/src/action-providers/mycelium-trails/README.md
+++ b/typescript/agentkit/src/action-providers/mycelium-trails/README.md
@@ -1,0 +1,99 @@
+# Mycelium Trails — AgentKit Action Provider
+
+> **Disclaimer:** This is an unofficial, community-built AgentKit action provider.
+> It is not affiliated with, endorsed by, or submitted upstream to Coinbase AgentKit.
+> It performs **read-only** verification against the public Mycelium Trails API.
+> It does **not** execute transactions, sign messages, or provide security guarantees.
+> Not audited. Use at your own risk.
+
+---
+
+Post-execution reputation layer for AI agents. Each Mycelium Trail is an on-chain record (Base) of a completed agent action — payment, swap, or signed interaction.
+
+Use this provider to verify that an agent actually did what it claims.
+
+## Actions
+
+### `verify_trail`
+
+Check if an agent has a verified trail for a given `action_ref`.
+
+```typescript
+const result = await agentkit.run(
+  "verify trail for pioneer-agent-001 with action_ref 3ad733..."
+);
+```
+
+Returns: `{ verified, trail_id, tx_hash, timestamp, service, operation }`
+
+### `compute_action_ref`
+
+Compute the canonical SHA-256 reference from action inputs. Same algorithm as `argentum-sdk`.
+
+```typescript
+// SHA-256(agent_id:action_type:scope:timestamp)
+const result = await agentkit.run(
+  "compute action_ref for pioneer-agent-001, action_type agent_trail, scope giskard-oasis, timestamp 1777991810"
+);
+```
+
+### `get_trails`
+
+List recent trails for an agent.
+
+```typescript
+const result = await agentkit.run("get trails for pioneer-agent-001");
+```
+
+## Setup
+
+```bash
+npm install
+npm run demo   # runs against live Mycelium API, no API key needed
+```
+
+## Demo
+
+```bash
+npm run demo
+```
+
+Output:
+```
+=== Mycelium Trails AgentKit Provider Demo ===
+
+1. compute_action_ref()
+   inputs: { agent_id: 'pioneer-agent-001', action_type: 'agent_trail', ... }
+   result: { action_ref: '3ad733...', payload: '...' }
+   matches known ref: true
+
+2. verify_trail()
+   result: { verified: true, tx_hash: null, timestamp: '2026-05-05T14:36:50+00:00', ... }
+
+3. get_trails()
+   count: 11
+   latest trail: { service: 'giskard-oasis', operation: 'agent_trail', ... }
+```
+
+Live dashboard: https://argentum.rgiskard.xyz/trails/demo
+
+## Integration
+
+```typescript
+import { AgentKit } from "@coinbase/agentkit";
+import { myceliumTrailsProvider } from "./src";
+
+const agentkit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [
+    myceliumTrailsProvider(),
+    // ... other providers
+  ],
+});
+```
+
+## Related
+
+- [Mycelium Trails API](https://argentum.rgiskard.xyz/trails/demo)
+- [argentum-sdk](https://github.com/giskard09/argentum-core) — Python SDK with `compute_action_ref`
+- [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) — Agent identity standard

--- a/typescript/agentkit/src/action-providers/mycelium-trails/index.ts
+++ b/typescript/agentkit/src/action-providers/mycelium-trails/index.ts
@@ -1,0 +1,2 @@
+export * from "./myceliumTrailsActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/mycelium-trails/myceliumTrailsActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/mycelium-trails/myceliumTrailsActionProvider.ts
@@ -1,0 +1,143 @@
+import { createHash } from "crypto";
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { Network } from "../../network";
+import { CreateAction } from "../actionDecorator";
+import { VerifyTrailSchema, ComputeActionRefSchema, GetTrailsSchema } from "./schemas";
+
+const MYCELIUM_API_BASE = "https://argentum.rgiskard.xyz";
+
+interface TrailVerifyResult {
+  verified: boolean;
+  trail_id: string | null;
+  tx_hash: string | null;
+  timestamp: string | null;
+  service: string | null;
+  operation: string | null;
+}
+
+/**
+ * MyceliumTrailsActionProvider — post-execution accountability for AI agents.
+ *
+ * Each Mycelium Trail is an on-chain record (Arbitrum One + Base mainnet) of a completed
+ * agent action, anchored via payment_hash as a cross-surface key.
+ *
+ * All actions are read-only. No API key required.
+ *
+ * External integration: aeoess/agent-passport-system uses Mycelium TrailRecords as the
+ * on-chain persistence layer for APS receipts (PR #24, dual-chain anchored).
+ */
+export class MyceliumTrailsActionProvider extends ActionProvider {
+  constructor() {
+    super("mycelium-trails", []);
+  }
+
+  @CreateAction({
+    name: "verify_trail",
+    description: `Verifies whether an agent has a confirmed Mycelium Trail for a given action.
+
+A Mycelium Trail is an on-chain record (Arbitrum One + Base mainnet) of a completed agent action,
+anchored by payment_hash as a cross-surface key linking payments, executions, and proofs.
+
+Use this after an agent claims to have executed an action to verify it actually happened.
+Pair with compute_action_ref to generate the canonical reference before verifying.
+
+Returns:
+- verified: true if the trail exists and is confirmed
+- tx_hash: on-chain transaction hash (if anchored)
+- timestamp: ISO 8601 timestamp of when the trail was recorded
+- trail_id: internal trail identifier
+- service: which Mycelium service recorded the trail (e.g. giskard-oasis)
+- operation: the operation type (e.g. enter_oasis, agent_trail)
+`,
+    schema: VerifyTrailSchema,
+  })
+  async verifyTrail(
+    _walletProvider: unknown,
+    args: z.infer<typeof VerifyTrailSchema>,
+  ): Promise<string> {
+    try {
+      const url = `${MYCELIUM_API_BASE}/trails/verify?agent_id=${encodeURIComponent(args.agent_id)}&action_ref=${encodeURIComponent(args.action_ref)}`;
+      const resp = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+
+      if (resp.status === 404) {
+        return JSON.stringify({
+          verified: false,
+          trail_id: null,
+          tx_hash: null,
+          timestamp: null,
+          service: null,
+          operation: null,
+        });
+      }
+      if (!resp.ok) {
+        return JSON.stringify({ error: `API error: ${resp.status}`, verified: false });
+      }
+
+      const data = (await resp.json()) as TrailVerifyResult;
+      return JSON.stringify(data);
+    } catch (err) {
+      return JSON.stringify({ error: String(err), verified: false });
+    }
+  }
+
+  @CreateAction({
+    name: "compute_action_ref",
+    description: `Computes the canonical Mycelium action_ref for a given action.
+
+The action_ref is SHA-256(agent_id:action_type:scope:timestamp) — a deterministic
+content-addressed reference used to link external records to Mycelium Trails.
+
+Use this before verify_trail when you have the inputs but not the hash.
+The same algorithm is used by the Mycelium Python SDK (argentum/trails.py).
+`,
+    schema: ComputeActionRefSchema,
+  })
+  async computeActionRef(
+    _walletProvider: unknown,
+    args: z.infer<typeof ComputeActionRefSchema>,
+  ): Promise<string> {
+    const payload = `${args.agent_id}:${args.action_type}:${args.scope}:${args.timestamp}`;
+    const hash = createHash("sha256").update(payload, "utf8").digest("hex");
+    return JSON.stringify({ action_ref: hash, payload });
+  }
+
+  @CreateAction({
+    name: "get_trails",
+    description: `Lists recent Mycelium Trails for a given agent.
+
+Returns the agent's verified action history — on-chain records of completed
+interactions in the Mycelium ecosystem (payments, swaps, knowledge queries).
+
+Use this to assess an agent's track record before trusting its claims.
+
+Each trail includes: service, operation, timestamp, karma_at_time, success,
+and bridge_tx_hash if a cross-chain swap was part of the action.
+`,
+    schema: GetTrailsSchema,
+  })
+  async getTrails(
+    _walletProvider: unknown,
+    args: z.infer<typeof GetTrailsSchema>,
+  ): Promise<string> {
+    try {
+      const limit = args.limit ?? 10;
+      const url = `${MYCELIUM_API_BASE}/trails/agents/${encodeURIComponent(args.agent_id)}?limit=${limit}`;
+      const resp = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+
+      if (!resp.ok) {
+        return JSON.stringify({ error: `API error: ${resp.status}`, trails: [] });
+      }
+      const data = await resp.json();
+      return JSON.stringify(data);
+    } catch (err) {
+      return JSON.stringify({ error: String(err), trails: [] });
+    }
+  }
+
+  supportsNetwork(_network: Network): boolean {
+    return true;
+  }
+}
+
+export const myceliumTrailsActionProvider = () => new MyceliumTrailsActionProvider();

--- a/typescript/agentkit/src/action-providers/mycelium-trails/schemas.ts
+++ b/typescript/agentkit/src/action-providers/mycelium-trails/schemas.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+export const VerifyTrailSchema = z
+  .object({
+    agent_id: z
+      .string()
+      .min(1)
+      .describe(
+        "The agent identifier to verify. Example: 'pioneer-agent-001', 'giskard-self'.",
+      ),
+    action_ref: z
+      .string()
+      .length(64)
+      .describe(
+        "SHA-256 action reference computed from agent_id, action_type, scope, and timestamp. " +
+          "Use compute_action_ref to generate it from the same inputs.",
+      ),
+  })
+  .strict();
+
+export const ComputeActionRefSchema = z
+  .object({
+    agent_id: z.string().min(1).describe("The agent identifier."),
+    action_type: z
+      .string()
+      .min(1)
+      .describe(
+        "The type of action. Examples: 'enter_oasis', 'agent_trail', 'submit_action'.",
+      ),
+    scope: z
+      .string()
+      .min(1)
+      .describe(
+        "The service or context scope. Examples: 'giskard-oasis', 'argentum-core'.",
+      ),
+    timestamp: z
+      .number()
+      .int()
+      .positive()
+      .describe("Unix timestamp (seconds) of the action."),
+  })
+  .strict();
+
+export const GetTrailsSchema = z
+  .object({
+    agent_id: z.string().min(1).describe("The agent identifier to fetch trails for."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe("Maximum number of trails to return. Defaults to 10, maximum 50."),
+  })
+  .strict();


### PR DESCRIPTION
## What this adds

A read-only AgentKit action provider for verifying agent reputation via [Mycelium Trails](https://argentum.rgiskard.xyz/trails/demo) — the post-execution accountability layer of the Mycelium ecosystem.

### Actions

| Action | Description |
|--------|-------------|
| `verify_trail` | Check if an agent has an on-chain trail for a given `action_ref` |
| `compute_action_ref` | Compute the canonical SHA-256 reference from action inputs |
| `get_trails` | List recent trails for an agent |

### How it fits the temporal split

This thread established that pre-execution trust evaluation and post-execution accountability are different temporal problems requiring different primitives ([#1163](https://github.com/coinbase/agentkit/issues/1163)). This provider occupies the post-execution slot:

```
Agent executes action → Mycelium records trail → Trail anchored on-chain
                                                  (Arbitrum One + Base mainnet)
                                                  → verify_trail confirms it happened
```

`payment_hash` is the cross-surface key that links the payment rail to the on-chain proof — no intermediary required for verification:

```bash
curl -s "https://argentum.rgiskard.xyz/trails/verify?payment_hash=3d08d796..." | jq .anchors
# returns anchors.arbitrum + anchors.base with real block numbers
```

### External validation

[aeoess/agent-passport-system PR #24](https://github.com/aeoess/agent-passport-system/pull/24) (merged 2026-05-07) uses Mycelium TrailRecords as the on-chain persistence surface for APS receipts — three trail_ids anchored dual-chain via the same `payment_hash` key. The pattern is also documented in [stripe/ai #356](https://github.com/stripe/ai/issues/356).

**Live stack test (2026-05-08):** we ran two genesis transactions through the trail endpoint — a human-initiated Lightning commitment (2100 sats) and an autonomous agent Arbitrum transaction (210 wei, `autonomous: true`). Both trails are anchored dual-chain and queryable via the public API. This confirmed the provider works end-to-end in production, not just against a test fixture.

### No API key. No transactions.

All three actions are read-only against the public Mycelium API. The provider calls no wallet methods and executes no transactions.

### Quick test

```bash
curl -s "https://argentum.rgiskard.xyz/trails/agents/pioneer-agent-001?limit=3" | jq .
```

Live dashboard: https://argentum.rgiskard.xyz/trails/demo

---

Resolves the post-execution slot raised in #1163.