### PR TITLE
Add QuantOracle action provider

### DIFF
--- a/typescript/.changeset/quantoracle-action-provider.md
+++ b/typescript/.changeset/quantoracle-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added QuantOracle action provider for deterministic quant finance math (Black-Scholes pricing, Kelly Criterion, Monte Carlo simulation, full risk audit, hedge recommendations). Free tier covers calculator endpoints; paid composites settle automatically via the agent's wallet using x402 micropayments on Base or Solana.

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -20,6 +20,7 @@ export * from "./farcaster";
 export * from "./jupiter";
 export * from "./messari";
 export * from "./pyth";
+export * from "./quantoracle";
 export * from "./moonwell";
 export * from "./morpho";
 export * from "./opensea";

--- a/typescript/agentkit/src/action-providers/quantoracle/README.md
+++ b/typescript/agentkit/src/action-providers/quantoracle/README.md
@@ -1,0 +1,68 @@
+# QuantOracle Action Provider
+
+This directory contains the QuantOracle action provider implementation, which gives AgentKit agents access to deterministic quant finance math — Black-Scholes pricing, Kelly Criterion sizing, Monte Carlo simulation, full risk audits, and hedge recommendations.
+
+## Why this exists
+
+AI agents trying to compute Black-Scholes prices, Kelly fractions, or Monte Carlo simulations in-context drift. The numbers are wrong, the Greeks are hallucinated, and the agent can't tell. QuantOracle is grounded math: same inputs always produce the same outputs, tested against published textbook values (Hull, Wilmott, Lopez de Prado), 120 accuracy benchmarks passing.
+
+## Getting Started
+
+No setup required — the free tier covers the calculator endpoints with no signup or API key. Paid composites (`assess_portfolio_risk`, `recommend_hedge`) settle automatically via your AgentKit wallet using x402 micropayments on Base or Solana.
+
+### Optional Environment Variables
+
+```
+QUANTORACLE_API_URL  # Override the default https://api.quantoracle.dev (e.g. for staging)
+```
+
+## Directory Structure
+
+```
+quantoracle/
+├── constants.ts                       # API base URL and User-Agent
+├── index.ts                           # Main exports
+├── quantoracleActionProvider.test.ts  # Tests for the provider
+├── quantoracleActionProvider.ts       # Main provider with QuantOracle API actions
+├── README.md                          # Documentation
+└── schemas.ts                         # Zod schemas for each action
+```
+
+## Actions
+
+The provider exposes 5 curated actions. The full QuantOracle API has 73 endpoints; this provider intentionally surfaces only the actions that solve real agent decisions.
+
+- **`price_option`** (free tier) — Black-Scholes option pricing with full Greeks
+- **`calculate_kelly`** (free tier) — Kelly Criterion optimal bet sizing
+- **`simulate_portfolio`** (free tier) — Monte Carlo with retirement-style withdrawals
+- **`assess_portfolio_risk`** ($0.04 USDC via x402) — Composite Sharpe/Sortino/Calmar/maxDD/VaR/CVaR/Kelly/Hurst audit
+- **`recommend_hedge`** ($0.04 USDC via x402) — Ranked hedge structures (collar, protective put, partial put, inverse)
+
+## Rate Limiting
+
+| Endpoint Tier | Limit |
+|---|---|
+| Free (no signup) | 1,000 requests per IP per day |
+| Paid composites | No limit; $0.04 USDC per call |
+
+## Usage
+
+```typescript
+import { AgentKit } from "@coinbase/agentkit";
+import { quantoracleActionProvider } from "@coinbase/agentkit";
+
+const agentkit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [quantoracleActionProvider()],
+});
+```
+
+## Try without code
+
+The same engine powers 12 free interactive calculators at [quantoracle.dev](https://quantoracle.dev) — useful for verifying outputs before wiring the action provider into your agent.
+
+## Resources
+
+- API documentation: [api.quantoracle.dev/openapi.json](https://api.quantoracle.dev/openapi.json)
+- Repository: [github.com/QuantOracledev/quantoracle](https://github.com/QuantOracledev/quantoracle)
+- x402 protocol: [github.com/coinbase/x402](https://github.com/coinbase/x402)

--- a/typescript/agentkit/src/action-providers/quantoracle/constants.ts
+++ b/typescript/agentkit/src/action-providers/quantoracle/constants.ts
@@ -1,0 +1,19 @@
+/**
+ * Base URL for the QuantOracle API.
+ *
+ * Override via the QUANTORACLE_API_URL env var if you're proxying through a
+ * private gateway or testing against a staging instance.
+ */
+export const QUANTORACLE_BASE_URL =
+  process.env.QUANTORACLE_API_URL ?? "https://api.quantoracle.dev";
+
+/**
+ * Free tier daily limit per IP. Free tier covers calculator endpoints
+ * (price_option, calculate_kelly, simulate_portfolio).
+ */
+export const FREE_TIER_DAILY_LIMIT = 1000;
+
+/**
+ * User-Agent for source attribution in QuantOracle's analytics dashboard.
+ */
+export const USER_AGENT = "QuantOracle-AgentKit/1.0";

--- a/typescript/agentkit/src/action-providers/quantoracle/index.ts
+++ b/typescript/agentkit/src/action-providers/quantoracle/index.ts
@@ -1,0 +1,3 @@
+export * from "./quantoracleActionProvider";
+export * from "./schemas";
+export * from "./constants";

--- a/typescript/agentkit/src/action-providers/quantoracle/quantoracleActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/quantoracle/quantoracleActionProvider.test.ts
@@ -1,0 +1,282 @@
+import { quantoracleActionProvider, QuantOracleActionProvider } from "./quantoracleActionProvider";
+import { QUANTORACLE_BASE_URL } from "./constants";
+
+const MOCK_PRICE_RESPONSE = {
+  price: 4.615,
+  intrinsic: 0,
+  time_value: 4.615,
+  breakeven: 104.615,
+  prob_itm: 0.5299,
+  greeks: {
+    delta: 0.56946,
+    gamma: 0.039288,
+    theta: -0.028696,
+    vega: 0.19644,
+    rho: 0.130828,
+  },
+  d1: 0.175,
+  d2: 0.075,
+  ms: 19.84,
+};
+
+const MOCK_KELLY_RESPONSE = {
+  full_kelly: 0.25,
+  half_kelly: 0.125,
+  quarter_kelly: 0.0625,
+  edge: 37.5,
+  payoff_ratio: 1.5,
+  recommended: "QUARTER_KELLY",
+  ms: 17.09,
+};
+
+const MOCK_KELLY_NEGATIVE_RESPONSE = {
+  full_kelly: -0.05,
+  half_kelly: -0.025,
+  quarter_kelly: -0.0125,
+  edge: -5,
+  payoff_ratio: 0.8,
+  recommended: "QUARTER_KELLY",
+  ms: 12,
+};
+
+const MOCK_MC_RESPONSE = {
+  terminal: {
+    mean: 219417.91,
+    median: 184473.98,
+    p5: 62105.06,
+    p25: 116413.12,
+    p75: 277432.19,
+    p95: 508381.34,
+  },
+  prob_loss: 0.18,
+  prob_double: 0.443,
+  prob_ruin: 0,
+  cagr: 0.0818,
+  sample_paths: [],
+  ms: 2912.96,
+};
+
+const MOCK_RISK_ANALYSIS_RESPONSE = {
+  sharpe: { sharpe_ratio: 1.42 },
+  sortino: { sortino_ratio: 2.18 },
+  calmar: { calmar_ratio: 0.85 },
+  drawdown: { max_drawdown: -0.18 },
+  var: {
+    var_results: {
+      "95": { var_pct: 1.61, cvar_pct: 2.15 },
+      "99": { var_pct: 2.5, cvar_pct: 2.94 },
+    },
+  },
+  kelly: { kelly_fraction: 0.32 },
+  hurst: { hurst_exponent: 0.55 },
+};
+
+const MOCK_HEDGE_RESPONSE = {
+  structures: [
+    {
+      name: "Collar",
+      cost_pct: 0.0061,
+      cost_dollars: 613,
+      downside_floor: -0.05,
+      upside_cap: 0.1,
+      legs: [
+        {
+          action: "buy",
+          quantity: 1,
+          type: "put",
+          strike: 175.75,
+          premium: 4.5,
+        },
+        {
+          action: "sell",
+          quantity: 1,
+          type: "call",
+          strike: 203.5,
+          premium: 3.88,
+        },
+      ],
+    },
+  ],
+};
+
+describe("QuantOracleActionProvider", () => {
+  let provider: QuantOracleActionProvider;
+
+  beforeEach(() => {
+    provider = quantoracleActionProvider();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("creates an instance without configuration", () => {
+      const p = quantoracleActionProvider();
+      expect(p).toBeInstanceOf(QuantOracleActionProvider);
+    });
+
+    it("supports any network", () => {
+      expect(provider.supportsNetwork({ protocolFamily: "evm" } as never)).toBe(true);
+      expect(provider.supportsNetwork({ protocolFamily: "svm" } as never)).toBe(true);
+    });
+  });
+
+  describe("priceOption", () => {
+    it("calls the /v1/options/price endpoint with the right body", async () => {
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_PRICE_RESPONSE,
+      } as Response);
+
+      const result = await provider.priceOption({
+        S: 100,
+        K: 100,
+        T: 0.25,
+        r: 0.05,
+        sigma: 0.2,
+        option_type: "call",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${QUANTORACLE_BASE_URL}/v1/options/price`,
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+          }),
+        }),
+      );
+      expect(result).toContain("CALL");
+      expect(result).toContain("$4.6150");
+      expect(result).toContain("Delta: 0.5695");
+    });
+
+    it("returns an error message when the API fails", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "internal" }),
+      } as Response);
+
+      const result = await provider.priceOption({
+        S: 100,
+        K: 100,
+        T: 0.25,
+        r: 0.05,
+        sigma: 0.2,
+        option_type: "call",
+      });
+
+      expect(result).toContain("Failed to price option");
+    });
+  });
+
+  describe("calculateKelly", () => {
+    it("returns Kelly variants for a positive-edge strategy", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_KELLY_RESPONSE,
+      } as Response);
+
+      const result = await provider.calculateKelly({
+        win_rate: 0.55,
+        avg_win: 150,
+        avg_loss: 100,
+      });
+
+      expect(result).toContain("Full Kelly: 25.00%");
+      expect(result).toContain("Half Kelly: 12.50%");
+      expect(result).toContain("Quarter Kelly: 6.25%");
+      expect(result).toContain("quarter kelly");
+    });
+
+    it("warns about negative edge", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_KELLY_NEGATIVE_RESPONSE,
+      } as Response);
+
+      const result = await provider.calculateKelly({
+        win_rate: 0.45,
+        avg_win: 100,
+        avg_loss: 120,
+      });
+
+      expect(result).toContain("Negative edge");
+      expect(result).toContain("Do not deploy capital");
+    });
+  });
+
+  describe("simulatePortfolio", () => {
+    it("returns terminal-distribution and probability events", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_MC_RESPONSE,
+      } as Response);
+
+      const result = await provider.simulatePortfolio({
+        initial_value: 100000,
+        annual_return: 0.08,
+        annual_vol: 0.18,
+        years: 20,
+        simulations: 1000,
+        contributions: 0,
+        withdrawal_rate: 0,
+      });
+
+      expect(result).toContain("Median: $184,474");
+      expect(result).toContain("Loss vs starting value: 18.0%");
+      expect(result).toContain("Probability of ruin");
+    });
+  });
+
+  describe("assessPortfolioRisk", () => {
+    it("surfaces Sharpe, Sortino, Calmar, VaR, CVaR, Kelly, Hurst", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_RISK_ANALYSIS_RESPONSE,
+      } as Response);
+
+      const returns = Array.from({ length: 252 }, () => 0.001);
+      const result = await provider.assessPortfolioRisk({
+        returns,
+        risk_free_rate: 0.04,
+        annualization_factor: 252,
+      });
+
+      expect(result).toContain("Sharpe ratio: 1.42");
+      expect(result).toContain("Sortino ratio: 2.18");
+      expect(result).toContain("Calmar ratio: 0.85");
+      expect(result).toContain("Max drawdown: -18.00%");
+      expect(result).toContain("VaR (95%): 1.61%");
+      expect(result).toContain("CVaR / Expected Shortfall (95%): 2.15%");
+      expect(result).toContain("paid via x402");
+    });
+  });
+
+  describe("recommendHedge", () => {
+    it("returns ranked hedge structures with cost and floor", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_HEDGE_RESPONSE,
+      } as Response);
+
+      const result = await provider.recommendHedge({
+        position_type: "long_stock",
+        position_value: 100000,
+        asset_price: 185,
+        volatility: 0.28,
+        time_horizon_days: 30,
+        max_hedge_cost_pct: 0.02,
+        r: 0.05,
+      });
+
+      expect(result).toContain("Collar");
+      expect(result).toContain("cost 0.61% ($613.00)");
+      expect(result).toContain("buy 1× put @ $175.75");
+      expect(result).toContain("sell 1× call @ $203.50");
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/quantoracle/quantoracleActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/quantoracle/quantoracleActionProvider.ts
@@ -1,0 +1,372 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { Network } from "../../network";
+import {
+  AssessPortfolioRiskSchema,
+  CalculateKellySchema,
+  PriceOptionSchema,
+  RecommendHedgeSchema,
+  SimulatePortfolioSchema,
+} from "./schemas";
+import { QUANTORACLE_BASE_URL, USER_AGENT } from "./constants";
+
+/**
+ * QuantOracleActionProvider — deterministic quant finance math for AgentKit agents.
+ *
+ * QuantOracle is a free pay-per-call API serving 73 deterministic financial
+ * calculators. This provider exposes the five highest-leverage actions an
+ * autonomous trading or finance agent typically needs.
+ *
+ * Free tier: 1,000 calls/IP/day with no signup or API key (covers
+ * price_option, calculate_kelly, simulate_portfolio). Paid composites
+ * (assess_portfolio_risk, recommend_hedge) cost $0.04 USDC each, settled
+ * via x402 on Base or Solana — AgentKit's wallet pays automatically.
+ *
+ * @augments ActionProvider
+ */
+export class QuantOracleActionProvider extends ActionProvider {
+  /**
+   * Constructor for QuantOracleActionProvider. No configuration required —
+   * the free tier covers calculator endpoints, and paid composites use
+   * AgentKit's wallet to settle x402 payments.
+   */
+  constructor() {
+    super("quantoracle", []);
+  }
+
+  /**
+   * Price a European call or put option using Black-Scholes with full Greeks.
+   *
+   * @param args - Spot price, strike, time to expiry, rate, vol, type
+   * @returns Markdown-formatted summary with price, breakeven, and Greeks
+   */
+  @CreateAction({
+    name: "price_option",
+    description: `
+Price a European call or put option using Black-Scholes with full Greeks.
+Returns the option's theoretical price, breakeven, probability ITM, and
+all first-order Greeks (delta, gamma, vega, theta, rho).
+
+Use this when:
+- Verifying that a market option price is reasonable before placing an order
+- Estimating PnL on an existing options position given a view on the underlying
+- Computing position deltas for portfolio hedging decisions
+- Sizing options trades based on Greek exposures
+
+Inputs: spot price, strike, time to expiry (in years; 30 days = 0.083),
+risk-free rate, volatility, option type (call or put).
+`,
+    schema: PriceOptionSchema,
+  })
+  async priceOption(args: z.infer<typeof PriceOptionSchema>): Promise<string> {
+    try {
+      const data = await this.callApi("/v1/options/price", args);
+      const ms = (data.ms as number) ?? 0;
+      const greeks = (data.greeks as Record<string, number>) ?? {};
+      return [
+        `**${args.option_type.toUpperCase()} on $${args.S} underlying, $${args.K} strike, ${(args.T * 365).toFixed(0)}d to expiry, ${(args.sigma * 100).toFixed(1)}% IV**`,
+        ``,
+        `- Price: $${(data.price as number).toFixed(4)}`,
+        `- Breakeven: $${(data.breakeven as number).toFixed(2)}`,
+        `- Probability ITM: ${((data.prob_itm as number) * 100).toFixed(1)}%`,
+        `- Delta: ${greeks.delta.toFixed(4)}`,
+        `- Gamma: ${greeks.gamma.toFixed(4)}`,
+        `- Vega: ${greeks.vega.toFixed(4)}`,
+        `- Theta (per day): ${greeks.theta.toFixed(4)}`,
+        `- Rho: ${greeks.rho.toFixed(4)}`,
+        ``,
+        `_Computed in ${ms.toFixed(0)}ms via QuantOracle._`,
+      ].join("\n");
+    } catch (err) {
+      return `Failed to price option: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  /**
+   * Calculate Kelly Criterion optimal bet/position sizing.
+   *
+   * @param args - Win rate, average win, average loss
+   * @returns Markdown-formatted summary with Kelly variants and edge analysis
+   */
+  @CreateAction({
+    name: "calculate_kelly",
+    description: `
+Calculate Kelly Criterion optimal bet sizing given a strategy's win rate
+and average win/loss amounts. Returns the full-, half-, and quarter-Kelly
+fractions, the edge per dollar risked, and the payoff ratio.
+
+Use this when:
+- Deriving the risk-per-trade fraction for a position-sizing system
+- Comparing two strategies head-to-head (higher Kelly = better edge per unit risk)
+- Validating that a strategy is positive-expected-value before deploying capital
+
+Most professionals use half- or quarter-Kelly because edge estimates are noisy
+and overestimating edge causes severe overbetting.
+`,
+    schema: CalculateKellySchema,
+  })
+  async calculateKelly(args: z.infer<typeof CalculateKellySchema>): Promise<string> {
+    try {
+      const data = await this.callApi("/v1/risk/kelly", { mode: "discrete", ...args });
+      const fullKelly = (data.full_kelly as number) * 100;
+      const halfKelly = (data.half_kelly as number) * 100;
+      const quarterKelly = (data.quarter_kelly as number) * 100;
+      const recommendation = (data.recommended as string).replace(/_/g, " ").toLowerCase();
+      return [
+        `**Kelly sizing for ${(args.win_rate * 100).toFixed(1)}% win rate, $${args.avg_win} avg win, $${args.avg_loss} avg loss**`,
+        ``,
+        `- Full Kelly: ${fullKelly.toFixed(2)}%`,
+        `- Half Kelly: ${halfKelly.toFixed(2)}% _(typical for risk-tolerant)_`,
+        `- Quarter Kelly: ${quarterKelly.toFixed(2)}% _(safer; recommended)_`,
+        `- Edge: ${(data.edge as number).toFixed(2)}%`,
+        `- Payoff ratio: ${(data.payoff_ratio as number).toFixed(2)}×`,
+        `- **Recommendation:** ${recommendation}`,
+        ``,
+        fullKelly < 0
+          ? `_Negative edge — this strategy has negative expected value. Do not deploy capital._`
+          : `_Computed via QuantOracle._`,
+      ].join("\n");
+    } catch (err) {
+      return `Failed to calculate Kelly: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  /**
+   * Run a Monte Carlo portfolio simulation.
+   *
+   * @param args - Initial value, return/vol assumptions, time horizon, contributions/withdrawals
+   * @returns Markdown-formatted summary with distribution percentiles and probability events
+   */
+  @CreateAction({
+    name: "simulate_portfolio",
+    description: `
+Run a Monte Carlo simulation projecting the distribution of portfolio
+outcomes over a chosen time horizon. Returns terminal-value percentiles
+(P5/P25/median/P75/P95), probability of loss, probability of doubling,
+and probability of ruin under withdrawals.
+
+Use this when:
+- Stress-testing a withdrawal-rate plan (e.g. "is 4% sustainable for 30 years?")
+- Comparing portfolio strategies head-to-head
+- Quantifying sequence-of-returns risk for retirement-style allocations
+- Showing a user the realistic range of outcomes (not just expected return)
+`,
+    schema: SimulatePortfolioSchema,
+  })
+  async simulatePortfolio(args: z.infer<typeof SimulatePortfolioSchema>): Promise<string> {
+    try {
+      const data = await this.callApi("/v1/simulate/montecarlo", args);
+      const t = data.terminal as Record<string, number>;
+      const probLoss = ((data.prob_loss as number) * 100).toFixed(1);
+      const probRuin = ((data.prob_ruin as number) * 100).toFixed(2);
+      const cagr = ((data.cagr as number) * 100).toFixed(2);
+      const fmt = (v: number) => `$${v.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+      return [
+        `**Monte Carlo: $${args.initial_value.toLocaleString()} over ${args.years} years, ${(args.annual_return * 100).toFixed(1)}% return, ${(args.annual_vol * 100).toFixed(1)}% vol**`,
+        ``,
+        `_Distribution of terminal outcomes (across ${args.simulations.toLocaleString()} simulated paths):_`,
+        `- Median: ${fmt(t.median)}`,
+        `- 5th percentile (worst 5%): ${fmt(t.p5)}`,
+        `- 95th percentile (best 5%): ${fmt(t.p95)}`,
+        `- Median CAGR: ${cagr}%`,
+        ``,
+        `**Probability events:**`,
+        `- Loss vs starting value: ${probLoss}%`,
+        `- Probability of ruin (portfolio depleted): ${probRuin}%`,
+        ``,
+        `_Computed in ${(data.ms as number).toFixed(0)}ms via QuantOracle._`,
+      ].join("\n");
+    } catch (err) {
+      return `Failed to simulate: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  /**
+   * Compute a full risk-adjusted-return audit. PAID composite endpoint.
+   *
+   * @param args - Historical returns array, risk-free rate, annualization factor
+   * @returns Markdown-formatted comprehensive risk summary
+   */
+  @CreateAction({
+    name: "assess_portfolio_risk",
+    description: `
+Run a comprehensive risk audit on a return series. Returns Sharpe ratio,
+Sortino ratio, Calmar ratio, max drawdown, VaR (95%/99%), CVaR (Expected
+Shortfall), Kelly fraction, and Hurst exponent (regime indicator).
+
+Use this when:
+- Evaluating a backtest before deploying real capital
+- Auditing an existing strategy's risk-adjusted performance
+- Comparing two strategies on multiple risk dimensions in one call
+- Generating a one-page risk summary for a stakeholder
+
+PAID composite endpoint: $0.04 per call, settled in USDC via x402 on Base
+or Solana. AgentKit's wallet pays automatically — no API key, no signup.
+The savings vs running 8 separate calculator calls is meaningful in both
+cost and latency.
+
+Requires at least 30 observations of historical returns; 252+ recommended
+for statistical significance.
+`,
+    schema: AssessPortfolioRiskSchema,
+  })
+  async assessPortfolioRisk(args: z.infer<typeof AssessPortfolioRiskSchema>): Promise<string> {
+    try {
+      const data = await this.callApi("/v1/risk/full-analysis", args);
+      const sharpe = ((data.sharpe as Record<string, number>)?.sharpe_ratio as number) ?? 0;
+      const sortino = ((data.sortino as Record<string, number>)?.sortino_ratio as number) ?? 0;
+      const calmar = ((data.calmar as Record<string, number>)?.calmar_ratio as number) ?? 0;
+      const maxDd = ((data.drawdown as Record<string, number>)?.max_drawdown as number) ?? 0;
+      const varObj = (
+        data.var as { var_results?: Record<string, { var_pct: number; cvar_pct: number }> }
+      )?.var_results?.["95"];
+      const var95 = varObj?.var_pct ?? 0;
+      const cvar95 = varObj?.cvar_pct ?? 0;
+      const kelly = ((data.kelly as Record<string, number>)?.kelly_fraction as number) ?? 0;
+      const hurst = ((data.hurst as Record<string, number>)?.hurst_exponent as number) ?? 0;
+      return [
+        `**Risk audit on ${args.returns.length} observations** _(paid via x402, $0.04 USDC)_`,
+        ``,
+        `**Risk-adjusted return:**`,
+        `- Sharpe ratio: ${sharpe.toFixed(2)}`,
+        `- Sortino ratio: ${sortino.toFixed(2)}`,
+        `- Calmar ratio: ${calmar.toFixed(2)}`,
+        ``,
+        `**Tail risk:**`,
+        `- Max drawdown: ${(maxDd * 100).toFixed(2)}%`,
+        `- VaR (95%): ${var95.toFixed(2)}%`,
+        `- CVaR / Expected Shortfall (95%): ${cvar95.toFixed(2)}%`,
+        ``,
+        `**Sizing & regime:**`,
+        `- Kelly fraction: ${(kelly * 100).toFixed(2)}%`,
+        `- Hurst exponent: ${hurst.toFixed(3)} ${hurst > 0.6 ? "_(trending)_" : hurst < 0.4 ? "_(mean-reverting)_" : "_(random walk)_"}`,
+        ``,
+        `_Composite analysis via QuantOracle. Settled on-chain via x402._`,
+      ].join("\n");
+    } catch (err) {
+      return `Failed to assess risk: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  /**
+   * Recommend ranked hedge structures. PAID composite endpoint.
+   *
+   * @param args - Position details and hedge parameters
+   * @returns Markdown-formatted ranked list of hedge structures
+   */
+  @CreateAction({
+    name: "recommend_hedge",
+    description: `
+Recommend ranked hedge structures (collar, protective put, partial put,
+inverse) for an existing position. Each recommendation includes the cost
+as a percentage of position value, the downside protection floor, and the
+upside cap (if any).
+
+Use this when:
+- An agent holding a long position wants to limit downside before an event
+  (earnings, FOMC, FDA decision) without selling
+- An agent needs to compare hedge strategies head-to-head by cost vs protection
+- Programmatic risk management of crypto positions ahead of high-vol periods
+
+PAID composite endpoint: $0.04 per call, settled in USDC via x402 on Base or
+Solana. AgentKit's wallet pays automatically.
+`,
+    schema: RecommendHedgeSchema,
+  })
+  async recommendHedge(args: z.infer<typeof RecommendHedgeSchema>): Promise<string> {
+    try {
+      const data = await this.callApi("/v1/hedging/recommend", args);
+      const structures = (data.structures as Array<Record<string, unknown>>) ?? [];
+      const lines: string[] = [
+        `**Hedge recommendations for $${args.position_value.toLocaleString()} ${args.position_type} position over ${args.time_horizon_days} days** _(paid via x402, $0.04 USDC)_`,
+        ``,
+      ];
+      for (let i = 0; i < structures.length; i++) {
+        const s = structures[i];
+        const upsideStr = s.upside_cap
+          ? `, upside cap ${((s.upside_cap as number) * 100).toFixed(1)}%`
+          : ", unlimited upside";
+        lines.push(
+          `**${i + 1}. ${s.name as string}** — cost ${((s.cost_pct as number) * 100).toFixed(2)}% ($${(s.cost_dollars as number).toFixed(2)}), floor ${((s.downside_floor as number) * 100).toFixed(1)}%${upsideStr}`,
+        );
+        if (s.legs) {
+          for (const leg of s.legs as Array<Record<string, unknown>>) {
+            lines.push(
+              `   - ${leg.action as string} ${leg.quantity as number}× ${leg.type as string} @ $${(leg.strike as number).toFixed(2)} (premium $${(leg.premium as number).toFixed(2)})`,
+            );
+          }
+        }
+        lines.push(``);
+      }
+      return lines.join("\n");
+    } catch (err) {
+      return `Failed to recommend hedge: ${err instanceof Error ? err.message : String(err)}`;
+    }
+  }
+
+  /**
+   * QuantOracle works on any network because the calculations are pure math
+   * (no on-chain reads). x402 settlement for paid endpoints works on Base
+   * mainnet and Solana mainnet, but the agent's network does not constrain
+   * which calculator endpoints can be called.
+   *
+   * @param _ - The network the agent is operating on (unused)
+   * @returns true for any network
+   */
+  supportsNetwork(_: Network): boolean {
+    return true;
+  }
+
+  /**
+   * Internal helper. POSTs JSON to a QuantOracle endpoint and returns the
+   * parsed response. Throws on non-2xx responses.
+   *
+   * @param path - Endpoint path beginning with /v1/...
+   * @param body - JSON-serializable request body
+   * @returns Parsed JSON response
+   */
+  private async callApi(
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const res = await fetch(`${QUANTORACLE_BASE_URL}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+        "X-Source": "agentkit",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      let detail = "";
+      try {
+        const j = await res.json();
+        detail = JSON.stringify(j).slice(0, 200);
+      } catch {
+        // ignore parse errors on error responses
+      }
+      throw new Error(`QuantOracle ${path} returned ${res.status}: ${detail}`);
+    }
+    return (await res.json()) as Record<string, unknown>;
+  }
+}
+
+/**
+ * Factory function — returns a configured QuantOracleActionProvider instance.
+ *
+ * @example
+ * ```ts
+ * import { quantoracleActionProvider } from "@coinbase/agentkit";
+ *
+ * const agent = await AgentKit.from({
+ *   walletProvider,
+ *   actionProviders: [quantoracleActionProvider()],
+ * });
+ * ```
+ *
+ * @returns Configured QuantOracleActionProvider
+ */
+export const quantoracleActionProvider = (): QuantOracleActionProvider =>
+  new QuantOracleActionProvider();

--- a/typescript/agentkit/src/action-providers/quantoracle/schemas.ts
+++ b/typescript/agentkit/src/action-providers/quantoracle/schemas.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+/**
+ * Input schema for the price_option action — Black-Scholes option pricing.
+ */
+export const PriceOptionSchema = z
+  .object({
+    S: z.number().positive().describe("Spot price of the underlying"),
+    K: z.number().positive().describe("Strike price"),
+    T: z.number().positive().describe("Time to expiry in years (0.083 = 30 days)"),
+    r: z.number().describe("Risk-free interest rate as decimal (0.05 = 5%)"),
+    sigma: z.number().positive().describe("Annualized volatility as decimal (0.28 = 28%)"),
+    option_type: z.enum(["call", "put"]).default("call").describe("Option type — call or put"),
+  })
+  .describe(
+    "Black-Scholes option pricing with full Greeks. Returns price, breakeven, probability ITM, and all first-order Greeks (delta, gamma, vega, theta, rho).",
+  );
+
+/**
+ * Input schema for the calculate_kelly action — discrete-bet Kelly Criterion.
+ */
+export const CalculateKellySchema = z
+  .object({
+    win_rate: z.number().min(0.01).max(0.99).describe("Probability of winning (0-1)"),
+    avg_win: z.number().positive().describe("Average dollar amount won on winning trades"),
+    avg_loss: z
+      .number()
+      .positive()
+      .describe("Average dollar amount lost on losing trades (positive number)"),
+  })
+  .describe(
+    "Kelly Criterion optimal bet sizing. Returns full-, half-, and quarter-Kelly fractions plus edge and payoff ratio. Use half- or quarter-Kelly in real trading because edge estimates are noisy.",
+  );
+
+/**
+ * Input schema for the simulate_portfolio action — Monte Carlo simulation.
+ */
+export const SimulatePortfolioSchema = z
+  .object({
+    initial_value: z.number().positive().describe("Starting portfolio value"),
+    annual_return: z.number().describe("Expected annual return as decimal (0.08 = 8%)"),
+    annual_vol: z.number().positive().describe("Annual volatility as decimal (0.18 = 18%)"),
+    years: z.number().positive().describe("Time horizon in years"),
+    simulations: z
+      .number()
+      .int()
+      .min(100)
+      .max(10000)
+      .default(1000)
+      .describe("Number of Monte Carlo paths (1000-2500 typical)"),
+    contributions: z
+      .number()
+      .min(0)
+      .default(0)
+      .describe("Annual contribution amount (set 0 if none)"),
+    withdrawal_rate: z
+      .number()
+      .min(0)
+      .max(0.5)
+      .default(0)
+      .describe("Annual withdrawal rate as decimal (0.04 = 4%)"),
+  })
+  .describe(
+    "Monte Carlo portfolio simulation. Returns distribution of terminal outcomes (P5/P25/median/P75/P95), probability of loss, probability of doubling, and probability of ruin under withdrawals.",
+  );
+
+/**
+ * Input schema for the assess_portfolio_risk action — composite risk audit.
+ */
+export const AssessPortfolioRiskSchema = z
+  .object({
+    returns: z
+      .array(z.number())
+      .min(30)
+      .describe(
+        "Array of historical periodic returns as decimals (0.012 = 1.2%). Daily returns assumed; minimum 30 observations.",
+      ),
+    risk_free_rate: z
+      .number()
+      .default(0.04)
+      .describe("Annual risk-free rate as decimal (0.04 = 4%)"),
+    annualization_factor: z
+      .number()
+      .int()
+      .default(252)
+      .describe("252 for daily returns, 52 for weekly, 12 for monthly"),
+  })
+  .describe(
+    "Composite full risk analysis: Sharpe, Sortino, Calmar, max drawdown, VaR, CVaR, Hurst exponent, and Kelly. PAID endpoint ($0.04 per call, settled in USDC). AgentKit's wallet pays automatically.",
+  );
+
+/**
+ * Input schema for the recommend_hedge action — ranked hedge structures.
+ */
+export const RecommendHedgeSchema = z
+  .object({
+    position_type: z
+      .enum(["long_stock", "short_stock", "long_crypto", "long_options"])
+      .describe("Type of position to hedge"),
+    position_value: z.number().positive().describe("Current dollar value of the position"),
+    asset_price: z.number().positive().describe("Current spot price of the underlying"),
+    volatility: z
+      .number()
+      .positive()
+      .describe("Annualized volatility of the underlying as decimal (0.28 = 28%)"),
+    time_horizon_days: z
+      .number()
+      .int()
+      .positive()
+      .default(30)
+      .describe("Hedge time horizon in days"),
+    max_hedge_cost_pct: z
+      .number()
+      .min(0)
+      .max(0.5)
+      .default(0.05)
+      .describe("Maximum hedge cost as fraction of position (0.05 = 5%)"),
+    r: z.number().default(0.05).describe("Risk-free rate as decimal"),
+  })
+  .describe(
+    "Recommend ranked hedge structures (collar, protective put, partial put, inverse) for an existing position. Returns each structure's cost, downside protection, and upside cap. PAID endpoint ($0.04 per call, settled in USDC). AgentKit's wallet pays automatically.",
+  );


### PR DESCRIPTION
## Summary

Adds a new action provider giving AgentKit agents access to deterministic quant finance math — Black-Scholes pricing, Kelly Criterion sizing, Monte Carlo simulation, full risk audits, and hedge recommendations.

The two paid composite actions (`assess_portfolio_risk`, `recommend_hedge`) settle automatically via the agent's wallet using **x402 micropayments** on Base or Solana — no API key, no signup, no billing infrastructure required. This is the structural fit with AgentKit: the framework's USDC-native wallets unlock paid endpoints that traditional API-key services can't reach as cleanly.

## What's new

5 curated actions covering the financial decisions an autonomous trading or finance agent typically faces:

| Action | Cost | Use case |
|---|---|---|
| `price_option` | Free | Pre-trade Black-Scholes pricing with full Greeks |
| `calculate_kelly` | Free | Optimal bet sizing with full/half/quarter Kelly |
| `simulate_portfolio` | Free | Monte Carlo with retirement-style withdrawals |
| `assess_portfolio_risk` | $0.04 USDC via x402 | Composite Sharpe/Sortino/Calmar/maxDD/VaR/CVaR/Kelly/Hurst audit |
| `recommend_hedge` | $0.04 USDC via x402 | Ranked hedge structures (collar, protective put, partial put, inverse) |

Free tier: 1,000 calls/IP/day with no signup or API key, covers all three calculator actions.

## Why deterministic finance math matters for agents

LLMs trying to compute Black-Scholes prices, Kelly fractions, or Monte Carlo simulations in-context drift — the numbers are wrong, the Greeks are hallucinated, and the agent can't tell. QuantOracle's API is tested against published textbook values (Hull, Wilmott, Lopez de Prado) with 120 accuracy benchmarks passing.

For agents making financial decisions, this matters: a bad Black-Scholes price is the difference between a profitable trade and a losing one.

## Implementation

Follows the existing action-provider pattern (modeled on `messari` and `pyth`):

- **`quantoracleActionProvider.ts`** — main class with `@CreateAction`-decorated methods for each action
- **`schemas.ts`** — Zod schemas with rich `.describe()` strings for the LLM
- **`constants.ts`** — API base URL (override via `QUANTORACLE_API_URL` env var)
- **`index.ts`** — re-exports
- **`README.md`** — follows the directory documentation convention (Getting Started, Actions, Rate Limiting, Usage)
- **`quantoracleActionProvider.test.ts`** — 9 jest tests covering happy-path, error-handling, and negative-edge Kelly

Also exports the new provider from `src/action-providers/index.ts` (placed alphabetically after `pyth`) and adds a changeset entry.

## Validation

- ✅ `pnpm run lint` — clean
- ✅ `pnpm run build` — clean
- ✅ `pnpm test -- quantoracle` — 9/9 passing

## Demo

Sample agent prompts the LLM can satisfy via this provider:

- _"Price a 30-day NVDA call with strike $185, spot $180, 28% IV"_ → `price_option`
- _"I have 55% win rate, $150 avg win, $100 avg loss — what's my Kelly?"_ → `calculate_kelly`
- _"Simulate $100K over 30 years with 7% return, 16% vol, 4% withdrawal"_ → `simulate_portfolio`
- _"Audit risk on my last 252 daily returns: [...]"_ → `assess_portfolio_risk` (paid)
- _"Recommend hedges for my $100K long NVDA position over 30 days"_ → `recommend_hedge` (paid)

## Resources

- **API:** https://api.quantoracle.dev (73 endpoints total; this provider surfaces a curated subset)
- **OpenAPI spec:** https://api.quantoracle.dev/openapi.json
- **Try without code:** 12 free interactive calculators backed by the same engine at https://quantoracle.dev
- **Repository:** https://github.com/QuantOracledev/quantoracle

Happy to adjust scope, copy, or implementation based on review feedback.