### PR TITLE
fix(x402): respect protocol family in network support checks

### DIFF
--- a/typescript/agentkit/src/action-providers/x402/x402ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402/x402ActionProvider.test.ts
@@ -190,6 +190,16 @@ describe("X402ActionProvider", () => {
       expect(provider.supportsNetwork(network)).toBe(true);
     });
 
+    it("should not support Solana networks with EVM protocol family", () => {
+      const network: Network = { protocolFamily: "evm", networkId: "solana-mainnet" };
+      expect(provider.supportsNetwork(network)).toBe(false);
+    });
+
+    it("should not support Base networks with SVM protocol family", () => {
+      const network: Network = { protocolFamily: "svm", networkId: "base-mainnet" };
+      expect(provider.supportsNetwork(network)).toBe(false);
+    });
+
     it("should not support non-EVM/SVM networks", () => {
       const network: Network = { protocolFamily: "bitcoin", networkId: "mainnet" };
       expect(provider.supportsNetwork(network)).toBe(false);

--- a/typescript/agentkit/src/action-providers/x402/x402ActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402/x402ActionProvider.ts
@@ -832,8 +832,22 @@ These are the only services that can be called using make_http_request or make_h
    * @param network - The network to check support for
    * @returns True if the network is supported, false otherwise
    */
-  supportsNetwork = (network: Network) =>
-    (SUPPORTED_NETWORKS as readonly string[]).includes(network.networkId!);
+  supportsNetwork = (network: Network) => {
+    if (!(SUPPORTED_NETWORKS as readonly string[]).includes(network.networkId!)) {
+      return false;
+    }
+
+    switch (network.networkId) {
+      case "base-mainnet":
+      case "base-sepolia":
+        return network.protocolFamily === "evm";
+      case "solana-mainnet":
+      case "solana-devnet":
+        return network.protocolFamily === "svm";
+      default:
+        return false;
+    }
+  };
 
   /**
    * Creates an x402 client configured for the given wallet provider.


### PR DESCRIPTION
## Description

Updates the x402 action provider network support check to validate both `networkId` and `protocolFamily`.

Previously, `supportsNetwork` only checked the network ID, so mismatched combinations such as an EVM network object with `solana-mainnet` could be reported as supported.

This keeps Base networks gated to `evm` and Solana networks gated to `svm`.

