### PR TITLE
examples(python): add langchain-krewe-inference-chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ agentkit/
 │       ├── langchain-cdp-smart-wallet-chatbot/
 │       ├── langchain-cdp-solana-chatbot/
 │       ├── langchain-eth-account-chatbot/
+│       ├── langchain-krewe-inference-chatbot/
 │       ├── langchain-nillion-secretvault-chatbot/
 │       ├── langchain-twitter-chatbot/
 │       ├── openai-agents-sdk-cdp-chatbot/

--- a/python/examples/langchain-krewe-inference-chatbot/.env.local
+++ b/python/examples/langchain-krewe-inference-chatbot/.env.local
@@ -1,0 +1,22 @@
+# Required
+CDP_API_KEY_ID=
+CDP_API_KEY_SECRET=
+CDP_WALLET_SECRET=
+OPENAI_API_KEY=
+
+# Optional — krewe is mainnet-only today. Set to base-sepolia if you've
+# pointed krewe at a sepolia orchestrator (see KREWE_PREDICT_URL below).
+NETWORK_ID=base-mainnet
+
+# Optional — override the krewe orchestrator URL (e.g. for self-hosted
+# orchestrators or staging). Defaults to the production Railway orchestrator.
+KREWE_PREDICT_URL=https://krewe-orchestrator-production.up.railway.app/v2/predict
+
+# Optional — hard ceiling on USDC per call. Defaults to $0.10. Pricing today:
+# $0.005 text.structure, $0.01 text.embed, $0.02 web.scrape, $0.05 text.complete.
+KREWE_MAX_PAYMENT_USDC=0.10
+
+# Optional account knobs (inherited from the CDP template)
+ADDRESS=
+IDEMPOTENCY_KEY=
+RPC_URL=

--- a/python/examples/langchain-krewe-inference-chatbot/Makefile
+++ b/python/examples/langchain-krewe-inference-chatbot/Makefile
@@ -1,0 +1,29 @@
+ifneq (,$(wildcard ./.env))
+	include .env
+endif
+
+export
+
+.PHONY: install
+install:
+	uv sync
+
+.PHONY: run
+run:
+	uv run chatbot.py
+
+.PHONY: format
+format:
+	uv run ruff format .
+
+.PHONY: format-check
+format-check:
+	uv run ruff format . --check
+
+.PHONY: lint
+lint:
+	uv run ruff check .
+
+.PHONY: lint-fix
+lint-fix:
+	uv run ruff check . --fix

--- a/python/examples/langchain-krewe-inference-chatbot/README.md
+++ b/python/examples/langchain-krewe-inference-chatbot/README.md
@@ -1,0 +1,101 @@
+# krewe Inference + AgentKit + LangChain — Python Chatbot
+
+This example shows how a Python LangChain agent can call **[krewe](https://www.krewe.world)** — a decentralized AI inference network on Base mainnet — using AgentKit's built-in `x402_action_provider`. Each inference call is paid per-request in USDC via the [x402 protocol](https://x402.org); no API keys or pre-paid quotas required.
+
+The agent has a CDP-managed Base wallet and four inference tools through krewe:
+
+| `kind`           | Cost   | What it does                                                          |
+| ---------------- | ------ | --------------------------------------------------------------------- |
+| `text.structure` | $0.005 | Regex/JSON extraction from unstructured text                          |
+| `text.embed`     | $0.01  | Sentence embeddings via a small quantized model                       |
+| `web.scrape`     | $0.02  | Fetch + clean a URL payload                                           |
+| `text.complete`  | $0.05  | Small-language-model completion (greedy decode, server-pinned model)  |
+
+Every USDC paid through this example flows directly back to the miners that answered the job — krewe's orchestrator sweeps payments hourly, swaps them for `$KREW` on Uniswap V4, and deposits the proceeds into the registry's reward pool.
+
+This is the Python sibling to the [TypeScript example](../../../typescript/examples/langchain-krewe-inference-chatbot/) — same orchestrator, same pricing, same auth flow, native Python idioms.
+
+## Prompts to try
+
+- `"Extract every email and date from this text: 'RSVP to hi@krewe.world by 2026-05-17 or call us 2026-05-20.'"`
+- `"Embed this sentence: 'Decentralized AI inference on Base'."`
+- `"Scrape https://www.krewe.world and tell me what the project does."`
+- `"Use krewe's text.complete to write a one-sentence summary of x402."`
+
+## Prerequisites
+
+- **Python 3.10+** — verify with `python3 --version`. Install via [pyenv](https://github.com/pyenv/pyenv) if needed.
+- **[uv](https://docs.astral.sh/uv/)** — the package manager this example uses.
+- API keys:
+  - **CDP API key** — https://portal.cdp.coinbase.com/access/api
+  - **CDP wallet secret** — https://portal.cdp.coinbase.com/products/wallet-api
+  - **OpenAI API key** — https://platform.openai.com/docs/quickstart#create-and-export-an-api-key
+
+Rename `.env.local` to `.env` and fill in:
+
+```bash
+CDP_API_KEY_ID=...
+CDP_API_KEY_SECRET=...
+CDP_WALLET_SECRET=...
+OPENAI_API_KEY=...
+
+NETWORK_ID=base-mainnet                       # krewe is mainnet-only today
+KREWE_PREDICT_URL=https://krewe-orchestrator-production.up.railway.app/v2/predict
+KREWE_MAX_PAYMENT_USDC=0.10                   # safety cap per call
+```
+
+### Funding the agent
+
+The agent's CDP wallet needs **USDC on Base mainnet** to pay for inference. The cheapest job (`text.structure`) costs $0.005, so $1 funds 200 calls. Send USDC to the wallet address printed at startup.
+
+> Note: krewe's *production* orchestrator runs only on Base mainnet today. The `NETWORK_ID=base-sepolia` path works against a self-hosted orchestrator.
+
+## Running the example
+
+From the repository root:
+
+```bash
+cd python/examples/langchain-krewe-inference-chatbot
+make install     # uv sync — installs deps + the in-tree coinbase-agentkit
+make run         # uv run chatbot.py
+```
+
+You'll be prompted for **chat** (interactive prompts) or **auto** (autonomous loop that fires a creative krewe job every 30s).
+
+## How the x402 handshake works under the hood
+
+The flow is invisible to your agent code, but worth knowing:
+
+1. Agent calls `https://krewe-orchestrator-production.up.railway.app/v2/predict` with a job body.
+2. Orchestrator returns `402 Payment Required` with a signed EIP-3009 challenge specifying the USDC `value`, `to`, `nonce`, and validity window.
+3. AgentKit's `x402_action_provider` signs the challenge with the CDP wallet (via the x402 facilitator).
+4. Orchestrator verifies the signature, submits `transferWithAuthorization` on the USDC contract, waits for confirmation, then runs the inference job through krewe's miner network.
+5. 2-of-3 byte-equal miner consensus produces the output, which is returned along with the on-chain `paymentTxHash`.
+
+Full protocol writeup: [`docs/x402.md`](https://github.com/krewe-AI/krewe/blob/main/docs/x402.md) in the krewe repo.
+
+## Without AgentKit — direct krewe Python SDK
+
+If you only need to call krewe (not the full AgentKit stack), the standalone [`krewe-x402`](https://pypi.org/project/krewe-x402/) package is simpler — no CDP wallet provider needed, just an `eth_account.Account`:
+
+```python
+from eth_account import Account
+from krewe_x402 import KreweClient
+
+with KreweClient(account=Account.from_key("0x...")) as client:
+    result = client.predict(kind="text.structure",
+                            payload={"text": "Email hi@krewe.world by 2026-05-17"})
+print(result["output"])
+```
+
+## Want a self-hosted orchestrator?
+
+The orchestrator is open-source and small (~2k LOC of TypeScript). See [`SETUP.md`](https://github.com/krewe-AI/krewe/blob/main/SETUP.md) in the krewe repo for the dev path, and [`docs/architecture.md`](https://github.com/krewe-AI/krewe/blob/main/docs/architecture.md) for the network model. Point `KREWE_PREDICT_URL` at your instance and this example works against it unchanged.
+
+## Links
+
+- krewe site: https://www.krewe.world
+- krewe repo: https://github.com/krewe-AI/krewe
+- `$KREW` on Basescan: https://basescan.org/address/0xc411E6deE1F70F57F08714D3bd54b4F36f904B07
+- x402 spec: https://x402.org
+- AgentKit docs: https://docs.cdp.coinbase.com/agentkit/docs/welcome

--- a/python/examples/langchain-krewe-inference-chatbot/chatbot.py
+++ b/python/examples/langchain-krewe-inference-chatbot/chatbot.py
@@ -1,0 +1,254 @@
+"""LangChain chatbot example: AgentKit + krewe x402-paywalled inference.
+
+The agent has a CDP-managed Base wallet and four pay-per-call inference tools
+through krewe (https://www.krewe.world), accessed via AgentKit's built-in
+x402 action provider. Each call settles per-request in USDC on Base
+(EIP-3009 ``transferWithAuthorization``) — no API keys, no provisioning.
+
+Pricing (USDC base units / 6 decimals):
+  text.structure  $0.005    text.embed       $0.01
+  web.scrape      $0.02     text.complete    $0.05
+
+Every USDC paid here flows back to the miners that answered the job via
+krewe's hourly USDC → $KREW buyback recycler. Closes the circular economy.
+"""
+
+import os
+import sys
+import time
+
+from coinbase_agentkit import (
+    AgentKit,
+    AgentKitConfig,
+    CdpEvmWalletProvider,
+    CdpEvmWalletProviderConfig,
+    X402Config,
+    cdp_api_action_provider,
+    cdp_evm_wallet_action_provider,
+    erc20_action_provider,
+    wallet_action_provider,
+    x402_action_provider,
+)
+from coinbase_agentkit_langchain import get_langchain_tools
+from dotenv import load_dotenv
+from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.prebuilt import create_react_agent
+
+load_dotenv()
+
+DEFAULT_KREWE_PREDICT_URL = "https://krewe-orchestrator-production.up.railway.app/v2/predict"
+DEFAULT_MAX_PAYMENT_USDC = 0.10
+
+
+def initialize_agent(config: CdpEvmWalletProviderConfig):
+    """Initialize the LangChain agent with AgentKit + krewe x402 inference.
+
+    Args:
+        config: Configuration for the CDP EVM Server Wallet Provider.
+
+    Returns:
+        tuple[Agent, CdpEvmWalletProvider]: The initialized agent and wallet provider.
+    """
+    llm = ChatOpenAI(model="gpt-4o-mini")
+
+    wallet_provider = CdpEvmWalletProvider(
+        CdpEvmWalletProviderConfig(
+            api_key_id=config.api_key_id,
+            api_key_secret=config.api_key_secret,
+            wallet_secret=config.wallet_secret,
+            network_id=config.network_id,
+            address=config.address,
+            idempotency_key=config.idempotency_key,
+            rpc_url=config.rpc_url,
+        )
+    )
+
+    krewe_url = os.getenv("KREWE_PREDICT_URL", DEFAULT_KREWE_PREDICT_URL)
+    max_payment_usdc = float(os.getenv("KREWE_MAX_PAYMENT_USDC", DEFAULT_MAX_PAYMENT_USDC))
+
+    agentkit = AgentKit(
+        AgentKitConfig(
+            wallet_provider=wallet_provider,
+            action_providers=[
+                cdp_api_action_provider(),
+                cdp_evm_wallet_action_provider(),
+                erc20_action_provider(),
+                wallet_action_provider(),
+                x402_action_provider(
+                    X402Config(
+                        registered_services=[krewe_url],
+                        allow_dynamic_service_registration=False,
+                        max_payment_usdc=max_payment_usdc,
+                        registered_facilitators={},
+                    )
+                ),
+            ],
+        )
+    )
+
+    tools = get_langchain_tools(agentkit)
+
+    memory = MemorySaver()
+    agent_config = {"configurable": {"thread_id": "krewe Inference Chatbot Example"}}
+
+    return (
+        create_react_agent(
+            llm,
+            tools=tools,
+            checkpointer=memory,
+            state_modifier=(
+                f"You are an onchain agent with access to:\n"
+                f"  - A CDP EVM wallet on Base.\n"
+                f"  - The krewe inference network at {krewe_url}, called via the x402 "
+                f"action provider. krewe is a decentralized AI inference network — your "
+                f"wallet pays USDC per call (cap: ${max_payment_usdc}). The supported "
+                f"job kinds are text.structure (regex/JSON extraction, $0.005), "
+                f"text.embed (sentence embeddings, $0.01), web.scrape (clean HTML "
+                f"fetch, $0.02), and text.complete (small-LM completion, $0.05).\n\n"
+                f"When a user asks for structured extraction, embeddings, a clean "
+                f"scrape, or a quick small-model completion, prefer routing through "
+                f"krewe via the x402 service — it pays krewe miners and gets a 2-of-3 "
+                f"consensus output.\n\n"
+                f'Always send the body: {{"kind": "...", "payload": <kind-specific JSON>}}. '
+                f"If a call returns 402 'payment-required', the x402 provider handles "
+                f"signing and on-chain settlement automatically — just retry once via "
+                f"the same tool.\n\n"
+                f"Be concise. If you can't do something with your current tools, say so."
+            ),
+        ),
+        wallet_provider,
+    ), agent_config
+
+
+def setup():
+    """Set up the agent with persistent wallet storage.
+
+    Returns:
+        tuple[Agent, dict]: The initialized agent and its configuration.
+    """
+    network_id = os.getenv("NETWORK_ID", "base-mainnet")
+    wallet_file = f"wallet_data_{network_id.replace('-', '_')}.txt"
+
+    # Load existing wallet data if available
+    wallet_data: dict = {}
+    if os.path.exists(wallet_file):
+        try:
+            import json
+
+            with open(wallet_file) as f:
+                wallet_data = json.load(f)
+                print(f"Loading existing wallet from {wallet_file}")
+        except json.JSONDecodeError:
+            print(f"Warning: Invalid wallet data for {network_id}")
+            wallet_data = {}
+
+    wallet_address = wallet_data.get("address") or os.getenv("ADDRESS") or None
+
+    config = CdpEvmWalletProviderConfig(
+        api_key_id=os.getenv("CDP_API_KEY_ID"),
+        api_key_secret=os.getenv("CDP_API_KEY_SECRET"),
+        wallet_secret=os.getenv("CDP_WALLET_SECRET"),
+        network_id=network_id,
+        address=wallet_address,
+        idempotency_key=(os.getenv("IDEMPOTENCY_KEY") if not wallet_address else None),
+        rpc_url=os.getenv("RPC_URL"),
+    )
+
+    (agent_executor, wallet_provider), agent_config = initialize_agent(config)
+
+    import json
+
+    new_wallet_data = {
+        "address": wallet_provider.get_address(),
+        "network_id": network_id,
+        "created_at": time.strftime("%Y-%m-%d %H:%M:%S")
+        if not wallet_data
+        else wallet_data.get("created_at"),
+    }
+    with open(wallet_file, "w") as f:
+        json.dump(new_wallet_data, f, indent=2)
+        print(f"Wallet data saved to {wallet_file}")
+
+    return (agent_executor, agent_config)
+
+
+def run_autonomous_mode(agent_executor, config, interval=30):
+    """Run the agent autonomously — picks a creative krewe inference job each tick."""
+    print("Starting autonomous mode...")
+    while True:
+        try:
+            thought = (
+                "Pick an interesting short snippet of text or a public URL and route a "
+                "krewe job through the x402 service to do something useful with it "
+                "(extract structured data, embed, summarize, or scrape). Tell me the "
+                "kind you chose, the payment cost, and the resulting output."
+            )
+            for chunk in agent_executor.stream(
+                {"messages": [HumanMessage(content=thought)]}, config
+            ):
+                if "agent" in chunk:
+                    print(chunk["agent"]["messages"][0].content)
+                elif "tools" in chunk:
+                    print(chunk["tools"]["messages"][0].content)
+                print("-------------------")
+            time.sleep(interval)
+        except KeyboardInterrupt:
+            print("Goodbye Agent!")
+            sys.exit(0)
+
+
+def run_chat_mode(agent_executor, config):
+    """Run the agent interactively based on user input."""
+    print("Starting chat mode... Type 'exit' to end.")
+    print(
+        'Try: "Extract emails and dates from this text: '
+        'Email hi@krewe.world by 2026-05-17"'
+    )
+    while True:
+        try:
+            user_input = input("\nPrompt: ")
+            if user_input.lower() == "exit":
+                break
+            for chunk in agent_executor.stream(
+                {"messages": [HumanMessage(content=user_input)]}, config
+            ):
+                if "agent" in chunk:
+                    print(chunk["agent"]["messages"][0].content)
+                elif "tools" in chunk:
+                    print(chunk["tools"]["messages"][0].content)
+                print("-------------------")
+        except KeyboardInterrupt:
+            print("Goodbye Agent!")
+            sys.exit(0)
+
+
+def choose_mode():
+    """Choose whether to run in autonomous or chat mode based on user input."""
+    while True:
+        print("\nAvailable modes:")
+        print("1. chat    - Interactive chat mode")
+        print("2. auto    - Autonomous action mode")
+        choice = input("\nChoose a mode (enter number or name): ").lower().strip()
+        if choice in ["1", "chat"]:
+            return "chat"
+        elif choice in ["2", "auto"]:
+            return "auto"
+        print("Invalid choice. Please try again.")
+
+
+def main():
+    """Start the chatbot agent."""
+    load_dotenv()
+    agent_executor, agent_config = setup()
+    mode = choose_mode()
+    if mode == "chat":
+        run_chat_mode(agent_executor=agent_executor, config=agent_config)
+    elif mode == "auto":
+        run_autonomous_mode(agent_executor=agent_executor, config=agent_config)
+
+
+if __name__ == "__main__":
+    print("Starting krewe-inference Agent...")
+    main()

--- a/python/examples/langchain-krewe-inference-chatbot/pyproject.toml
+++ b/python/examples/langchain-krewe-inference-chatbot/pyproject.toml
@@ -1,0 +1,49 @@
+[project]
+name = "krewe-inference-langchain-chatbot"
+version = "0.0.1"
+description = "AgentKit + LangChain chatbot using krewe's x402-paywalled decentralized AI inference network on Base mainnet"
+authors = [{ name = "krewe", email = "hi@krewe.world" }]
+requires-python = "~=3.10"
+readme = "README.md"
+dependencies = [
+    "python-dotenv>=1.0.1,<2",
+    "langchain-openai>=0.2.4,<0.3",
+    "langgraph>=0.2.39,<0.3",
+    "coinbase-agentkit",
+    "coinbase-agentkit-langchain",
+]
+
+[dependency-groups]
+dev = ["ruff>=0.7.1,<0.8"]
+
+[tool.uv]
+package = false
+
+[tool.uv.sources]
+coinbase-agentkit = { path = "../../../python/coinbase-agentkit", editable = true }
+coinbase-agentkit-langchain = { path = "../../../python/framework-extensions/langchain", editable = true }
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.langchain-krewe-inference-chatbot]
+private = true
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+exclude = ["./build/**", "./dist/**", "./docs/**"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "D", "UP", "B", "C4", "SIM", "RUF"]
+ignore = ["D213", "D203", "D100", "D104", "D107", "E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint.isort]
+known-first-party = ["coinbase_agentkit, cdp"]


### PR DESCRIPTION
## Summary

Adds the Python sibling to the TypeScript example proposed in #1222: a LangChain chatbot that uses AgentKit's built-in `x402_action_provider` to call **[krewe](https://www.krewe.world)** — a decentralized AI inference network on Base mainnet — for four pay-per-call job kinds.

Same orchestrator, same pricing table, same handshake — just native Python idioms and the canonical `langchain-cdp-chatbot` example structure.

### Why both PRs

The agent ecosystem splits roughly 50/50 between TypeScript (Vercel AI SDK, Mastra, agentkit-langchain TS) and Python (LangChain Python, autogen, CrewAI, pydantic-ai). Shipping only one half leaves the other audience locked out of the `x402` action provider pattern. These two PRs together demonstrate the canonical *\"x402-paywalled inference as a first-class agent tool\"* recipe against a real production endpoint, on both sides of the monorepo.

### What's in this PR

- `python/examples/langchain-krewe-inference-chatbot/chatbot.py` — entrypoint, mirrors `langchain-cdp-chatbot/chatbot.py` (chat + autonomous modes, identical CDP wallet wiring, persistent wallet file). Only the action-provider list and the system prompt differ.
- `pyproject.toml` — uv-managed, lifted from `langchain-cdp-chatbot` with only the package name + description changed. Same dep pins, same ruff config, same `[tool.uv.sources]` workspace deps.
- `Makefile` — identical install / run / lint / format targets.
- `.env.local` — adds `NETWORK_ID`, `KREWE_PREDICT_URL`, `KREWE_MAX_PAYMENT_USDC` (all with sensible defaults).
- `README.md` — prompts to try, prerequisites, env vars, run instructions, plus a section on the standalone [`krewe-x402` PyPI package](https://pypi.org/project/krewe-x402/) for callers who don't need the full AgentKit stack.
- Root `README.md` — adds the new example to the Python directory tree (alphabetically between `langchain-eth-account-chatbot` and `langchain-nillion-secretvault-chatbot`).

### Pricing surfaced in the system prompt

| `kind` | Cost |
|---|---|
| `text.structure` | \$0.005 |
| `text.embed` | \$0.01 |
| `web.scrape` | \$0.02 |
| `text.complete` | \$0.05 |

Quoted server-side per call; AgentKit's `max_payment_usdc` ceiling (default $0.10 in this example) protects against unexpected prices.

### Production endpoint verified

The orchestrator at `https://krewe-orchestrator-production.up.railway.app/v2/predict` is live and returns the documented `WWW-Authenticate: x402 scheme=\"x402-eip3009-usdc\"` header on the 402 challenge — verified by hand with the existing `x402_action_provider`.

### Test plan
- [x] `chatbot.py` mirrors the proven `langchain-cdp-chatbot` template structure — wallet config, agent setup, chat/auto loops are identical patterns.
- [x] x402 challenge against the production endpoint verified by hand: `curl -X POST .../v2/predict` returns 402 with the documented challenge JSON and `WWW-Authenticate` header.
- [x] Tooling files (`pyproject.toml`, `Makefile`, ruff config) lifted verbatim from `langchain-cdp-chatbot` to match repo conventions.
- [x] Root `README.md` Python examples tree updated alphabetically.

Happy to tweak the system prompt wording, the bundled action-provider list, or the env-var naming.

---

Companion PR: [#1222](https://github.com/coinbase/agentkit/pull/1222) (TypeScript sibling).

Links:
- krewe site: https://www.krewe.world
- krewe repo: https://github.com/krewe-AI/krewe
- x402 protocol docs (krewe-side): https://github.com/krewe-AI/krewe/blob/main/docs/x402.md
- \$KREW on Basescan: https://basescan.org/address/0xc411E6deE1F70F57F08714D3bd54b4F36f904B07
- Standalone Python SDK: https://pypi.org/project/krewe-x402/ (and source at https://github.com/krewe-AI/krewe/tree/main/clients/krewe-x402-python)