### PR TITLE
docs: fix typo in advertisements agent README

### DIFF
--- a/python/examples/advertisements-agent-with-strands-agents-x402-cdp-chatbot/README.md
+++ b/python/examples/advertisements-agent-with-strands-agents-x402-cdp-chatbot/README.md
@@ -50,7 +50,7 @@ The sample demonstrates integration between multiple systems:
    uv sync
    ```
 
-3. **Start the payment server on a seperate terminal:**
+3. **Start the payment server on a separate terminal:**
    ```bash
    uv run paid_server.py
    ```


### PR DESCRIPTION
Fixes a small typo in the advertisements agent example README: "seperate" -> "separate".

No code changes.