### PR TITLE
feat(action-provider): add @vdm-nexus action provider — signed inference for agents

### DIFF
--- a/typescript/.changeset/vdm-nexus-action-provider.md
+++ b/typescript/.changeset/vdm-nexus-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added vdm-nexus action provider — signed inference via x402 on Solana with verifiable receipts.

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -73,7 +73,8 @@
     "sushi": "6.2.1",
     "twitter-api-v2": "^1.18.2",
     "viem": "2.47.4",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@vdm-nexus/x402": "^0.4.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -28,6 +28,7 @@ export * from "./superfluid";
 export * from "./sushi";
 export * from "./truemarkets";
 export * from "./twitter";
+export * from "./vdm-nexus";
 export * from "./wallet";
 export * from "./weth";
 export * from "./wow";

--- a/typescript/agentkit/src/action-providers/vdm-nexus/README.md
+++ b/typescript/agentkit/src/action-providers/vdm-nexus/README.md
@@ -1,0 +1,101 @@
+# VDM Nexus Action Provider
+
+This directory contains the **VdmNexusActionProvider** implementation, which exposes [VDM Nexus](https://vdmnexus.com) — a signed-inference rail — as a tool surface inside any AgentKit-built agent.
+
+Every paid `nexus_chat` call settles a USDC payment inline via [x402](https://github.com/coinbase/x402) and returns the OpenAI chat completion alongside a Signed Inference Receipt ([SIR v2](https://docs.vdmnexus.com/docs/spec/sir-v2)) anchored to the on-chain settlement transaction. Receipts are independently verifiable — a third party can confirm what the model returned without trusting the caller or the service operator.
+
+First mainnet receipt: <https://vdmnexus.com/r/c9710ea7-9e1f-46ee-aaa9-903a536ae12e>
+
+## Directory Structure
+
+```
+vdm-nexus/
+├── vdmNexusActionProvider.ts          # Main provider with the three actions
+├── vdmNexusActionProvider.test.ts     # Jest tests
+├── schemas.ts                         # Zod input schemas
+├── index.ts                           # Public exports
+└── README.md                          # This file
+```
+
+## Usage
+
+```typescript
+import { AgentKit, SolanaKeypairWalletProvider } from "@coinbase/agentkit";
+import { vdmNexusActionProvider } from "@coinbase/agentkit";
+
+const walletProvider = await SolanaKeypairWalletProvider.fromNetwork(
+  "solana-mainnet",
+  process.env.SOLANA_PRIVATE_KEY!,
+);
+
+const agentKit = await AgentKit.from({
+  walletProvider,
+  actionProviders: [vdmNexusActionProvider()],
+});
+```
+
+The wallet attached to AgentKit IS the agent identity — its keypair signs the SPL USDC transfer carried in the x402 `X-Payment` header. No separate agent secret env var is required.
+
+## Configuration
+
+```typescript
+vdmNexusActionProvider({
+  // Point at a different deployment (e.g. self-hosted)
+  endpoint: "https://nexus.example.com/api/v1",
+
+  // Pin the operator pubkey for offline verification. When omitted, the
+  // verifier fetches it from `${endpoint}/operator-key` on first use.
+  operatorKey: "<base58 Ed25519 pubkey>",
+});
+```
+
+## Actions
+
+### `nexus_chat`
+
+Pay-per-call signed inference. Performs the x402 two-roundtrip handshake (probe → sign → paid), runs the inference upstream, and returns the OpenAI chat completion plus the SIR v2 receipt and the settlement record.
+
+**Inputs:** `model`, `messages`, optional `network` override.
+
+**Returns:** `{ ok, openai, receipt, payment }` on success; `{ ok: false, error, ... }` on failure.
+
+### `nexus_verify_receipt`
+
+Run the five-check SIR v2 verifier against a receipt, prompt, and response. Confirms:
+
+1. `prompt_hash_ok` — sha256(prompt) matches `receipt.prompt_hash`
+2. `response_hash_ok` — sha256(response) matches `receipt.response_hash`
+3. `nexus_signature_ok` — operator Ed25519 signature is valid
+4. `payment_on_chain_ok` — settlement tx landed at the recipient
+5. `payer_matches` — tx payer equals `receipt.agent_pubkey`
+
+**Returns:** `{ ok, checks }` with the full breakdown so the agent can act on partial failures.
+
+### `nexus_get_deposit_address`
+
+Fetch the on-chain USDC deposit address for prepaid credit top-ups. Per-call x402 settlement via `nexus_chat` does **not** require this — it settles inline. Use this only when batching deposits is cheaper than per-call settlement (high-volume agents).
+
+**Returns:** `{ ok, address, mint, network }`.
+
+## Network Support
+
+| Network | CAIP-2 | Status |
+|---|---|---|
+| Solana mainnet | `solana:mainnet` | Live |
+| Solana devnet | `solana:devnet` | Live |
+
+`supportsNetwork` returns true for any SVM (`network.protocolFamily === "svm"`) network. An EVM-bound sibling provider for Base mainnet/Sepolia settlement is on the roadmap.
+
+## Why signed inference?
+
+- **Audit trails.** Every inference call produces a tamper-evident receipt the caller can verify cryptographically. Useful for compliance regimes that require evidence of what a model returned (EU AI Act Article 12, NIST AI agent standards, OWASP LLM Top 10 logging).
+- **Trustless multi-agent flows.** Agent A can hand Agent B a receipt; Agent B can verify it without trusting Agent A — the operator's Ed25519 signature plus the on-chain settlement record are the trust anchor.
+- **Pay-per-call autonomy.** No prepaid balance to babysit. The wallet pays inline.
+
+## Specification
+
+The Signed Inference Receipt v2 wire format and verification rules are documented at <https://docs.vdmnexus.com/docs/spec/sir-v2>.
+
+## Relationship to the existing `x402` action provider
+
+The upstream [`x402` action provider](../x402/README.md) is a general-purpose client for calling any x402-protected API. `vdm-nexus` is a higher-level adapter targeting one specific x402 rail (Nexus) and adding the verifiable-receipt semantics on top — the wire-level handshake is the same, but the receipt verification, model selection, and OpenAI response shape are specific to the Nexus deployment. Use `x402` when you want to call arbitrary paid APIs; use `vdm-nexus` when you specifically want paid LLM inference with cryptographic receipts.

--- a/typescript/agentkit/src/action-providers/vdm-nexus/index.ts
+++ b/typescript/agentkit/src/action-providers/vdm-nexus/index.ts
@@ -1,0 +1,2 @@
+export * from "./vdmNexusActionProvider";
+export { NexusChatSchema, NexusVerifyReceiptSchema, NexusGetDepositAddressSchema } from "./schemas";

--- a/typescript/agentkit/src/action-providers/vdm-nexus/schemas.ts
+++ b/typescript/agentkit/src/action-providers/vdm-nexus/schemas.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+/**
+ * OpenAI-shape chat message.
+ */
+const ChatMessageSchema = z.object({
+  role: z.enum(["system", "user", "assistant"]),
+  content: z.string(),
+});
+
+/**
+ * Input schema for the `nexus_chat` action.
+ *
+ * Mirrors the OpenAI chat completions request shape. The optional `network`
+ * field selects the settlement chain — must match a chain the configured
+ * wallet can sign for. For an `SvmWalletProvider`-bound provider, valid
+ * values are `solana:mainnet` and `solana:devnet`.
+ */
+export const NexusChatSchema = z
+  .object({
+    model: z
+      .string()
+      .describe(
+        'OpenRouter-style model slug, e.g. "openai/gpt-4o-mini", "anthropic/claude-3-haiku".',
+      ),
+    messages: z.array(ChatMessageSchema).min(1).describe("OpenAI-shape chat messages array."),
+    network: z
+      .string()
+      .optional()
+      .describe(
+        'Optional CAIP-2 settlement network override. Must match the wallet\'s chain — e.g. "solana:mainnet" or "solana:devnet". Omit to use the server default.',
+      ),
+  })
+  .describe(
+    "Pay-per-call signed inference against a VDM Nexus endpoint. " +
+      "Returns the OpenAI chat completion plus a Signed Inference Receipt (SIR v2) " +
+      "anchored to an on-chain USDC settlement transaction.",
+  );
+
+/**
+ * Input schema for the `nexus_verify_receipt` action.
+ *
+ * Takes the original receipt + prompt + response and runs the five-check
+ * SIR v2 verification: hash recompute (prompt + response), operator Ed25519
+ * signature, on-chain settlement tx, payer identity.
+ */
+export const NexusVerifyReceiptSchema = z
+  .object({
+    receipt: z
+      .unknown()
+      .describe(
+        "The Signed Inference Receipt (SIR v2) to verify, as returned by `nexus_chat` in the `receipt` field.",
+      ),
+    prompt: z
+      .union([z.string(), z.array(ChatMessageSchema)])
+      .describe(
+        "The prompt the receipt covers. For x402 chat-completion receipts, pass the `messages` array you sent. For prepaid `/inference` receipts, pass the raw prompt string.",
+      ),
+    response: z
+      .union([z.string(), z.unknown()])
+      .describe(
+        "The response the receipt covers. For x402 chat-completion receipts, pass the OpenAI response body. For prepaid receipts, pass the raw response string.",
+      ),
+    endpoint: z
+      .string()
+      .optional()
+      .describe(
+        "Optional Nexus base URL (e.g. https://nexus.vdmnexus.com). Used to fetch the operator public key when `operatorKey` is not supplied.",
+      ),
+    operatorKey: z
+      .string()
+      .optional()
+      .describe(
+        "Optional base58 Ed25519 operator public key. If omitted, fetched from the endpoint's `/api/v1/operator-key`.",
+      ),
+    rpc: z
+      .string()
+      .optional()
+      .describe(
+        "Optional RPC URL override for the on-chain payment check. Defaults are derived from `receipt.payment.network`.",
+      ),
+  })
+  .describe(
+    "Run the five-check SIR v2 verification: prompt_hash_ok, response_hash_ok, " +
+      "nexus_signature_ok, payment_on_chain_ok, payer_matches. Returns the full " +
+      "check breakdown so the agent can act on partial failures.",
+  );
+
+/**
+ * Input schema for the `nexus_get_deposit_address` action.
+ */
+export const NexusGetDepositAddressSchema = z
+  .object({
+    network: z
+      .string()
+      .optional()
+      .describe(
+        'Optional CAIP-2 network override, e.g. "solana:mainnet". Omit to use the endpoint default.',
+      ),
+  })
+  .describe(
+    "Returns the USDC deposit address agents should send funds to in order to top up their prepaid credit balance on a Nexus deployment. " +
+      "Per-call x402 settlement via `nexus_chat` does NOT require this — it settles inline.",
+  );

--- a/typescript/agentkit/src/action-providers/vdm-nexus/vdmNexusActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/vdm-nexus/vdmNexusActionProvider.test.ts
@@ -1,0 +1,409 @@
+// Mocks for ESM-only transitive deps (loaded via wallet-providers ←
+// actionProvider ← our provider). These must be declared before any
+// imports because jest hoists `jest.mock(...)` to the top of the file.
+jest.mock("jose", () => ({}));
+jest.mock("@coinbase/cdp-sdk", () => ({}));
+
+import { verifyReceipt } from "@vdm-nexus/x402";
+import { x402Client } from "@x402/fetch";
+import { vdmNexusActionProvider, VdmNexusActionProvider } from "./vdmNexusActionProvider";
+import { NexusChatSchema, NexusVerifyReceiptSchema, NexusGetDepositAddressSchema } from "./schemas";
+import { SvmWalletProvider } from "../../wallet-providers";
+
+jest.mock("@vdm-nexus/x402", () => ({
+  verifyReceipt: jest.fn(),
+}));
+
+jest.mock("@x402/svm", () => ({
+  toClientSvmSigner: jest.fn(() => ({ kind: "mock-signer" })),
+}));
+
+jest.mock("@x402/svm/exact/client", () => ({
+  ExactSvmScheme: jest.fn().mockImplementation(() => ({ kind: "mock-scheme" })),
+}));
+
+jest.mock("@x402/fetch", () => ({
+  x402Client: jest.fn(),
+}));
+
+const verifyReceiptMock = verifyReceipt as jest.MockedFunction<typeof verifyReceipt>;
+const x402ClientMock = x402Client as unknown as jest.Mock;
+
+const MOCK_ENDPOINT = "https://nexus.example.com/api/v1";
+const MOCK_RECEIPT = {
+  v: 2,
+  agent_pubkey: "BSKq2XtBCXHGZKvP9KStjJdpimTAJbmRP7FqZ1SBTshR",
+  model: "openai/gpt-4o-mini",
+  cost_usdc: 0.01,
+  prompt_hash: "abc",
+  response_hash: "def",
+  inference_id: "test-receipt-id",
+  nexus_signature: "sig",
+};
+
+/**
+ * Encode an object as a base64 JSON string — mirrors the action provider's
+ * own header encoder so tests can construct realistic response headers.
+ *
+ * @param obj - The object to serialize.
+ * @returns The base64-encoded JSON string.
+ */
+function encodeHeader(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj), "utf8").toString("base64");
+}
+
+describe("VdmNexusActionProvider", () => {
+  const fetchMock = jest.fn();
+  global.fetch = fetchMock as unknown as typeof global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchMock.mockReset();
+  });
+
+  describe("schema validation", () => {
+    describe("NexusChatSchema", () => {
+      it("accepts a minimal valid input", () => {
+        const r = NexusChatSchema.safeParse({
+          model: "openai/gpt-4o-mini",
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(r.success).toBe(true);
+      });
+
+      it("accepts a per-call network override", () => {
+        const r = NexusChatSchema.safeParse({
+          model: "openai/gpt-4o-mini",
+          messages: [{ role: "user", content: "hi" }],
+          network: "solana:mainnet",
+        });
+        expect(r.success).toBe(true);
+      });
+
+      it("rejects empty messages", () => {
+        const r = NexusChatSchema.safeParse({
+          model: "openai/gpt-4o-mini",
+          messages: [],
+        });
+        expect(r.success).toBe(false);
+      });
+
+      it("rejects unknown role", () => {
+        const r = NexusChatSchema.safeParse({
+          model: "openai/gpt-4o-mini",
+          messages: [{ role: "tool", content: "hi" }],
+        });
+        expect(r.success).toBe(false);
+      });
+    });
+
+    describe("NexusVerifyReceiptSchema", () => {
+      it("accepts messages-array prompt + object response", () => {
+        const r = NexusVerifyReceiptSchema.safeParse({
+          receipt: MOCK_RECEIPT,
+          prompt: [{ role: "user", content: "hi" }],
+          response: { choices: [] },
+        });
+        expect(r.success).toBe(true);
+      });
+
+      it("accepts string prompt + string response (prepaid receipt shape)", () => {
+        const r = NexusVerifyReceiptSchema.safeParse({
+          receipt: MOCK_RECEIPT,
+          prompt: "what is 2+2?",
+          response: "4",
+        });
+        expect(r.success).toBe(true);
+      });
+    });
+
+    describe("NexusGetDepositAddressSchema", () => {
+      it("accepts an empty input", () => {
+        const r = NexusGetDepositAddressSchema.safeParse({});
+        expect(r.success).toBe(true);
+      });
+
+      it("accepts a network override", () => {
+        const r = NexusGetDepositAddressSchema.safeParse({ network: "solana:mainnet" });
+        expect(r.success).toBe(true);
+      });
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    const provider = vdmNexusActionProvider();
+
+    it("returns true for SVM networks", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "svm",
+          networkId: "solana-mainnet",
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false for EVM networks", () => {
+      expect(
+        provider.supportsNetwork({
+          protocolFamily: "evm",
+          networkId: "base-mainnet",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("nexusGetDepositAddress", () => {
+    it("returns the address on success", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          address: "4nTiDhEbCFJtfPsi49rPGam8R5azUQNZHpb49CLYxiSv",
+          mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          network: "solana:mainnet",
+        }),
+      });
+
+      const provider = vdmNexusActionProvider({ endpoint: MOCK_ENDPOINT });
+      const result = await provider.nexusGetDepositAddress({});
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.address).toBe("4nTiDhEbCFJtfPsi49rPGam8R5azUQNZHpb49CLYxiSv");
+      expect(parsed.network).toBe("solana:mainnet");
+      expect(fetchMock).toHaveBeenCalledWith(`${MOCK_ENDPOINT}/deposit-address`);
+    });
+
+    it("passes the network query param when supplied", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ address: "x", mint: "y", network: "solana:devnet" }),
+      });
+
+      const provider = vdmNexusActionProvider({ endpoint: MOCK_ENDPOINT });
+      await provider.nexusGetDepositAddress({ network: "solana:devnet" });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${MOCK_ENDPOINT}/deposit-address?network=solana%3Adevnet`,
+      );
+    });
+
+    it("returns an error result on non-2xx", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+
+      const provider = vdmNexusActionProvider({ endpoint: MOCK_ENDPOINT });
+      const result = await provider.nexusGetDepositAddress({});
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toBe("deposit_address_fetch_failed");
+      expect(parsed.status).toBe(503);
+    });
+  });
+
+  describe("nexusVerifyReceipt", () => {
+    it("delegates to verifyReceipt and returns the check breakdown", async () => {
+      verifyReceiptMock.mockResolvedValueOnce({
+        ok: true,
+        checks: {
+          prompt_hash_ok: true,
+          response_hash_ok: true,
+          nexus_signature_ok: true,
+          payment_on_chain_ok: true,
+          payer_matches: true,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const provider = vdmNexusActionProvider({
+        endpoint: MOCK_ENDPOINT,
+        operatorKey: "pinned-key",
+      });
+      const result = await provider.nexusVerifyReceipt({
+        receipt: MOCK_RECEIPT,
+        prompt: [{ role: "user", content: "hi" }],
+        response: { choices: [] },
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.checks.nexus_signature_ok).toBe(true);
+      expect(verifyReceiptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: MOCK_ENDPOINT,
+          operatorKey: "pinned-key",
+        }),
+      );
+    });
+
+    it("returns a verify_failed error when the verifier throws", async () => {
+      verifyReceiptMock.mockRejectedValueOnce(new Error("rpc dead"));
+
+      const provider = vdmNexusActionProvider();
+      const result = await provider.nexusVerifyReceipt({
+        receipt: MOCK_RECEIPT,
+        prompt: "what is 2+2?",
+        response: "4",
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toBe("verify_failed");
+      expect(parsed.detail).toBe("rpc dead");
+    });
+  });
+
+  describe("nexusChat", () => {
+    /**
+     * Build a stub SvmWalletProvider whose getKeyPairSigner returns a
+     * placeholder — the @x402/svm import is mocked so the placeholder is
+     * never actually used.
+     *
+     * @returns A typed stub SvmWalletProvider.
+     */
+    function mockWallet(): SvmWalletProvider {
+      return {
+        getKeyPairSigner: jest.fn().mockResolvedValue({ address: "mock-pubkey" }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+    }
+
+    /**
+     * Wire the next x402Client construction to return a client whose
+     * createPaymentPayload resolves to the given canned payment object.
+     *
+     * @param payment - The payment payload the mock client should return.
+     */
+    function mockX402Client(payment: object) {
+      x402ClientMock.mockImplementationOnce(() => ({
+        register: jest.fn(),
+        createPaymentPayload: jest.fn().mockResolvedValue(payment),
+      }));
+    }
+
+    it("runs the full handshake and returns the receipt", async () => {
+      const challenge = { accepts: [{ network: "solana:mainnet", scheme: "exact" }] };
+      const payment = { network: "solana:mainnet", scheme: "exact", payload: "signed" };
+      const openai = { id: "chatcmpl-xyz", choices: [{ message: { content: "hi" } }] };
+
+      fetchMock
+        .mockResolvedValueOnce({
+          status: 402,
+          headers: {
+            get: (k: string) => (k === "x-payment-required" ? encodeHeader(challenge) : null),
+          },
+          text: async () => "",
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: {
+            get: (k: string) => {
+              if (k === "x-nexus-receipt") return encodeHeader(MOCK_RECEIPT);
+              if (k === "x-payment-response") return encodeHeader({ transaction: "tx-sig" });
+              return null;
+            },
+          },
+          json: async () => openai,
+        });
+
+      mockX402Client(payment);
+
+      const provider = vdmNexusActionProvider({ endpoint: MOCK_ENDPOINT });
+      const result = await provider.nexusChat(mockWallet(), {
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(true);
+      expect(parsed.openai.id).toBe("chatcmpl-xyz");
+      expect(parsed.receipt.inference_id).toBe("test-receipt-id");
+      expect(parsed.payment.transaction).toBe("tx-sig");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns an error if the probe does not return 402", async () => {
+      fetchMock.mockResolvedValueOnce({
+        status: 500,
+        headers: { get: () => null },
+        text: async () => "boom",
+      });
+
+      const provider = vdmNexusActionProvider({ endpoint: MOCK_ENDPOINT });
+      const result = await provider.nexusChat(mockWallet(), {
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toBe("x402_probe_failed");
+    });
+
+    it("returns x402_missing_challenge when the 402 has no challenge header", async () => {
+      fetchMock.mockResolvedValueOnce({
+        status: 402,
+        headers: { get: () => null },
+        text: async () => "",
+      });
+
+      const provider = vdmNexusActionProvider({ endpoint: MOCK_ENDPOINT });
+      const result = await provider.nexusChat(mockWallet(), {
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toBe("x402_missing_challenge");
+    });
+
+    it("returns x402_payment_replay on 409 from the paid retry", async () => {
+      const challenge = { accepts: [{ network: "solana:mainnet", scheme: "exact" }] };
+
+      fetchMock
+        .mockResolvedValueOnce({
+          status: 402,
+          headers: {
+            get: (k: string) => (k === "x-payment-required" ? encodeHeader(challenge) : null),
+          },
+          text: async () => "",
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 409,
+          headers: { get: () => null },
+          json: async () => ({}),
+        });
+
+      mockX402Client({ network: "solana:mainnet", scheme: "exact" });
+
+      const provider = vdmNexusActionProvider({ endpoint: MOCK_ENDPOINT });
+      const result = await provider.nexusChat(mockWallet(), {
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toBe("x402_payment_replay");
+    });
+  });
+
+  describe("constructor", () => {
+    it("normalizes a trailing-slash endpoint", () => {
+      const provider = new VdmNexusActionProvider({
+        endpoint: "https://example.com/api/v1/",
+      });
+      // Indirect check: a subsequent fetch should target the path without
+      // a doubled slash.
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ address: "x", mint: "y", network: "solana:mainnet" }),
+      });
+      return provider.nexusGetDepositAddress({}).then(() => {
+        expect(fetchMock).toHaveBeenCalledWith("https://example.com/api/v1/deposit-address");
+      });
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/vdm-nexus/vdmNexusActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/vdm-nexus/vdmNexusActionProvider.ts
@@ -1,0 +1,368 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { Network } from "../../network";
+import { CreateAction } from "../actionDecorator";
+import { SvmWalletProvider } from "../../wallet-providers";
+import { x402Client } from "@x402/fetch";
+import { ExactSvmScheme } from "@x402/svm/exact/client";
+import { toClientSvmSigner } from "@x402/svm";
+import {
+  verifyReceipt,
+  type NexusReceipt,
+  type ChatMessage,
+  type OpenAIChatCompletion,
+  type PaymentPayload,
+  type PaymentRequired,
+  type X402PaymentResponse,
+} from "@vdm-nexus/x402";
+import { NexusChatSchema, NexusVerifyReceiptSchema, NexusGetDepositAddressSchema } from "./schemas";
+
+const DEFAULT_ENDPOINT = "https://nexus.vdmnexus.com/api/v1";
+
+const PAYMENT_HEADER = "x-payment";
+const PAYMENT_REQUIRED_HEADER = "x-payment-required";
+const PAYMENT_RESPONSE_HEADER = "x-payment-response";
+const RECEIPT_HEADER = "x-nexus-receipt";
+
+/**
+ * Configuration options for the VDM Nexus action provider.
+ */
+export interface VdmNexusActionProviderConfig {
+  /**
+   * Base URL of the Nexus deployment to target, including the version
+   * prefix. Defaults to the public production endpoint.
+   *
+   * @default "https://nexus.vdmnexus.com/api/v1"
+   */
+  endpoint?: string;
+
+  /**
+   * Optional base58 Ed25519 operator public key to pin for offline receipt
+   * verification. When omitted, the verifier fetches it from
+   * `${endpoint}/operator-key` on first use. Pinning is recommended for
+   * production audit pipelines so a compromised endpoint cannot serve a
+   * forged operator key.
+   */
+  operatorKey?: string;
+}
+
+/**
+ * Decode a base64-encoded JSON header value into a typed object.
+ *
+ * @param value - The raw header string, or null if absent.
+ * @returns The parsed object, or null if the header was absent or unparseable.
+ */
+function decodeHeader<T>(value: string | null): T | null {
+  if (!value) return null;
+  try {
+    const json = Buffer.from(value, "base64").toString("utf8");
+    return JSON.parse(json) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Encode an arbitrary object as a base64-encoded JSON header value.
+ *
+ * @param obj - The object to serialize.
+ * @returns The base64-encoded JSON string suitable for an HTTP header.
+ */
+function encodeHeader(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj), "utf8").toString("base64");
+}
+
+/**
+ * VdmNexusActionProvider — pay-per-call signed inference with verifiable
+ * cryptographic receipts.
+ *
+ * VDM Nexus is an x402-gated inference rail: every paid `/chat/completions`
+ * call settles a USDC payment inline and returns the OpenAI response plus
+ * an Ed25519-signed receipt (SIR v2) anchored to the on-chain settlement
+ * transaction. Receipts are independently verifiable — third parties can
+ * confirm what the model returned without trusting the caller or the
+ * service operator.
+ *
+ * Three actions are exposed:
+ * - `nexus_chat` — paid inference, returns OpenAI response + receipt
+ * - `nexus_verify_receipt` — five-check SIR v2 verification
+ * - `nexus_get_deposit_address` — destination for off-band USDC top-ups
+ *
+ * The AgentKit-managed wallet IS the agent identity: its keypair signs
+ * the SPL USDC transfer carried in the x402 `X-Payment` header. No
+ * separate agent secret env var is required.
+ *
+ * Spec: https://docs.vdmnexus.com/docs/spec/sir-v2
+ */
+export class VdmNexusActionProvider extends ActionProvider<SvmWalletProvider> {
+  private readonly endpoint: string;
+  private readonly operatorKey: string | undefined;
+
+  /**
+   * Constructor for the VdmNexusActionProvider.
+   *
+   * @param config - Optional endpoint + operator-key overrides.
+   */
+  constructor(config?: VdmNexusActionProviderConfig) {
+    super("vdm_nexus", []);
+    this.endpoint = (config?.endpoint ?? DEFAULT_ENDPOINT).replace(/\/$/, "");
+    this.operatorKey = config?.operatorKey;
+  }
+
+  /**
+   * Run a paid inference call against VDM Nexus.
+   *
+   * Performs the standard x402 two-roundtrip handshake — an initial unpaid
+   * POST returns a 402 with the payment challenge, the AgentKit-managed
+   * wallet signs the SPL USDC transfer, and the paid retry returns the
+   * OpenAI chat completion plus a signed receipt.
+   *
+   * @param walletProvider - The Solana wallet the agent runs on. Its
+   *   keypair signs the payment.
+   * @param args - Validated `NexusChatSchema` arguments.
+   * @returns Stringified JSON `{ ok, openai, receipt, payment }` on
+   *   success; `{ ok: false, error, … }` on failure.
+   */
+  @CreateAction({
+    name: "nexus_chat",
+    description: `
+Run a paid inference call against VDM Nexus, the signed-inference rail.
+Settles a USDC payment inline via x402 from the agent's wallet, runs the
+inference upstream, and returns the OpenAI chat completion alongside a
+Signed Inference Receipt (SIR v2) anchored to the on-chain settlement
+transaction.
+
+Inputs:
+- model: OpenRouter-style model slug (e.g. "openai/gpt-4o-mini",
+  "anthropic/claude-3-haiku").
+- messages: OpenAI-shape chat messages array.
+- network (optional): Override the settlement chain. Must be a network the
+  agent's wallet can sign for. For a Solana wallet, valid values are
+  "solana:mainnet" and "solana:devnet". Omit to use the server default.
+
+The wallet attached to AgentKit IS the agent identity. No separate
+agent secret is required. Cost is reported per call by the upstream
+provider and passed through 1:1; expect ~$0.01-$0.05 per call depending
+on the model and prompt size.
+`,
+    schema: NexusChatSchema,
+  })
+  async nexusChat(
+    walletProvider: SvmWalletProvider,
+    args: z.infer<typeof NexusChatSchema>,
+  ): Promise<string> {
+    const url = `${this.endpoint}/chat/completions`;
+    const requestBody = JSON.stringify({
+      model: args.model,
+      messages: args.messages,
+      ...(args.network ? { network: args.network } : {}),
+    });
+
+    // 1. Probe — unpaid POST returns 402 with the x402 challenge.
+    const probe = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: requestBody,
+    });
+
+    if (probe.status !== 402) {
+      const text = await probe.text();
+      return JSON.stringify({
+        ok: false,
+        error: "x402_probe_failed",
+        detail: `expected 402, got ${probe.status}: ${text.slice(0, 200)}`,
+      });
+    }
+
+    const challenge = decodeHeader<PaymentRequired>(probe.headers.get(PAYMENT_REQUIRED_HEADER));
+    if (!challenge) {
+      return JSON.stringify({
+        ok: false,
+        error: "x402_missing_challenge",
+        detail: "402 response had no X-Payment-Required header carrying the payment options",
+      });
+    }
+
+    // 2. Sign the payment with the AgentKit-managed wallet.
+    const kitSigner = await walletProvider.getKeyPairSigner();
+    const signer = toClientSvmSigner(kitSigner);
+    const client = new x402Client();
+    client.register("solana:*", new ExactSvmScheme(signer, {}));
+    const payment: PaymentPayload = await client.createPaymentPayload(challenge);
+
+    // 3. Paid retry — facilitator settles inline, route runs inference,
+    //    response carries the signed receipt.
+    const paid = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [PAYMENT_HEADER]: encodeHeader(payment),
+      },
+      body: requestBody,
+    });
+
+    if (paid.status === 409) {
+      return JSON.stringify({
+        ok: false,
+        error: "x402_payment_replay",
+        detail:
+          "this tx_signature was already credited — re-issue the request to obtain a fresh challenge",
+      });
+    }
+    if (!paid.ok) {
+      const errBody = (await paid.json().catch(() => ({}))) as { detail?: string };
+      return JSON.stringify({
+        ok: false,
+        error: "x402_upstream_error",
+        status: paid.status,
+        detail: errBody.detail ?? `HTTP ${paid.status}`,
+      });
+    }
+
+    const openai = (await paid.json()) as OpenAIChatCompletion;
+    const receipt = decodeHeader<NexusReceipt>(paid.headers.get(RECEIPT_HEADER));
+    const settlement = decodeHeader<X402PaymentResponse>(paid.headers.get(PAYMENT_RESPONSE_HEADER));
+
+    return JSON.stringify({
+      ok: true,
+      openai,
+      receipt,
+      payment: settlement,
+    });
+  }
+
+  /**
+   * Verify a Signed Inference Receipt end-to-end.
+   *
+   * Delegates to `verifyReceipt` from `@vdm-nexus/x402`, which runs five
+   * checks: prompt hash recompute, response hash recompute, operator
+   * Ed25519 signature, on-chain settlement transaction lookup, and payer
+   * identity match. Returns the full breakdown so the agent can decide
+   * what to do on partial failure.
+   *
+   * @param args - Validated `NexusVerifyReceiptSchema` arguments.
+   * @returns Stringified JSON `{ ok, checks: { … } }` or
+   *   `{ ok: false, error, … }` on failure.
+   */
+  @CreateAction({
+    name: "nexus_verify_receipt",
+    description: `
+Verify a VDM Nexus Signed Inference Receipt (SIR v2) end-to-end. Runs five
+independent checks against the receipt, the original prompt/response, and
+the on-chain settlement record:
+- prompt_hash_ok: sha256 of the prompt matches receipt.prompt_hash
+- response_hash_ok: sha256 of the response matches receipt.response_hash
+- nexus_signature_ok: operator Ed25519 signature is valid
+- payment_on_chain_ok: settlement tx landed at the recipient
+- payer_matches: tx payer equals receipt.agent_pubkey
+
+Pass the receipt as it was returned by nexus_chat (the receipt field),
+the prompt as the messages array you sent, and the response as the
+OpenAI response body. Returns the full check breakdown so the agent can
+act on partial failures (e.g. ignore vacuous payment checks on prepaid
+receipts).
+
+Spec: https://docs.vdmnexus.com/docs/spec/sir-v2
+`,
+    schema: NexusVerifyReceiptSchema,
+  })
+  async nexusVerifyReceipt(args: z.infer<typeof NexusVerifyReceiptSchema>): Promise<string> {
+    try {
+      const result = await verifyReceipt({
+        receipt: args.receipt as NexusReceipt,
+        prompt: args.prompt as ChatMessage[] | string,
+        response: args.response as OpenAIChatCompletion | string,
+        endpoint: args.endpoint ?? this.endpoint,
+        operatorKey: args.operatorKey ?? this.operatorKey,
+        rpc: args.rpc,
+      });
+      return JSON.stringify({ ok: result.ok, checks: result.checks });
+    } catch (error) {
+      return JSON.stringify({
+        ok: false,
+        error: "verify_failed",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Fetch the on-chain USDC deposit address for prepaid credit top-ups.
+   *
+   * Per-call x402 settlement via `nexus_chat` does NOT require this — it
+   * settles inline. Use this when batching deposits across many calls is
+   * cheaper than per-call settlement.
+   *
+   * @param args - Validated `NexusGetDepositAddressSchema` arguments.
+   * @returns Stringified JSON `{ ok, address, mint, network }` on success;
+   *   `{ ok: false, error, … }` on failure.
+   */
+  @CreateAction({
+    name: "nexus_get_deposit_address",
+    description: `
+Fetch the on-chain USDC deposit address for topping up an agent's prepaid
+credit balance on a VDM Nexus deployment.
+
+Per-call x402 settlement (nexus_chat) settles inline and does NOT require
+a deposit; this action is for agents that prefer to batch many calls
+against a prepaid balance to amortize RPC + facilitator overhead.
+
+Returns the address, the USDC mint, and the network the address lives on.
+`,
+    schema: NexusGetDepositAddressSchema,
+  })
+  async nexusGetDepositAddress(
+    args: z.infer<typeof NexusGetDepositAddressSchema>,
+  ): Promise<string> {
+    const qs = args.network ? `?network=${encodeURIComponent(args.network)}` : "";
+    const url = `${this.endpoint}/deposit-address${qs}`;
+    try {
+      const r = await fetch(url);
+      if (!r.ok) {
+        return JSON.stringify({
+          ok: false,
+          error: "deposit_address_fetch_failed",
+          status: r.status,
+        });
+      }
+      const body = (await r.json()) as {
+        address: string;
+        mint: string;
+        network: string;
+      };
+      return JSON.stringify({
+        ok: true,
+        address: body.address,
+        mint: body.mint,
+        network: body.network,
+      });
+    } catch (error) {
+      return JSON.stringify({
+        ok: false,
+        error: "deposit_address_fetch_failed",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
+   * Checks if the provider supports the given network. VDM Nexus settles
+   * USDC payments on Solana via SPL transfer; the wallet must be an SVM
+   * wallet. Base / EVM settlement is on the roadmap as a sibling provider
+   * bound to `EvmWalletProvider`.
+   *
+   * @param network - The network descriptor from the wallet provider.
+   * @returns True iff the network's protocol family is `"svm"`.
+   */
+  supportsNetwork = (network: Network): boolean => network.protocolFamily === "svm";
+}
+
+/**
+ * Factory function for the VDM Nexus action provider.
+ *
+ * @param config - Optional endpoint + operator-key overrides.
+ * @returns A fresh `VdmNexusActionProvider` instance.
+ */
+export const vdmNexusActionProvider = (
+  config?: VdmNexusActionProviderConfig,
+): VdmNexusActionProvider => new VdmNexusActionProvider(config);

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@vaultsfyi/sdk':
         specifier: ^2.1.9
         version: 2.1.9(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@vdm-nexus/x402':
+        specifier: ^0.4.0
+        version: 0.4.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
       '@x402/evm':
         specifier: ^2.7.0
         version: 2.7.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
@@ -109,7 +112,7 @@ importers:
         version: 2.7.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
       '@x402/svm':
         specifier: ^2.7.0
-        version: 2.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))
+        version: 2.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@zerodev/ecdsa-validator':
         specifier: ^5.4.5
         version: 5.4.5(@zerodev/sdk@5.4.28(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))
@@ -698,22 +701,6 @@ importers:
         specifier: ^4.7.1
         version: 4.19.3
 
-  examples/register:
-    dependencies:
-      '@coinbase/agentkit':
-        specifier: latest
-        version: 0.10.4(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(@types/node@20.17.27)(abitype@1.2.3(typescript@5.8.2)(zod@3.25.56))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(graphql@16.11.0)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.4.7
-      viem:
-        specifier: ^2.21.19
-        version: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-    devDependencies:
-      tsx:
-        specifier: ^4.7.1
-        version: 4.19.3
-
   examples/vercel-ai-sdk-smart-wallet-chatbot:
     dependencies:
       '@ai-sdk/openai':
@@ -1130,23 +1117,14 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@coinbase/agentkit@0.10.4':
-    resolution: {integrity: sha512-1ZnjY6ohuBXqseZDUhrkFnlU+UjNBr9TeZjpa4wjR8pGQq2RhhVKXQSe5UOFpitgtK3z8ytsQXTHwKRohkExKw==}
-
   '@coinbase/cdp-sdk@1.45.0':
     resolution: {integrity: sha512-4fgGOhyN9g/pTDE9NtsKUapwFsubrk9wafz8ltmBqSwWqLZWfWxXkVmzMYYFAf+qeGf/X9JqJtmvDVaHFlXWlw==}
-
-  '@coinbase/coinbase-sdk@0.20.0':
-    resolution: {integrity: sha512-OoMMktKbjmeEwtwQCK3kIIoX5M+hNelxAGX5Llymvw6bmyrMDaEBZ/Myga9kaLJ+7Hi5Y4jPDy4Cy2MGxxXg6w==}
 
   '@coinbase/wallet-sdk@3.9.3':
     resolution: {integrity: sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==}
 
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
-
-  '@coinbase/x402@0.6.4':
-    resolution: {integrity: sha512-T0tNU8/oZ64GaKC3dbGcOFHqYO0BjII/uZeC/tAS9HOqhWBvewhoa0rzPzaE8SHeKOIwX2YpbFXdG0Hyh0d4mw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3295,6 +3273,12 @@ packages:
   '@vaultsfyi/sdk@2.1.9':
     resolution: {integrity: sha512-pXxEGh24/dnRQjF2uIUHaLtu0WC9+V2wpWCvyEBfS/zfFdKt35AY8Jgr6rOe3T3ehBQMq8BKCJZq+WPJFGj+ig==}
 
+  '@vdm-nexus/sdk@0.2.0':
+    resolution: {integrity: sha512-+/ws61DO6tfboZN5KETuZ7c3GzB6Xe0YZe//QEZJYM15PXARDwroCcJP2NWatEu2CU3jfHjKciFdcUYzYcYRag==}
+
+  '@vdm-nexus/x402@0.4.0':
+    resolution: {integrity: sha512-fK11T+HtheLiQqlgFwBLqaOf++DwiWKY1K6M+148aXygWcbjabRrmCAXpln0vyWzqqCBOaLZnvWfxq5EHqUCpg==}
+
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
@@ -3426,6 +3410,9 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
+  '@x402/core@2.13.0':
+    resolution: {integrity: sha512-wZjjYZ9UxXZh8O2uP/x0u4M4Dvuw5hHdN7uzEseoS4V9fkMewi+VAx9Wd98PdU9VegvG24+ES88fgFB4C5QVUw==}
+
   '@x402/core@2.7.0':
     resolution: {integrity: sha512-2l1QaRO50qtWpnTJed45HtGRAUp3z2Mep1caNCuaNBzeiE8OfWfuXmip+ujgp3vWZHxRqag221aRSnKbA6gDaQ==}
 
@@ -3434,6 +3421,11 @@ packages:
 
   '@x402/fetch@2.7.0':
     resolution: {integrity: sha512-hkJvoVtYjybkhLk1K2kRB0aVVWaxz43qYBSGZo0wgnUuIUXzmArGohhM/VfG8kVqcl+NDIuCD8tFiKSONr9X6A==}
+
+  '@x402/svm@2.13.0':
+    resolution: {integrity: sha512-qgR7GY+A8mZ+y/6iDRIHG11S415OFw7dp4QQHP08cu8wrSENZPCKfl62OGWTZGfAAR9jnaWK2w4/HUarOqTS4A==}
+    peerDependencies:
+      '@solana/kit': '>=5.1.0'
 
   '@x402/svm@2.7.0':
     resolution: {integrity: sha512-5XcaVdYXCkqQbZFYd4mxNZw+rPCDuveTT00qpcIP69TarBPt82G63axULtxxd3frL4fyK0N7XfGwhkotkkJDIg==}
@@ -3769,11 +3761,6 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios-mock-adapter@1.22.0:
-    resolution: {integrity: sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==}
-    peerDependencies:
-      axios: '>= 0.17.0'
-
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
@@ -3859,13 +3846,6 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
-  bip32@4.0.0:
-    resolution: {integrity: sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==}
-    engines: {node: '>=6.0.0'}
-
-  bip39@3.1.0:
-    resolution: {integrity: sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==}
-
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -3933,9 +3913,6 @@ packages:
 
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
-
-  bs58check@2.1.2:
-    resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -4068,10 +4045,6 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
-
-  cipher-base@1.0.6:
-    resolution: {integrity: sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==}
-    engines: {node: '>= 0.10'}
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
@@ -4220,9 +4193,6 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
-
-  create-hash@1.2.0:
-    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -4483,9 +4453,6 @@ packages:
   eciesjs@0.4.15:
     resolution: {integrity: sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
-
-  ed2curve@0.3.0:
-    resolution: {integrity: sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -5194,10 +5161,6 @@ packages:
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
-  hash-base@3.1.0:
-    resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
-    engines: {node: '>=4'}
-
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
 
@@ -5453,10 +5416,6 @@ packages:
 
   is-buffer@1.1.6:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
-
-  is-buffer@2.0.5:
-    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
-    engines: {node: '>=4'}
 
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
@@ -5932,9 +5891,6 @@ packages:
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
-  jose@5.10.0:
-    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
-
   jose@6.0.10:
     resolution: {integrity: sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==}
 
@@ -6217,9 +6173,6 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-
-  md5.js@1.3.5:
-    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
@@ -7246,9 +7199,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  ripemd160@2.0.2:
-    resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
-
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -7309,10 +7259,6 @@ packages:
 
   scrypt-js@3.0.1:
     resolution: {integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==}
-
-  secp256k1@5.0.1:
-    resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
-    engines: {node: '>=18.0.0'}
 
   secure-compare@3.0.1:
     resolution: {integrity: sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==}
@@ -7379,10 +7325,6 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
-  sha.js@2.4.11:
-    resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
-    hasBin: true
 
   sha.js@2.4.12:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
@@ -7979,9 +7921,6 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
 
-  typeforce@1.18.0:
-    resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
-
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
@@ -8243,14 +8182,6 @@ packages:
       typescript:
         optional: true
 
-  viem@2.38.3:
-    resolution: {integrity: sha512-By2TutLv07iNHHtWqHHzjGipevYsfGqT7KQbGEmqLco1qTJxKnvBbSviqiu6/v/9REV6Q/FpmIxf2Z7/l5AbcQ==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   viem@2.47.4:
     resolution: {integrity: sha512-h0Wp/SYmJO/HB4B/em1OZ3W1LaKrmr7jzaN7talSlZpo0LCn0V6rZ5g923j6sf4VUSrqp/gUuWuHFc7UcoIp8A==}
     peerDependencies:
@@ -8360,9 +8291,6 @@ packages:
   wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
-  wif@2.0.6:
-    resolution: {integrity: sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==}
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -8456,9 +8384,6 @@ packages:
 
   x402-fetch@0.7.0:
     resolution: {integrity: sha512-HS7v6wsIVrU8TvAGBwRmA3I+ZXbanPraA3OMj90y6Hn1Mej1wAELOK4VpGh6zI8d6w5E464BnGu9o0FE+8DRAA==}
-
-  x402@0.6.1:
-    resolution: {integrity: sha512-9UmeCSsYzFGav5FdVP70VplKlR3V90P0DZ9fPSrlLVp0ifUVi1S9TztvegkmIHE9xTGZ1GWNi+bkne6N0Ea58w==}
 
   x402@0.7.2:
     resolution: {integrity: sha512-JleP1GmeOP1bEuwzFVtjusL3t5H1PGufROrBKg5pj/MfcGswkBvfB6j5Gm5UeA+kwp0ZmOkkHAqkoHF1WexbsQ==}
@@ -8599,10 +8524,6 @@ snapshots:
       freeport-promise: 2.0.0
       merge-options: 3.0.4
       xml2js: 0.6.2
-
-  '@across-protocol/app-sdk@0.2.0(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
 
   '@across-protocol/app-sdk@0.2.0(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -8924,26 +8845,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@base-org/account@2.2.0(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.2)(zod@3.25.56)
-      preact: 10.24.2
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      zustand: 5.0.3(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@cfworker/json-schema@4.1.1': {}
@@ -9146,83 +9047,6 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
-  '@coinbase/agentkit@0.10.4(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(@types/node@20.17.27)(abitype@1.2.3(typescript@5.8.2)(zod@3.25.56))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(graphql@16.11.0)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@across-protocol/app-sdk': 0.2.0(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@alloralabs/allora-sdk': 0.1.0
-      '@base-org/account': 2.2.0(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      '@coinbase/cdp-sdk': 1.45.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
-      '@coinbase/coinbase-sdk': 0.20.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      '@coinbase/x402': 0.6.4(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@ensofinance/sdk': 2.0.6
-      '@jup-ag/api': 6.0.40
-      '@privy-io/public-api': 2.18.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@privy-io/server-auth': 1.18.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/spl-token': 0.4.13(@solana/web3.js@1.98.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.2)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.2)(utf-8-validate@5.0.10)
-      '@vaultsfyi/sdk': 2.1.9(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/evm': 2.7.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
-      '@x402/fetch': 2.7.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)
-      '@x402/svm': 2.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))
-      '@zerodev/ecdsa-validator': 5.4.5(@zerodev/sdk@5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)))(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@zerodev/intent': 0.0.24(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@zerodev/sdk': 5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@zoralabs/coins-sdk': 0.2.8(abitype@1.2.3(typescript@5.8.2)(zod@3.25.56))(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@zoralabs/protocol-deployments': 0.6.1
-      bs58: 4.0.1
-      canonicalize: 2.1.0
-      clanker-sdk: 4.1.19(@types/node@20.17.27)(typescript@5.8.2)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      decimal.js: 10.5.0
-      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      graphql-request: 7.2.0(graphql@16.11.0)
-      md5: 2.3.0
-      opensea-js: 7.1.18(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      reflect-metadata: 0.2.2
-      sushi: 6.2.1(typescript@5.8.2)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56)
-      twitter-api-v2: 1.22.0
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      zod: 3.25.56
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/node'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@zerodev/webauthn-key'
-      - abitype
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - graphql
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - ws
-
   '@coinbase/cdp-sdk@1.45.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana-program/system': 0.10.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))
@@ -9244,29 +9068,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
-
-  '@coinbase/coinbase-sdk@0.20.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)':
-    dependencies:
-      '@scure/bip32': 1.7.0
-      abitype: 1.2.3(typescript@5.8.2)(zod@3.25.56)
-      axios: 1.12.2
-      axios-mock-adapter: 1.22.0(axios@1.12.2)
-      axios-retry: 4.5.0(axios@1.12.2)
-      bip32: 4.0.0
-      bip39: 3.1.0
-      decimal.js: 10.5.0
-      dotenv: 16.4.7
-      ed2curve: 0.3.0
-      ethers: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      jose: 5.10.0
-      secp256k1: 5.0.1
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - typescript
-      - utf-8-validate
-      - zod
 
   '@coinbase/wallet-sdk@3.9.3':
     dependencies:
@@ -9301,47 +9102,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-
-  '@coinbase/x402@0.6.4(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@coinbase/cdp-sdk': 1.45.0(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      x402: 0.6.1(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      zod: 3.25.56
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -9827,14 +9587,6 @@ snapshots:
       '@fidm/asn1': 1.0.4
       tweetnacl: 1.0.3
 
-  '@gemini-wallet/core@0.2.0(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      '@metamask/rpc-errors': 7.0.2
-      eventemitter3: 5.0.1
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-    transitivePeerDependencies:
-      - supports-color
-
   '@gemini-wallet/core@0.2.0(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
@@ -10007,13 +9759,6 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
-
-  '@inquirer/external-editor@1.0.1(@types/node@20.17.27)':
-    dependencies:
-      chardet: 2.1.0
-      iconv-lite: 0.6.3
-    optionalDependencies:
-      '@types/node': 20.17.27
 
   '@inquirer/external-editor@1.0.1(@types/node@22.13.14)':
     dependencies:
@@ -11505,27 +11250,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@privy-io/server-auth@1.18.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@solana/web3.js': 1.98.1(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.2)(utf-8-validate@5.0.10)
-      canonicalize: 2.1.0
-      dotenv: 16.4.7
-      jose: 4.15.9
-      node-fetch-native: 1.6.6
-      redaxios: 0.5.1
-      svix: 1.62.0(encoding@0.1.13)
-      ts-case-convert: 2.1.0
-      type-fest: 3.13.1
-    optionalDependencies:
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-
   '@privy-io/server-auth@1.18.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       '@noble/curves': 1.8.1
@@ -12013,6 +11737,10 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
+  '@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
+
   '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -12021,15 +11749,17 @@ snapshots:
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
 
-  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))':
+  '@solana-program/token-2022@0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)
 
-  '@solana-program/token-2022@0.6.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))':
+  '@solana-program/token-2022@0.6.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/sysvars': 5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)
+
+  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
 
   '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
@@ -13278,43 +13008,6 @@ snapshots:
 
   '@uniswap/token-lists@1.0.0-beta.33': {}
 
-  '@vaultsfyi/sdk@2.1.9(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      x402-fetch: 0.7.0(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
-
   '@vaultsfyi/sdk@2.1.9(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       x402-fetch: 0.7.0(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -13352,51 +13045,27 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@vercel/oidc@3.1.0': {}
-
-  '@wagmi/connectors@5.10.0(@wagmi/core@2.21.0(@tanstack/query-core@5.89.0)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)))(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56)':
+  '@vdm-nexus/sdk@0.2.0':
     dependencies:
-      '@base-org/account': 1.1.1(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.56)
-      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.0.9)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(zod@3.25.56)
-      '@gemini-wallet/core': 0.2.0(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      '@wagmi/core': 2.21.0(@tanstack/query-core@5.89.0)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-    optionalDependencies:
-      typescript: 5.8.2
+      bs58: 6.0.0
+      tweetnacl: 1.0.3
+
+  '@vdm-nexus/x402@0.4.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
+      '@vdm-nexus/sdk': 0.2.0
+      '@x402/core': 2.13.0
+      '@x402/svm': 2.13.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))
+      bs58: 6.0.0
+      tweetnacl: 1.0.3
     transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
+      - '@solana/sysvars'
       - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - uploadthing
-      - use-sync-external-store
+      - fastestsmallesttextencoderdecoder
+      - typescript
       - utf-8-validate
-      - zod
+
+  '@vercel/oidc@3.1.0': {}
 
   '@wagmi/connectors@5.10.0(@wagmi/core@2.21.0(@tanstack/query-core@5.89.0)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.56)':
     dependencies:
@@ -13441,21 +13110,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-
-  '@wagmi/core@2.21.0(@tanstack/query-core@5.89.0)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.8.2)
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      zustand: 5.0.0(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
-    optionalDependencies:
-      '@tanstack/query-core': 5.89.0
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
 
   '@wagmi/core@2.21.0(@tanstack/query-core@5.89.0)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -14019,6 +13673,10 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
+  '@x402/core@2.13.0':
+    dependencies:
+      zod: 3.25.56
+
   '@x402/core@2.7.0':
     dependencies:
       zod: 3.25.56
@@ -14043,11 +13701,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/svm@2.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))':
+  '@x402/svm@2.13.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10))
+      '@solana/kit': 5.5.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(utf-8-validate@5.0.10)
+      '@x402/core': 2.13.0
+    transitivePeerDependencies:
+      - '@solana/sysvars'
+
+  '@x402/svm@2.7.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana-program/compute-budget': 0.11.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token': 0.9.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token-2022': 0.6.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@x402/core': 2.7.0
     transitivePeerDependencies:
@@ -14120,11 +13788,6 @@ snapshots:
       rxjs: 7.8.2
       undici: 5.29.0
 
-  '@zerodev/ecdsa-validator@5.4.5(@zerodev/sdk@5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)))(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      '@zerodev/sdk': 5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-
   '@zerodev/ecdsa-validator@5.4.5(@zerodev/sdk@5.4.28(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       '@zerodev/sdk': 5.4.28(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))
@@ -14139,23 +13802,6 @@ snapshots:
     transitivePeerDependencies:
       - '@zerodev/webauthn-key'
 
-  '@zerodev/intent@0.0.24(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      '@zerodev/ecdsa-validator': 5.4.5(@zerodev/sdk@5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)))(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@zerodev/multi-chain-ecdsa-validator': 5.4.4(@zerodev/sdk@5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)))(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      '@zerodev/sdk': 5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-    transitivePeerDependencies:
-      - '@zerodev/webauthn-key'
-
-  '@zerodev/multi-chain-ecdsa-validator@5.4.4(@zerodev/sdk@5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)))(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      '@simplewebauthn/browser': 9.0.1
-      '@simplewebauthn/typescript-types': 8.3.4
-      '@zerodev/sdk': 5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      merkletreejs: 0.3.11
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-
   '@zerodev/multi-chain-ecdsa-validator@5.4.4(@zerodev/sdk@5.4.28(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)))(@zerodev/webauthn-key@5.4.3(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       '@simplewebauthn/browser': 9.0.1
@@ -14164,11 +13810,6 @@ snapshots:
       '@zerodev/webauthn-key': 5.4.3(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       merkletreejs: 0.3.11
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)
-
-  '@zerodev/sdk@5.4.28(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      semver: 7.7.1
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
 
   '@zerodev/sdk@5.4.28(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -14188,13 +13829,6 @@ snapshots:
       '@zoralabs/protocol-deployments': 0.6.1
       abitype: 1.0.8(typescript@5.8.2)(zod@4.3.6)
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)
-
-  '@zoralabs/coins-sdk@0.2.8(abitype@1.2.3(typescript@5.8.2)(zod@3.25.56))(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))':
-    dependencies:
-      '@hey-api/client-fetch': 0.8.4
-      '@zoralabs/protocol-deployments': 0.6.1
-      abitype: 1.2.3(typescript@5.8.2)(zod@3.25.56)
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
 
   '@zoralabs/protocol-deployments@0.6.1': {}
 
@@ -14221,11 +13855,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.2
       zod: 4.3.6
-
-  abitype@1.1.0(typescript@5.8.2)(zod@3.25.56):
-    optionalDependencies:
-      typescript: 5.8.2
-      zod: 3.25.56
 
   abitype@1.1.0(typescript@5.8.2)(zod@4.3.6):
     optionalDependencies:
@@ -14470,12 +14099,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios-mock-adapter@1.22.0(axios@1.12.2):
-    dependencies:
-      axios: 1.12.2
-      fast-deep-equal: 3.1.3
-      is-buffer: 2.0.5
-
   axios-retry@4.5.0(axios@1.12.2):
     dependencies:
       axios: 1.12.2
@@ -14594,17 +14217,6 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  bip32@4.0.0:
-    dependencies:
-      '@noble/hashes': 1.8.0
-      '@scure/base': 1.2.6
-      typeforce: 1.18.0
-      wif: 2.0.6
-
-  bip39@3.1.0:
-    dependencies:
-      '@noble/hashes': 1.8.0
-
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -14699,12 +14311,6 @@ snapshots:
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
-
-  bs58check@2.1.2:
-    dependencies:
-      bs58: 4.0.1
-      create-hash: 1.2.0
-      safe-buffer: 5.2.1
 
   bser@2.1.1:
     dependencies:
@@ -14839,25 +14445,7 @@ snapshots:
 
   ci-info@3.9.0: {}
 
-  cipher-base@1.0.6:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
   cjs-module-lexer@1.4.3: {}
-
-  clanker-sdk@4.1.19(@types/node@20.17.27)(typescript@5.8.2)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)):
-    dependencies:
-      '@openzeppelin/merkle-tree': 1.0.8
-      abitype: 1.0.8(typescript@5.8.2)(zod@3.25.56)
-      dotenv: 16.4.7
-      inquirer: 8.2.7(@types/node@20.17.27)
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      zod: 3.25.56
-    transitivePeerDependencies:
-      - '@types/node'
-      - supports-color
-      - typescript
 
   clanker-sdk@4.1.19(@types/node@22.13.14)(typescript@5.8.2)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
@@ -14979,14 +14567,6 @@ snapshots:
   corser@2.0.1: {}
 
   crc-32@1.2.2: {}
-
-  create-hash@1.2.0:
-    dependencies:
-      cipher-base: 1.0.6
-      inherits: 2.0.4
-      md5.js: 1.3.5
-      ripemd160: 2.0.2
-      sha.js: 2.4.11
 
   create-jest@29.7.0(@types/node@20.17.27)(ts-node@10.9.2(@types/node@20.17.27)(typescript@5.8.2)):
     dependencies:
@@ -15238,10 +14818,6 @@ snapshots:
       '@noble/ciphers': 1.3.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
-
-  ed2curve@0.3.0:
-    dependencies:
-      tweetnacl: 1.0.3
 
   ee-first@1.1.1: {}
 
@@ -16161,12 +15737,6 @@ snapshots:
 
   has-unicode@2.0.1: {}
 
-  hash-base@3.1.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-      safe-buffer: 5.2.1
-
   hash.js@1.1.7:
     dependencies:
       inherits: 2.0.4
@@ -16373,26 +15943,6 @@ snapshots:
 
   ini@1.3.8: {}
 
-  inquirer@8.2.7(@types/node@20.17.27):
-    dependencies:
-      '@inquirer/external-editor': 1.0.1(@types/node@20.17.27)
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-width: 3.0.0
-      figures: 3.2.0
-      lodash: 4.17.21
-      mute-stream: 0.0.8
-      ora: 5.4.1
-      run-async: 2.4.1
-      rxjs: 7.8.2
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      through: 2.3.8
-      wrap-ansi: 6.2.0
-    transitivePeerDependencies:
-      - '@types/node'
-
   inquirer@8.2.7(@types/node@22.13.14):
     dependencies:
       '@inquirer/external-editor': 1.0.1(@types/node@22.13.14)
@@ -16556,8 +16106,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-buffer@1.1.6: {}
-
-  is-buffer@2.0.5: {}
 
   is-callable@1.2.7: {}
 
@@ -17337,8 +16885,6 @@ snapshots:
 
   jose@4.15.9: {}
 
-  jose@5.10.0: {}
-
   jose@6.0.10: {}
 
   jose@6.2.2: {}
@@ -17777,12 +17323,6 @@ snapshots:
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
-
-  md5.js@1.3.5:
-    dependencies:
-      hash-base: 3.1.0
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
 
   md5@2.3.0:
     dependencies:
@@ -18491,21 +18031,6 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.9.6(typescript@5.8.2)(zod@3.25.56):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.8.2)(zod@3.25.56)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - zod
-
   ox@0.9.6(typescript@5.8.2)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -19093,11 +18618,6 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  ripemd160@2.0.2:
-    dependencies:
-      hash-base: 3.1.0
-      inherits: 2.0.4
-
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -19178,12 +18698,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   scrypt-js@3.0.1: {}
-
-  secp256k1@5.0.1:
-    dependencies:
-      elliptic: 6.6.1
-      node-addon-api: 5.1.0
-      node-gyp-build: 4.8.4
 
   secure-compare@3.0.1: {}
 
@@ -19293,11 +18807,6 @@ snapshots:
       es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
-
-  sha.js@2.4.11:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
 
   sha.js@2.4.12:
     dependencies:
@@ -19573,19 +19082,6 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  sushi@6.2.1(typescript@5.8.2)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56):
-    dependencies:
-      '@uniswap/token-lists': 1.0.0-beta.33
-      big.js: 6.1.1
-      date-fns: 3.3.1
-      seedrandom: 3.0.5
-      tiny-invariant: 1.3.3
-      toformat: 2.0.0
-    optionalDependencies:
-      typescript: 5.8.2
-      viem: 2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      zod: 3.25.56
 
   sushi@6.2.1(typescript@5.8.2)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
     dependencies:
@@ -19963,8 +19459,6 @@ snapshots:
       typescript: 5.8.2
       yaml: 2.7.0
 
-  typeforce@1.18.0: {}
-
   typescript@5.8.2: {}
 
   uc.micro@2.1.0: {}
@@ -20200,23 +19694,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.38.3(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.1.0(typescript@5.8.2)(zod@3.25.56)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      ox: 0.9.6(typescript@5.8.2)(zod@3.25.56)
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.22.4):
     dependencies:
       '@noble/curves': 1.9.1
@@ -20269,45 +19746,6 @@ snapshots:
       - zod
 
   vlq@1.0.1: {}
-
-  wagmi@2.17.0(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56):
-    dependencies:
-      '@tanstack/react-query': 5.89.0(react@18.3.1)
-      '@wagmi/connectors': 5.10.0(@wagmi/core@2.21.0(@tanstack/query-core@5.89.0)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)))(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56)
-      '@wagmi/core': 2.21.0(@tanstack/query-core@5.89.0)(react@18.3.1)(typescript@5.8.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))
-      react: 18.3.1
-      use-sync-external-store: 1.4.0(react@18.3.1)
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-    optionalDependencies:
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - supports-color
-      - uploadthing
-      - utf-8-validate
-      - zod
 
   wagmi@2.17.0(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.56):
     dependencies:
@@ -20521,10 +19959,6 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
-  wif@2.0.6:
-    dependencies:
-      bs58check: 2.1.2
-
   word-wrap@1.2.5: {}
 
   wrap-ansi@6.2.0:
@@ -20576,143 +20010,10 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
-  x402-fetch@0.7.0(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      x402: 0.7.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      zod: 3.25.56
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
-
   x402-fetch@0.7.0(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
       x402: 0.7.2(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      zod: 3.25.56
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
-
-  x402@0.6.1(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      wagmi: 2.17.0(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56)
-      zod: 3.25.56
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
-
-  x402@0.7.2(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
-    dependencies:
-      '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-features': 1.3.0
-      '@wallet-standard/app': 1.1.0
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-      viem: 2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56)
-      wagmi: 2.17.0(@tanstack/query-core@5.89.0)(@tanstack/react-query@5.89.0(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)(viem@2.47.4(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.56))(zod@3.25.56)
       zod: 3.25.56
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -20753,7 +20054,7 @@ snapshots:
       '@scure/base': 1.2.6
       '@solana-program/compute-budget': 0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2))
+      '@solana-program/token-2022': 0.4.2(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.2)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-features': 1.3.0


### PR DESCRIPTION
## Description

This PR adds `vdm-nexus`, a new action provider at `typescript/agentkit/src/action-providers/vdm-nexus/` that exposes [VDM Nexus](https://vdmnexus.com) — a signed-inference rail — as a tool surface for any AgentKit-built agent. It ships three actions: `nexus_chat`, `nexus_verify_receipt`, and `nexus_get_deposit_address`.

**What signed inference is.** A *signed-inference receipt* pairs an LLM call with (a) a cryptographic hash of the prompt and response, (b) an Ed25519 signature from the inference operator over the canonical receipt body, and (c) an on-chain USDC settlement transaction proving the call was paid for by a specific agent wallet. Third parties can verify all of this without trusting the caller or the service operator — the operator's published public key plus the on-chain record are the only trust anchors. The wire format is open and documented as [SIR v2](https://docs.vdmnexus.com/docs/spec/sir-v2).

**What this action provider does.** `nexus_chat` performs the x402 two-roundtrip handshake (probe → sign with the AgentKit-managed Solana wallet → paid retry) against a Nexus `/chat/completions` endpoint and returns the OpenAI chat completion plus the SIR v2 receipt plus the settlement record. `nexus_verify_receipt` runs the five-check verifier against any receipt: prompt-hash recompute, response-hash recompute, operator-signature check, on-chain settlement lookup, and payer-identity match. `nexus_get_deposit_address` returns the destination address for off-band prepaid top-ups (the per-call path doesn't need it — payment settles inline).

**Why AgentKit users would want it.** An AgentKit agent gains a paid LLM endpoint that produces tamper-evident receipts in one wired-in action provider — useful for compliance regimes that demand audit trails of what models returned (EU AI Act Article 12, NIST AI agent standards, OWASP LLM Top 10 logging), and for trustless multi-agent flows where Agent A hands a receipt to Agent B and Agent B verifies it without trusting Agent A. The wallet attached to AgentKit IS the agent identity — no separate \`AGENT_SECRET_KEY\` env var is needed.

**Live mainnet receipts** (rendered by the same verifier code path this PR ships):
- First mainnet receipt: <https://vdmnexus.com/r/c9710ea7-9e1f-46ee-aaa9-903a536ae12e>
- Fresh receipt from the smoke test on the exact AgentKit code path: <https://vdmnexus.com/r/5cf63978-77e6-4541-934a-e5879f33ae7a>

**Project home:** <https://vdmnexus.com> — **Developer docs:** <https://docs.vdmnexus.com>

### Relationship to the existing \`x402\` action provider

The upstream [\`x402\` action provider](https://github.com/coinbase/agentkit/tree/main/typescript/agentkit/src/action-providers/x402) is a general-purpose client for calling any x402-protected API. \`vdm-nexus\` is a higher-level adapter targeting one specific x402 rail (Nexus) and adding the verifiable-receipt semantics on top — the wire-level handshake is the same, but the receipt verification, model selection, and OpenAI response shape are specific to the Nexus deployment. Use \`x402\` when you want to call arbitrary paid APIs; use \`vdm-nexus\` when you specifically want paid LLM inference with cryptographic receipts.

### Dependencies

- One new top-level dependency: \`@vdm-nexus/x402@^0.4.0\` (MIT, ESM-only, two source files: the x402 client driver and the SIR v2 receipt verifier). All transitive deps (\`@x402/core\`, \`@x402/svm\`, \`@solana/kit\`, \`bs58\`, \`tweetnacl\`) are already in the AgentKit dep graph via the existing \`x402\` provider.
- A changeset is included at \`typescript/.changeset/vdm-nexus-action-provider.md\` (patch bump).

## Tests

Includes a Jest suite at \`vdmNexusActionProvider.test.ts\` covering: schema validation (chat / verify / deposit), \`supportsNetwork\`, all three action paths with mocked \`fetch\` + mocked \`@x402/*\` + mocked \`@vdm-nexus/x402\`, and the constructor edge case. 20 tests, all passing locally.

```
Chatbot: tested via standalone Node smoke against live production rail (https://nexus.vdmnexus.com)
Network: solana:mainnet
Setup: TEST_AGENT mainnet wallet (BSKq2XtBCXHGZKvP9KStjJdpimTAJbmRP7FqZ1SBTshR) funded with mainnet USDC

Prompt: "Reply with exactly one sentence: 'AgentKit drop-in is live.'"

Agent output: "Great news! AgentKit drop-in is now live."

Receipt: https://vdmnexus.com/r/5cf63978-77e6-4541-934a-e5879f33ae7a
Five-check verification: all passed (prompt_hash_ok, response_hash_ok,
                         nexus_signature_ok, payment_on_chain_ok, payer_matches)
```

Local checks: \`pnpm run check\`, \`pnpm run lint\`, \`pnpm run format:check\`, and \`pnpm exec jest src/action-providers/vdm-nexus/\` all pass.

A langchain-cdp-smart-wallet-chatbot exercise is the next step — happy to add it in a follow-up if maintainers prefer or wire it now.

## Notes for reviewers

- Provider is bound to \`SvmWalletProvider\` because the wallet keypair signs the SPL USDC transfer carried in the x402 \`X-Payment\` header. An EVM-bound sibling for Base settlement is on the roadmap.
- The test file mocks \`jose\` and \`@coinbase/cdp-sdk\` at the top to avoid a known ESM-transform issue in the test environment (the cascade comes from \`actionProvider.ts → wallet-providers → cdpEvmWalletProvider → @coinbase/cdp-sdk → jose\`). Mirrors what \`setup-jest.js\` does at the suite level, but hoisted to the test file so it lands before the module imports resolve.
- Happy to rework any of this — the action names, the schema shapes, the description prompt copy, and the choice to keep the deposit-address action all easy to revise.
- I'll re-sign commits if signing is a hard requirement for review; flagging because the PR template requests it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)