### PR TITLE
docs(x402): add AgentScrape as real-world example service

### DIFF
--- a/typescript/agentkit/src/action-providers/x402/README.md
+++ b/typescript/agentkit/src/action-providers/x402/README.md
@@ -24,8 +24,7 @@ import { x402ActionProvider, X402Config } from "@coinbase/cdp-agentkit";
 const config: X402Config = {
   // Service URLs the agent can call (whitelist)
   registeredServices: [
-    "https://api.example.com",
-    "https://weather.x402.io"
+    "https://agent-scrape.healingsunhaven.workers.dev"
   ],
   
   // Allow agent to register new services at runtime
@@ -337,6 +336,26 @@ The following environment variables can be used to configure the provider:
 - `X402_MAX_PAYMENT_USDC`: Set the maximum payment limit in USDC (e.g., `"0.5"`)
 
 Configuration object values take precedence over environment variables.
+
+## Real-World Example Services
+
+The x402 ecosystem includes live, production agent-native services you can use as references when learning the protocol. The following service implements the full x402 v2 specification on Base mainnet and serves as a useful reference for AgentKit users:
+
+- **[AgentScrape](https://agent-scrape.healingsunhaven.workers.dev)** — Pay-per-call web scraping for AI agents. Six tools (scrape, extract, screenshot, metadata, session, workflow). MIT licensed open source. Live on Base mainnet with a 10-call free tier per wallet.
+  - x402 manifest: `https://agent-scrape.healingsunhaven.workers.dev/.well-known/x402.json`
+  - A2A Agent Card: `https://agent-scrape.healingsunhaven.workers.dev/.well-known/agent.json`
+  - Source: https://github.com/hshintelligence/agent-scrape
+
+To call it from AgentKit:
+
+```typescript
+const provider = x402ActionProvider({
+  registeredServices: [
+    "https://agent-scrape.healingsunhaven.workers.dev"
+  ],
+  maxPaymentUsdc: 0.01,
+});
+```
 
 ### Additional Resources
 


### PR DESCRIPTION
## What this PR does

Adds [AgentScrape](https://agent-scrape.healingsunhaven.workers.dev) as a real, live, production x402 service in the AgentKit x402 action provider's README.

## Why

The existing README's `registeredServices` example uses placeholder URLs (`https://api.example.com`, `https://weather.x402.io`) that aren't reachable production x402 endpoints. Developers reading the README to learn how to wire up x402 in AgentKit benefit from a real, copy-pasteable URL that actually returns 402 Payment Required and works end-to-end on Base mainnet.

## Changes

- Replaced placeholder URLs in the `X402Config` example with AgentScrape's real worker URL
- Added a **Real-World Example Services** section linking to AgentScrape's manifest, A2A card, and source code, with a complete `x402ActionProvider` config snippet

## About AgentScrape

- **Live**: `https://agent-scrape.healingsunhaven.workers.dev`
- **License**: MIT (open source)
- **Network**: Base mainnet (eip155:8453)
- **Asset**: USDC
- **Free tier**: 10 calls per wallet in first 30 days
- **Six tools**: scrape, extract (Groq + Llama 4), screenshot, metadata, session, workflow
- **Standards**: x402 v2, MCP Streamable HTTP, A2A Agent Card, OpenAPI 3.1, Schema.org JSON-LD, IPFS-pinned manifest
- **Listings**: Glama (License A / Quality A), Smithery (82/100), punkpeye/awesome-mcp-servers (merged), mcp.so

Happy to address any feedback, scope back the change, or split into separate commits if preferred.