### PR TITLE
docs: align CDP config examples with actual API in typescript/agentkit README

### DIFF
--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -81,9 +81,10 @@ npm install @coinbase/agentkit
 
 ## Usage
 
-### Create an AgentKit instance. If no wallet or action providers are specified, the agent will use the `CdpWalletProvider` and `WalletProvider` action provider.
+### Create an AgentKit instance. If no wallet or action providers are specified, the agent will use the `CdpSmartWalletProvider` and `WalletActionProvider` action provider.
 
 ```typescript
+// When using the AgentKit.from() shortcut:
 const agentKit = await AgentKit.from({
   cdpApiKeyId: "CDP API KEY NAME",
   cdpApiKeySecret: "CDP API KEY SECRET",
@@ -92,7 +93,7 @@ const agentKit = await AgentKit.from({
 
 ### Create an AgentKit instance
 
-If no wallet or action provider are specified, the agent will use the `CdpWalletProvider` and `WalletActionProvider` action provider by default.
+If no wallet or action provider are specified, the agent will use the `CdpSmartWalletProvider` and `WalletActionProvider` action provider by default.
 
 ```typescript
 const agentKit = await AgentKit.from({
@@ -106,9 +107,10 @@ const agentKit = await AgentKit.from({
 ```typescript
 import { CdpWalletProvider } from "@coinbase/agentkit";
 
+// When constructing a wallet provider manually:
 const walletProvider = await CdpWalletProvider.configureWithWallet({
   apiKeyId: "CDP API KEY NAME",
-  apiKeyPrivate: "CDP API KEY SECRET",
+  apiKeySecret: "CDP API KEY SECRET",
   networkId: "base-mainnet",
 });
 
@@ -127,7 +129,7 @@ const agentKit = await AgentKit.from({
   actionProviders: [
     cdpApiActionProvider({
       apiKeyId: "CDP API KEY NAME",
-      apiKeyPrivate: "CDP API KEY SECRET",
+      apiKeySecret: "CDP API KEY SECRET",
     }),
     pythActionProvider(),
   ],
@@ -1355,7 +1357,7 @@ import { ZeroDevWalletProvider, CdpWalletProvider } from "@coinbase/agentkit";
 // First create a CDP wallet provider as the signer
 const cdpWalletProvider = await CdpWalletProvider.configureWithWallet({
   apiKeyId: "CDP API KEY NAME",
-  apiKeyPrivate: "CDP API KEY SECRET",
+  apiKeySecret: "CDP API KEY SECRET",
   networkId: "base-mainnet",
 });
 


### PR DESCRIPTION
## Summary

Three related corrections to `typescript/agentkit/README.md`, all stemming from documentation that drifted from the actual TypeScript API. Each one would cause real authentication or import failures for a developer following the README.

## Changes

### 1. Default provider name — `CdpWalletProvider` → `CdpSmartWalletProvider`

**Lines 84 and 95.** The README claims the default wallet provider is `CdpWalletProvider`, but `typescript/agentkit/src/agentkit.ts:57` actually defaults to `CdpSmartWalletProvider`.

The two lines also disagreed with each other — line 84 said `WalletProvider`, line 95 said `WalletActionProvider`. Unified both to match the implementation:

```diff
- the agent will use the `CdpWalletProvider` and `WalletProvider` action provider
+ the agent will use the `CdpSmartWalletProvider` and `WalletActionProvider`
```

### 2. Wrong config field name — `apiKeyPrivate` → `apiKeySecret`

**Lines 111, 130, and ~1358.** Three separate code examples for `CdpWalletProvider.configureWithWallet()` use `apiKeyPrivate`:

```typescript
await CdpWalletProvider.configureWithWallet({
  apiKeyId: "CDP API KEY NAME",
  apiKeyPrivate: "CDP API KEY SECRET",  // ← not in CdpProviderConfig
});
```

But the actual interface at `typescript/agentkit/src/wallet-providers/cdp/cdpShared.ts:13` defines the field as `apiKeySecret`. TypeScript will silently drop the unrecognized field, so following these examples produces a working type-check but a failing runtime authentication call.

Fixed all three occurrences:

```diff
- apiKeyPrivate: "CDP API KEY SECRET",
+ apiKeySecret: "CDP API KEY SECRET",
```

### 3. Disambiguate adjacent code blocks with conflicting parameter names

**Lines 86 and 107.** Two code blocks sit right next to each other but use entirely different parameter naming conventions:

- `AgentKit.from()` shortcut → `cdpApiKeyId` / `cdpApiKeySecret`
- `CdpWalletProvider.configureWithWallet()` → `apiKeyId` / `apiKeySecret`

This is almost certainly the root cause of how the `apiKeyPrivate` typo propagated to three separate locations in fix #2 — readers copy-paste from the wrong block.

Added a one-line clarifying comment to each block:

```diff
+ // When using the AgentKit.from() shortcut:
  const agentKit = AgentKit.from({ ... });
```

```diff
+ // When constructing a wallet provider manually:
  await CdpWalletProvider.configureWithWallet({ ... });
```

## Verification

- ✅ Only `typescript/agentkit/README.md` modified
- ✅ Verified `CdpSmartWalletProvider` against `agentkit.ts:57`
- ✅ Verified `apiKeySecret` against `cdpShared.ts:13`
- ✅ No code changes — doc-only