### PR TITLE
docs: use https:// for GitHub link in create-onchain-agent READMEs

### DIFF
--- a/python/create-onchain-agent/README.md
+++ b/python/create-onchain-agent/README.md
@@ -88,5 +88,5 @@ poetry run python chatbot.py
 ## Documentation & Support
 
 - **Docs:** [https://docs.cdp.coinbase.com/agentkit/docs/welcome](https://docs.cdp.coinbase.com/agentkit/docs/welcome)
-- **GitHub Repo:** [http://github.com/coinbase/agentkit](http://github.com/coinbase/agentkit)
+- **GitHub Repo:** [https://github.com/coinbase/agentkit](https://github.com/coinbase/agentkit)
 - **Community & Support:** [https://discord.gg/CDP](https://discord.gg/CDP)

--- a/typescript/create-onchain-agent/README.md
+++ b/typescript/create-onchain-agent/README.md
@@ -63,5 +63,5 @@ agentkit generate create-agent
 ## Documentation & Support
 
 - **Docs:** [https://docs.cdp.coinbase.com/agentkit/docs/welcome](https://docs.cdp.coinbase.com/agentkit/docs/welcome)
-- **GitHub Repo:** [http://github.com/coinbase/agentkit](http://github.com/coinbase/agentkit)
+- **GitHub Repo:** [https://github.com/coinbase/agentkit](https://github.com/coinbase/agentkit)
 - **Community & Support:** [https://discord.gg/CDP](https://discord.gg/CDP)


### PR DESCRIPTION
## Summary

Both create-onchain-agent README files (TypeScript and Python) link to the AgentKit GitHub repo via `http://github.com` instead of `https://github.com`.

## Changes

**`typescript/create-onchain-agent/README.md`** (line 66):
```diff
- - **GitHub Repo:** [http://github.com/coinbase/agentkit](http://github.com/coinbase/agentkit)
+ - **GitHub Repo:** [https://github.com/coinbase/agentkit](https://github.com/coinbase/agentkit)
```

**`python/create-onchain-agent/README.md`** (line 91):
```diff
- - **GitHub Repo:** [http://github.com/coinbase/agentkit](http://github.com/coinbase/agentkit)
+ - **GitHub Repo:** [https://github.com/coinbase/agentkit](https://github.com/coinbase/agentkit)
```

## Why it matters

GitHub has [required HTTPS since 2018](https://github.blog/news-insights/the-library/improving-git-protocol-security-on-github/), so the HTTP URL works only via an immediate 301 redirect. Beyond the redirect cost:

- Corporate proxies and link checkers often flag `http://github.com` as insecure
- Some security scanners block `http://` external links in documentation entirely
- The `http://` link sets a bad example for users learning to build onchain agents

## Verification

- ✅ Only 2 README files modified
- ✅ Both the link label and the URL updated in each file
- ✅ No other content touched