### PR TITLE
feat(action-providers): add AlgoVault action provider

### DIFF
--- a/typescript/.changeset/algovault-action-provider.md
+++ b/typescript/.changeset/algovault-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added a new action provider for AlgoVault crypto trading signals (composite BUY/SELL/HOLD trade calls, market regime, and cross-venue funding arbitrage) over the AlgoVault MCP endpoint.

--- a/typescript/agentkit/package.json
+++ b/typescript/agentkit/package.json
@@ -46,6 +46,7 @@
     "@dtelecom/x402-client": "^0.1.3",
     "@ensofinance/sdk": "^2.0.6",
     "@jup-ag/api": "^6.0.39",
+    "@modelcontextprotocol/sdk": "^1.27.0",
     "@privy-io/public-api": "2.18.5",
     "@privy-io/server-auth": "1.18.4",
     "@solana/kit": "^2.1.1",

--- a/typescript/agentkit/src/action-providers/algovault/README.md
+++ b/typescript/agentkit/src/action-providers/algovault/README.md
@@ -1,0 +1,107 @@
+# AlgoVault Action Provider
+
+This directory contains the AlgoVault action provider implementation, which gives an agent
+access to AlgoVault's crypto trading signals: composite BUY/SELL/HOLD trade calls, market-regime
+classification, and cross-venue funding-rate arbitrage scanning.
+
+The provider is **walletless** and **read-only**. It speaks MCP directly to the AlgoVault MCP
+server (`api.algovault.com/mcp`) over Streamable HTTP — the same surface every AlgoVault client
+uses. All verdicts are backed by AlgoVault's verified, on-chain (Base Merkle-anchored) track
+record: [algovault.com/track-record](https://algovault.com/track-record).
+
+## Getting Started
+
+The free tier is **keyless** — no API key is required, so the provider works out of the box:
+
+```typescript
+import { algoVaultActionProvider } from "@coinbase/agentkit";
+
+const provider = algoVaultActionProvider();
+```
+
+An optional API key unlocks paid-tier limits. Provide it via the constructor or the
+`ALGOVAULT_API_KEY` environment variable:
+
+```typescript
+const provider = algoVaultActionProvider({
+  apiKey: "your_algovault_api_key",
+});
+```
+
+### Environment Variables
+
+```
+ALGOVAULT_API_KEY   # optional — only needed for paid tiers
+```
+
+## Directory Structure
+
+```
+algovault/
+├── algovaultActionProvider.test.ts  # Tests for the provider
+├── algovaultActionProvider.ts       # Main provider with the AlgoVault actions
+├── constants.ts                     # Endpoint, client info, and enum constants
+├── index.ts                         # Main exports
+├── README.md                        # Documentation
+├── schemas.ts                       # Action input schemas
+├── types.ts                         # Type definitions
+└── utils.ts                         # MCP client and error-formatting helpers
+```
+
+## Actions
+
+- `get_trade_call`: Composite BUY/SELL/HOLD trade call for a crypto perpetual-futures market (or a
+  supported TradFi symbol). Inputs: `coin`, optional `timeframe` (default `15m`), optional
+  `exchange` (default `BINANCE`), optional `includeReasoning`. Returns verdict, confidence, market
+  regime, funding rate, and reasoning. **Free.**
+- `get_trade_signal`: Alias of `get_trade_call` (same behavior, kept for backward compatibility).
+- `get_market_regime`: Classifies the market regime — `TRENDING_UP`, `TRENDING_DOWN`, `RANGING`, or
+  `VOLATILE`. Inputs: `coin`, optional `timeframe` (`1h`/`4h`/`1d`, default `4h`), optional
+  `exchange` (default `HL`). Returns the regime label, confidence, and a strategy hint.
+- `scan_funding_arb`: Scans for cross-venue funding-rate arbitrage opportunities across Binance,
+  Bybit, OKX, Bitget, and Hyperliquid. Inputs: optional `minSpreadBps` (default `5`), optional
+  `limit` (default `10`). Returns ranked opportunities with the funding spread per venue pair.
+
+## Rate Limiting
+
+The free tier allows **100 calls/month** and requires no API key. `HOLD` verdicts never cost
+quota. Paid tiers (set via `ALGOVAULT_API_KEY`) raise the monthly limit — see
+[algovault.com/pricing](https://algovault.com/pricing).
+
+## Examples
+
+### Composite trade call
+
+*What's the trade call for BTC right now?*
+
+<details>
+<summary>Tool Output</summary>
+
+```json
+{
+  "call": "HOLD",
+  "confidence": 15,
+  "price": 64202,
+  "indicators": {
+    "funding_rate": -0.00001362,
+    "funding_state": "ELEVATED",
+    "oi_change_pct": -3.7,
+    "volume_24h": 30454436125.28,
+    "trend_persistence": "HIGH",
+    "underlying_session": "ALWAYS_OPEN"
+  },
+  "regime": "TRENDING_UP",
+  "reasoning": "Trending regime, upward bias. Funding pressure elevated; one-sided crowd forming. Trend persistence elevated; momentum structure. No actionable setup at this snapshot.",
+  "coin": "BTC",
+  "timeframe": "15m",
+  "_algovault": {
+    "version": "1.20.0",
+    "tool": "get_trade_call",
+    "exchange": "BINANCE"
+  }
+}
+```
+
+</details>
+
+This output was produced by a live, keyless call against the AlgoVault free tier.

--- a/typescript/agentkit/src/action-providers/algovault/algovaultActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/algovault/algovaultActionProvider.test.ts
@@ -1,0 +1,297 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { algoVaultActionProvider, AlgoVaultActionProvider } from "./algovaultActionProvider";
+import { GetTradeCallSchema, GetMarketRegimeSchema, ScanFundingArbSchema } from "./schemas";
+import { extractToolText, formatAlgoVaultToolError, formatAlgoVaultError } from "./utils";
+import { ALGOVAULT_MCP_URL } from "./constants";
+
+jest.mock("@modelcontextprotocol/sdk/client/index.js");
+jest.mock("@modelcontextprotocol/sdk/client/streamableHttp.js");
+
+const MockedTransport = StreamableHTTPClientTransport as jest.MockedClass<
+  typeof StreamableHTTPClientTransport
+>;
+
+const mockConnect = Client.prototype.connect as jest.Mock;
+const mockCallTool = Client.prototype.callTool as jest.Mock;
+const mockClose = Client.prototype.close as jest.Mock;
+
+/**
+ * Builds a successful MCP tool result with the given JSON payload as text.
+ *
+ * @param payload - The object to serialize as the tool's text content.
+ * @returns A mock MCP `tools/call` result.
+ */
+function textResult(payload: unknown) {
+  return { content: [{ type: "text", text: JSON.stringify(payload) }] };
+}
+
+const TRADE_CALL_VERDICT = {
+  call: "HOLD",
+  confidence: 15,
+  regime: "TRENDING_UP",
+  coin: "BTC",
+  timeframe: "15m",
+};
+
+describe("AlgoVaultActionProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.ALGOVAULT_API_KEY;
+    mockConnect.mockResolvedValue(undefined);
+    mockClose.mockResolvedValue(undefined);
+    mockCallTool.mockResolvedValue(textResult(TRADE_CALL_VERDICT));
+  });
+
+  describe("constructor", () => {
+    it("should initialize keyless (no API key) without throwing", () => {
+      const provider = algoVaultActionProvider();
+      expect(provider).toBeInstanceOf(AlgoVaultActionProvider);
+      expect(provider["apiKey"]).toBeUndefined();
+      expect(provider["baseUrl"]).toBe(ALGOVAULT_MCP_URL);
+    });
+
+    it("should read the API key from the constructor config", () => {
+      const provider = algoVaultActionProvider({ apiKey: "custom-key" });
+      expect(provider["apiKey"]).toBe("custom-key");
+    });
+
+    it("should read the API key from the ALGOVAULT_API_KEY env var", () => {
+      process.env.ALGOVAULT_API_KEY = "env-key";
+      expect(algoVaultActionProvider()["apiKey"]).toBe("env-key");
+    });
+
+    it("should allow overriding the base URL", () => {
+      const provider = algoVaultActionProvider({ baseUrl: "https://example.test/mcp" });
+      expect(provider["baseUrl"]).toBe("https://example.test/mcp");
+    });
+  });
+
+  describe("getTradeCall", () => {
+    it("should return the verdict text and call the correct tool", async () => {
+      const provider = algoVaultActionProvider();
+      const args = {
+        coin: "BTC",
+        timeframe: "15m" as const,
+        includeReasoning: true,
+        exchange: "BINANCE" as const,
+      };
+
+      const result = await provider.getTradeCall(args);
+
+      expect(mockCallTool).toHaveBeenCalledWith({ name: "get_trade_call", arguments: args });
+      expect(result).toContain("HOLD");
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it("should connect keyless (no Authorization header) by default", async () => {
+      const provider = algoVaultActionProvider();
+      await provider.getTradeCall({
+        coin: "BTC",
+        timeframe: "15m",
+        includeReasoning: true,
+        exchange: "BINANCE",
+      });
+
+      const [url, options] = MockedTransport.mock.calls[0];
+      expect(url.toString()).toBe(ALGOVAULT_MCP_URL);
+      expect(options?.requestInit).toBeUndefined();
+    });
+
+    it("should send a bearer Authorization header when an API key is set", async () => {
+      const provider = algoVaultActionProvider({ apiKey: "secret" });
+      await provider.getTradeCall({
+        coin: "ETH",
+        timeframe: "1h",
+        includeReasoning: true,
+        exchange: "HL",
+      });
+
+      const [, options] = MockedTransport.mock.calls[0];
+      expect(options?.requestInit?.headers).toEqual({ Authorization: "Bearer secret" });
+    });
+
+    it("should surface a transport-level failure as a structured error", async () => {
+      mockCallTool.mockRejectedValueOnce(new Error("network down"));
+      const provider = algoVaultActionProvider();
+
+      const result = await provider.getTradeCall({
+        coin: "BTC",
+        timeframe: "15m",
+        includeReasoning: true,
+        exchange: "BINANCE",
+      });
+
+      expect(result).toContain("AlgoVault get_trade_call request failed: network down");
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it("should surface an AlgoVault structured tool error with suggestions", async () => {
+      mockCallTool.mockResolvedValueOnce({
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: "Symbol not in universe",
+              code: "SYMBOL_NOT_IN_UNIVERSE",
+              suggested_symbols: ["BTC", "ETH"],
+            }),
+          },
+        ],
+      });
+      const provider = algoVaultActionProvider();
+
+      const result = await provider.getTradeCall({
+        coin: "NOTACOIN",
+        timeframe: "15m",
+        includeReasoning: true,
+        exchange: "BINANCE",
+      });
+
+      expect(result).toContain("AlgoVault get_trade_call error [SYMBOL_NOT_IN_UNIVERSE]");
+      expect(result).toContain("Symbol not in universe");
+      expect(result).toContain("suggested_symbols");
+    });
+  });
+
+  describe("other actions", () => {
+    it("getTradeSignal should call the get_trade_signal tool", async () => {
+      const provider = algoVaultActionProvider();
+      await provider.getTradeSignal({
+        coin: "BTC",
+        timeframe: "15m",
+        includeReasoning: true,
+        exchange: "BINANCE",
+      });
+      expect(mockCallTool).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "get_trade_signal" }),
+      );
+    });
+
+    it("getMarketRegime should call the get_market_regime tool", async () => {
+      mockCallTool.mockResolvedValueOnce(textResult({ regime: "RANGING", confidence: 60 }));
+      const provider = algoVaultActionProvider();
+      const result = await provider.getMarketRegime({
+        coin: "BTC",
+        timeframe: "4h",
+        exchange: "HL",
+      });
+      expect(mockCallTool).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "get_market_regime" }),
+      );
+      expect(result).toContain("RANGING");
+    });
+
+    it("scanFundingArb should call the scan_funding_arb tool", async () => {
+      mockCallTool.mockResolvedValueOnce(textResult([{ pair: "BINANCE/HL", spreadBps: 12 }]));
+      const provider = algoVaultActionProvider();
+      const result = await provider.scanFundingArb({ minSpreadBps: 5, limit: 10 });
+      expect(mockCallTool).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "scan_funding_arb" }),
+      );
+      expect(result).toContain("spreadBps");
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should always return true (network-agnostic)", () => {
+      const provider = algoVaultActionProvider();
+      expect(provider.supportsNetwork({ protocolFamily: "evm" })).toBe(true);
+      expect(provider.supportsNetwork({ protocolFamily: "svm" })).toBe(true);
+      expect(provider.supportsNetwork({ protocolFamily: "unknown" })).toBe(true);
+    });
+  });
+});
+
+describe("utils", () => {
+  describe("extractToolText", () => {
+    it("should join text content blocks", () => {
+      expect(
+        extractToolText(
+          {
+            content: [
+              { type: "text", text: "a" },
+              { type: "text", text: "b" },
+            ],
+          },
+          "t",
+        ),
+      ).toBe("a\nb");
+    });
+
+    it("should report an empty response when no text content is present", () => {
+      expect(extractToolText({ content: [] }, "get_trade_call")).toContain("empty response");
+      expect(extractToolText({}, "get_trade_call")).toContain("empty response");
+    });
+
+    it("should format a tool error when isError is set", () => {
+      const out = extractToolText(
+        { isError: true, content: [{ type: "text", text: '{"error":"boom"}' }] },
+        "get_trade_call",
+      );
+      expect(out).toContain("AlgoVault get_trade_call error");
+      expect(out).toContain("boom");
+    });
+  });
+
+  describe("formatAlgoVaultToolError", () => {
+    it("should include code, message, and suggested_* fields", () => {
+      const out = formatAlgoVaultToolError(
+        JSON.stringify({ code: "X", error: "bad", suggested_action: "retry" }),
+        "scan_funding_arb",
+      );
+      expect(out).toContain("[X]");
+      expect(out).toContain("bad");
+      expect(out).toContain("suggested_action: retry");
+    });
+
+    it("should fall back to raw text for non-JSON input", () => {
+      expect(formatAlgoVaultToolError("plain text error", "get_market_regime")).toContain(
+        "plain text error",
+      );
+    });
+
+    it("should report 'unknown error' for empty text", () => {
+      expect(formatAlgoVaultToolError("", "get_market_regime")).toContain("unknown error");
+    });
+  });
+
+  describe("formatAlgoVaultError", () => {
+    it("should format Error instances", () => {
+      expect(formatAlgoVaultError(new Error("nope"), "get_trade_call")).toContain("nope");
+    });
+
+    it("should stringify non-Error values", () => {
+      expect(formatAlgoVaultError("weird", "get_trade_call")).toContain("weird");
+    });
+  });
+});
+
+describe("schemas", () => {
+  it("GetTradeCallSchema applies defaults", () => {
+    expect(GetTradeCallSchema.parse({ coin: "BTC" })).toEqual({
+      coin: "BTC",
+      timeframe: "15m",
+      includeReasoning: true,
+      exchange: "BINANCE",
+    });
+  });
+
+  it("GetTradeCallSchema rejects an over-long coin", () => {
+    expect(() => GetTradeCallSchema.parse({ coin: "X".repeat(21) })).toThrow();
+  });
+
+  it("GetMarketRegimeSchema applies defaults and rejects an unsupported timeframe", () => {
+    expect(GetMarketRegimeSchema.parse({ coin: "BTC" })).toEqual({
+      coin: "BTC",
+      timeframe: "4h",
+      exchange: "HL",
+    });
+    expect(() => GetMarketRegimeSchema.parse({ coin: "BTC", timeframe: "5m" })).toThrow();
+  });
+
+  it("ScanFundingArbSchema applies defaults", () => {
+    expect(ScanFundingArbSchema.parse({})).toEqual({ minSpreadBps: 5, limit: 10 });
+  });
+});

--- a/typescript/agentkit/src/action-providers/algovault/algovaultActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/algovault/algovaultActionProvider.ts
@@ -1,0 +1,160 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { Network } from "../../network";
+import {
+  GetTradeCallSchema,
+  GetTradeSignalSchema,
+  GetMarketRegimeSchema,
+  ScanFundingArbSchema,
+} from "./schemas";
+import { ALGOVAULT_MCP_URL } from "./constants";
+import { AlgoVaultActionProviderConfig } from "./types";
+import { callAlgoVaultTool, formatAlgoVaultError } from "./utils";
+
+/**
+ * AlgoVaultActionProvider exposes AlgoVault's crypto trading signals to an
+ * AgentKit agent. It is a walletless, read-only data provider that calls the
+ * AlgoVault MCP server (`api.algovault.com/mcp`) over Streamable HTTP.
+ *
+ * The free tier is keyless (no API key required); an optional `ALGOVAULT_API_KEY`
+ * unlocks paid-tier limits. All verdicts are backed by AlgoVault's verified,
+ * on-chain (Base Merkle-anchored) track record.
+ *
+ * @augments ActionProvider
+ */
+export class AlgoVaultActionProvider extends ActionProvider {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+
+  /**
+   * Constructor for the AlgoVaultActionProvider class.
+   *
+   * @param config - The configuration options for the AlgoVaultActionProvider.
+   */
+  constructor(config: AlgoVaultActionProviderConfig = {}) {
+    super("algovault", []);
+
+    // Keyless by default — the free tier needs no key. An optional key (config
+    // or ALGOVAULT_API_KEY) unlocks paid-tier limits.
+    this.apiKey = config.apiKey ?? process.env.ALGOVAULT_API_KEY;
+    this.baseUrl = config.baseUrl ?? ALGOVAULT_MCP_URL;
+  }
+
+  /**
+   * Returns AlgoVault's composite BUY/SELL/HOLD trade call for a market.
+   *
+   * @param args - The trade-call inputs (coin, timeframe, exchange, reasoning).
+   * @returns A JSON string with the verdict, confidence, regime, and reasoning.
+   */
+  @CreateAction({
+    name: "get_trade_call",
+    description: `
+This tool returns AlgoVault's composite BUY / SELL / HOLD trade call for a crypto perpetual-futures market (or a supported TradFi symbol).
+It takes a coin symbol (e.g. BTC, ETH, SOL), an optional candle timeframe (default 15m), an optional perp venue (default BINANCE), and whether to include reasoning.
+Returns a JSON object with the verdict, confidence, market regime, funding rate, and reasoning, backed by AlgoVault's verified, on-chain (Base Merkle-anchored) track record. The free tier is keyless — no API key required.
+`,
+    schema: GetTradeCallSchema,
+  })
+  async getTradeCall(args: z.infer<typeof GetTradeCallSchema>): Promise<string> {
+    return this.callTool("get_trade_call", args);
+  }
+
+  /**
+   * Alias of `get_trade_call` (same behavior, kept for backward compatibility).
+   *
+   * @param args - The trade-call inputs (coin, timeframe, exchange, reasoning).
+   * @returns A JSON string with the verdict, confidence, regime, and reasoning.
+   */
+  @CreateAction({
+    name: "get_trade_signal",
+    description: `
+Alias of get_trade_call — returns AlgoVault's composite BUY / SELL / HOLD trade call (same behavior, kept for backward compatibility). Prefer get_trade_call for new integrations.
+It takes a coin symbol, an optional timeframe (default 15m), an optional perp venue (default BINANCE), and whether to include reasoning.
+Returns a JSON object with the verdict, confidence, market regime, funding rate, and reasoning, backed by AlgoVault's verified, on-chain (Base Merkle-anchored) track record.
+`,
+    schema: GetTradeSignalSchema,
+  })
+  async getTradeSignal(args: z.infer<typeof GetTradeSignalSchema>): Promise<string> {
+    return this.callTool("get_trade_signal", args);
+  }
+
+  /**
+   * Classifies the current market regime for a market.
+   *
+   * @param args - The regime inputs (coin, timeframe, exchange).
+   * @returns A JSON string with the regime label, confidence, and strategy hint.
+   */
+  @CreateAction({
+    name: "get_market_regime",
+    description: `
+This tool classifies the current market regime — TRENDING_UP, TRENDING_DOWN, RANGING, or VOLATILE — for a crypto perpetual-futures market.
+It takes a coin symbol, an optional timeframe (1h / 4h / 1d, default 4h), and an optional perp venue (default HL).
+Returns a JSON object with the regime label, confidence, and a strategy hint, blending trend/ranging signals, volatility, and cross-venue funding sentiment. Backed by AlgoVault's verified, on-chain (Base Merkle-anchored) track record.
+`,
+    schema: GetMarketRegimeSchema,
+  })
+  async getMarketRegime(args: z.infer<typeof GetMarketRegimeSchema>): Promise<string> {
+    return this.callTool("get_market_regime", args);
+  }
+
+  /**
+   * Scans for cross-venue funding-rate arbitrage opportunities.
+   *
+   * @param args - The scan inputs (minimum spread, result limit).
+   * @returns A JSON string listing ranked funding-arbitrage opportunities.
+   */
+  @CreateAction({
+    name: "scan_funding_arb",
+    description: `
+This tool scans for cross-venue funding-rate arbitrage opportunities across Binance, Bybit, OKX, Bitget, and Hyperliquid perpetual futures (long one venue, short another).
+It takes an optional minimum funding-rate spread in basis points (default 5) and an optional result limit (default 10; the keyless free tier returns up to 5).
+Returns a JSON list of ranked opportunities with the funding spread per venue pair. Backed by AlgoVault's verified, on-chain (Base Merkle-anchored) track record.
+`,
+    schema: ScanFundingArbSchema,
+  })
+  async scanFundingArb(args: z.infer<typeof ScanFundingArbSchema>): Promise<string> {
+    return this.callTool("scan_funding_arb", args);
+  }
+
+  /**
+   * Checks if the action provider supports the given network. AlgoVault signals
+   * are network-agnostic, so this always returns true.
+   *
+   * @param _ - The network to check (unused).
+   * @returns Always true — AlgoVault signals are network-agnostic.
+   */
+  supportsNetwork(_: Network): boolean {
+    return true;
+  }
+
+  /**
+   * Invokes an AlgoVault MCP tool and returns its text content, converting any
+   * transport-level failure into a structured, LLM-readable error string.
+   *
+   * @param name - The AlgoVault MCP tool name.
+   * @param args - The tool arguments.
+   * @returns The tool result text, or a formatted error string.
+   */
+  private async callTool(name: string, args: Record<string, unknown>): Promise<string> {
+    try {
+      return await callAlgoVaultTool({
+        baseUrl: this.baseUrl,
+        apiKey: this.apiKey,
+        name,
+        arguments: args,
+      });
+    } catch (error) {
+      return formatAlgoVaultError(error, name);
+    }
+  }
+}
+
+/**
+ * Factory function to create a new AlgoVaultActionProvider instance.
+ *
+ * @param config - The configuration options for the AlgoVaultActionProvider.
+ * @returns A new instance of AlgoVaultActionProvider.
+ */
+export const algoVaultActionProvider = (config: AlgoVaultActionProviderConfig = {}) =>
+  new AlgoVaultActionProvider(config);

--- a/typescript/agentkit/src/action-providers/algovault/constants.ts
+++ b/typescript/agentkit/src/action-providers/algovault/constants.ts
@@ -1,0 +1,61 @@
+/**
+ * Default AlgoVault MCP endpoint (Streamable HTTP transport).
+ *
+ * The provider speaks MCP directly to this endpoint — the same surface every
+ * AlgoVault client uses. The free tier is keyless; an optional API key unlocks
+ * paid tiers.
+ */
+export const ALGOVAULT_MCP_URL = "https://api.algovault.com/mcp";
+
+/**
+ * Client identity reported to the AlgoVault MCP server during the handshake.
+ */
+export const ALGOVAULT_CLIENT_INFO = {
+  name: "agentkit-algovault-action-provider",
+  version: "1.0.0",
+} as const;
+
+/**
+ * Supported candle timeframes for the trade-call actions (mirrors the live tool enum).
+ */
+export const TRADE_TIMEFRAMES = [
+  "1m",
+  "3m",
+  "5m",
+  "15m",
+  "30m",
+  "1h",
+  "2h",
+  "4h",
+  "8h",
+  "12h",
+  "1d",
+] as const;
+
+/**
+ * Supported candle timeframes for the market-regime action (mirrors the live tool enum).
+ */
+export const REGIME_TIMEFRAMES = ["1h", "4h", "1d"] as const;
+
+/**
+ * Supported perpetual-futures venues (mirrors the live tool enum).
+ */
+export const EXCHANGES = [
+  "HL",
+  "BINANCE",
+  "BYBIT",
+  "OKX",
+  "BITGET",
+  "ASTER",
+  "EDGEX",
+  "GATE",
+  "MEXC",
+  "KUCOIN",
+  "PHEMEX",
+  "BINGX",
+  "HTX",
+  "WEEX",
+  "BITMART",
+  "XT",
+  "WHITEBIT",
+] as const;

--- a/typescript/agentkit/src/action-providers/algovault/index.ts
+++ b/typescript/agentkit/src/action-providers/algovault/index.ts
@@ -1,0 +1,5 @@
+export * from "./algovaultActionProvider";
+export * from "./schemas";
+export * from "./types";
+export * from "./constants";
+export * from "./utils";

--- a/typescript/agentkit/src/action-providers/algovault/schemas.ts
+++ b/typescript/agentkit/src/action-providers/algovault/schemas.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { TRADE_TIMEFRAMES, REGIME_TIMEFRAMES, EXCHANGES } from "./constants";
+
+/**
+ * Input schema for `get_trade_call` — a composite BUY/SELL/HOLD trade call.
+ */
+export const GetTradeCallSchema = z
+  .object({
+    coin: z
+      .string()
+      .max(20)
+      .describe(
+        "Asset symbol — e.g. BTC, ETH, SOL — for crypto perpetual futures, or a supported TradFi symbol.",
+      ),
+    timeframe: z
+      .enum(TRADE_TIMEFRAMES)
+      .default("15m")
+      .describe("Candle timeframe (1m to 1d). Defaults to 15m intraday."),
+    includeReasoning: z
+      .boolean()
+      .default(true)
+      .describe("Include the reasoning behind the verdict (regime, trend/ranging signals)."),
+    exchange: z
+      .enum(EXCHANGES)
+      .default("BINANCE")
+      .describe("Perpetual-futures venue — BINANCE (default), HL, BYBIT, OKX, BITGET, …"),
+  })
+  .describe("Input for an AlgoVault composite trade call.");
+
+/**
+ * Input schema for `get_trade_signal` — identical to `get_trade_call`
+ * (kept as a backward-compatibility alias).
+ */
+export const GetTradeSignalSchema = GetTradeCallSchema;
+
+/**
+ * Input schema for `get_market_regime` — the market-regime classifier.
+ */
+export const GetMarketRegimeSchema = z
+  .object({
+    coin: z.string().max(20).describe("Asset symbol — e.g. BTC, ETH, SOL."),
+    timeframe: z
+      .enum(REGIME_TIMEFRAMES)
+      .default("4h")
+      .describe("Candle timeframe — 1h, 4h, or 1d. Defaults to 4h."),
+    exchange: z
+      .enum(EXCHANGES)
+      .default("HL")
+      .describe("Perpetual-futures venue — HL (default), BINANCE, BYBIT, OKX, BITGET, …"),
+  })
+  .describe("Input for the AlgoVault market-regime classifier.");
+
+/**
+ * Input schema for `scan_funding_arb` — the cross-venue funding-arbitrage scanner.
+ */
+export const ScanFundingArbSchema = z
+  .object({
+    minSpreadBps: z
+      .number()
+      .min(0)
+      .max(10000)
+      .default(5)
+      .describe("Minimum funding-rate spread, in basis points, for the cross-venue scan."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .default(10)
+      .describe(
+        "Maximum number of opportunities to return (the keyless free tier returns up to 5).",
+      ),
+  })
+  .describe("Input for the AlgoVault cross-venue funding-arbitrage scan.");

--- a/typescript/agentkit/src/action-providers/algovault/types.ts
+++ b/typescript/agentkit/src/action-providers/algovault/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Configuration options for the AlgoVaultActionProvider.
+ */
+export interface AlgoVaultActionProviderConfig {
+  /**
+   * Optional AlgoVault API key. The free tier is keyless (no key required), so
+   * this is only needed to unlock paid-tier limits. Falls back to the
+   * `ALGOVAULT_API_KEY` environment variable when omitted.
+   */
+  apiKey?: string;
+
+  /**
+   * Optional override for the AlgoVault MCP endpoint. Defaults to
+   * `https://api.algovault.com/mcp`.
+   */
+  baseUrl?: string;
+}
+
+/**
+ * Options for a single AlgoVault MCP tool invocation.
+ */
+export interface AlgoVaultToolCallOptions {
+  /**
+   * The AlgoVault MCP endpoint to call.
+   */
+  baseUrl: string;
+
+  /**
+   * Optional API key sent as a bearer token (paid tiers).
+   */
+  apiKey?: string;
+
+  /**
+   * The name of the AlgoVault MCP tool to invoke.
+   */
+  name: string;
+
+  /**
+   * The arguments for the tool, matching its input schema.
+   */
+  arguments: Record<string, unknown>;
+}
+
+/**
+ * Minimal shape of an MCP `tools/call` result, as returned by the
+ * `@modelcontextprotocol/sdk` client.
+ */
+export interface ToolCallResultLike {
+  /**
+   * The content blocks returned by the tool.
+   */
+  content?: Array<{ type?: string; text?: string }>;
+
+  /**
+   * Whether the tool reported an error.
+   */
+  isError?: boolean;
+}

--- a/typescript/agentkit/src/action-providers/algovault/utils.ts
+++ b/typescript/agentkit/src/action-providers/algovault/utils.ts
@@ -1,0 +1,107 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ALGOVAULT_CLIENT_INFO } from "./constants";
+import { AlgoVaultToolCallOptions, ToolCallResultLike } from "./types";
+
+/**
+ * Invokes a single AlgoVault MCP tool over Streamable HTTP and returns its text
+ * content. The AlgoVault MCP server requires a full stateful handshake, which
+ * the `@modelcontextprotocol/sdk` client manages (session id, SSE, cleanup).
+ *
+ * @param options - The endpoint, optional API key, tool name, and arguments.
+ * @returns The tool's text content (a JSON string on success, or a formatted
+ *   error string when the tool reports a structured error).
+ */
+export async function callAlgoVaultTool(options: AlgoVaultToolCallOptions): Promise<string> {
+  const { baseUrl, apiKey, name, arguments: args } = options;
+
+  const transport = new StreamableHTTPClientTransport(new URL(baseUrl), {
+    requestInit: apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : undefined,
+  });
+
+  const client = new Client({ ...ALGOVAULT_CLIENT_INFO }, { capabilities: {} });
+
+  try {
+    await client.connect(transport);
+    const result = (await client.callTool({ name, arguments: args })) as ToolCallResultLike;
+    return extractToolText(result, name);
+  } finally {
+    // Best-effort cleanup — never mask the original result/error.
+    await client.close().catch(() => undefined);
+  }
+}
+
+/**
+ * Extracts the text content from an MCP tool result, surfacing AlgoVault's
+ * structured errors when the tool reports one.
+ *
+ * @param result - The MCP `tools/call` result.
+ * @param toolName - The tool name, used for error context.
+ * @returns The text content, or a formatted error string.
+ */
+export function extractToolText(result: ToolCallResultLike, toolName: string): string {
+  const content = Array.isArray(result?.content) ? result.content : [];
+  const text = content
+    .filter(
+      (c): c is { type: "text"; text: string } => c?.type === "text" && typeof c.text === "string",
+    )
+    .map(c => c.text)
+    .join("\n")
+    .trim();
+
+  if (result?.isError) {
+    return formatAlgoVaultToolError(text, toolName);
+  }
+
+  if (!text) {
+    return `AlgoVault ${toolName} returned an empty response.`;
+  }
+
+  return text;
+}
+
+/**
+ * Formats a structured AlgoVault tool error. AlgoVault returns errors as JSON
+ * text with an `error`/`code` message and optional `suggested_*` guidance
+ * fields; this surfaces them verbatim so the agent can act on them.
+ *
+ * @param text - The raw error text returned by the tool.
+ * @param toolName - The tool name, used for error context.
+ * @returns A human/LLM-readable error string.
+ */
+export function formatAlgoVaultToolError(text: string, toolName: string): string {
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    const code = parsed.code ?? parsed.error_code;
+    const message = parsed.error ?? parsed.message ?? text;
+    const suggestions = Object.entries(parsed)
+      .filter(([key]) => key.startsWith("suggested_"))
+      .map(
+        ([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`,
+      );
+
+    const parts = [
+      `AlgoVault ${toolName} error${code ? ` [${String(code)}]` : ""}: ${String(message)}`,
+    ];
+    if (suggestions.length > 0) {
+      parts.push(suggestions.join("; "));
+    }
+    return parts.join(" — ");
+  } catch {
+    return `AlgoVault ${toolName} error: ${text || "unknown error"}`;
+  }
+}
+
+/**
+ * Formats a transport/protocol-level error (e.g. the request never reached the
+ * tool).
+ *
+ * @param error - The thrown error.
+ * @param toolName - The tool name, used for error context.
+ * @returns A human/LLM-readable error string.
+ */
+export function formatAlgoVaultError(error: unknown, toolName: string): string {
+  return `AlgoVault ${toolName} request failed: ${
+    error instanceof Error ? error.message : String(error)
+  }`;
+}

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -41,3 +41,4 @@ export * from "./zerion";
 export * from "./zerodev";
 export * from "./zeroX";
 export * from "./zora";
+export * from "./algovault";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@jup-ag/api':
         specifier: ^6.0.39
         version: 6.0.40
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.0
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@privy-io/public-api':
         specifier: 2.18.5
         version: 2.18.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)


### PR DESCRIPTION
## Description

This PR adds a new **AlgoVault** action provider, giving AgentKit agents native access to AlgoVault's crypto trading signals: composite BUY/SELL/HOLD trade calls, market-regime classification, and cross-venue funding-rate arbitrage scanning.

- **Walletless + read-only** data provider (`supportsNetwork` returns true for all networks), modeled on the existing `messari` / `defillama` providers.
- Speaks MCP directly to the AlgoVault MCP server (`api.algovault.com/mcp`) over Streamable HTTP via `@modelcontextprotocol/sdk` (the same SDK already used in `framework-extensions/model-context-protocol`).
- **Keyless free tier** — works out of the box, no API key required. An optional `ALGOVAULT_API_KEY` (constructor config or env var) unlocks paid-tier limits.
- Actions (mirroring the live AlgoVault tools): `get_trade_call` (free), `get_trade_signal` (backward-compat alias), `get_market_regime`, `scan_funding_arb`.
- zod input schemas mirroring the live tool inputs; structured error handling that surfaces AlgoVault's `suggested_*` guidance fields.
- All verdicts are backed by AlgoVault's verified, on-chain (Base Merkle-anchored) track record: https://algovault.com/track-record

## Tests

```
cd typescript/agentkit && pnpm test
# Test Suites: 61 passed, 61 total
# Tests:       889 passed, 889 total   (25 new for the algovault provider)
```

Live, **keyless** end-to-end invocation through the built provider (no API key — free tier):

```
Setup:  algoVaultActionProvider()           // keyless free tier
Prompt: get_trade_call { coin: "BTC" }
```

```json
{
  "call": "HOLD",
  "confidence": 15,
  "price": 63875.4,
  "indicators": {
    "funding_rate": -0.00001279,
    "funding_state": "ELEVATED",
    "oi_change_pct": -3.7,
    "volume_24h": 30049729955.29,
    "trend_persistence": "HIGH",
    "underlying_session": "ALWAYS_OPEN"
  },
  "regime": "TRENDING_UP",
  "reasoning": "Trending regime, upward bias. Funding pressure elevated; one-sided crowd forming. Volatility neither expanding nor compressed. Trend persistence elevated; momentum structure. No actionable setup at this snapshot.",
  "coin": "BTC",
  "timeframe": "15m",
  "_algovault": { "version": "1.20.0", "tool": "get_trade_call", "exchange": "BINANCE" }
}
```

## Checklist

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry
