### PR TITLE
docs(x402): add TWZRD Agent Intel as example Solana x402 MCP service

### DIFF
--- a/typescript/agentkit/src/action-providers/x402/README.md
+++ b/typescript/agentkit/src/action-providers/x402/README.md
@@ -341,3 +341,9 @@ Configuration object values take precedence over environment variables.
 ### Additional Resources
 
 For more information on the **x402 protocol**, visit the [x402 documentation](https://docs.cdp.coinbase.com/x402/overview).
+
+#### Example Solana x402 Services
+
+The following is an example of a live Solana-native x402 MCP server compatible with this provider:
+
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** (`https://intel.twzrd.xyz/mcp`) — First Solana-native x402 MCP server for agent trust scoring. 4 free preflight tools score any Solana wallet; `get_trust_receipt` returns signed `twzrd.receipt.v5` trust tokens via HTTP 402 + USDC on Solana (<1s settlement). MCP config: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`. MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`.


### PR DESCRIPTION
## Summary

Adds TWZRD Agent Intel to the x402 action provider README as an example of a live Solana-native x402 MCP server.

**Why this fits:**
- x402 action provider already supports `solana-mainnet` / `solana-devnet` (in `SUPPORTED_NETWORKS`) and `@x402/svm` — TWZRD Agent Intel is a concrete live service that exercises this Solana path
- TWZRD is the first Solana-native x402 MCP server using the `twzrd.receipt.v5` signed trust token format
- Provides a real-world example developers can drop into `registeredServices` when building Solana-capable agents

**Service details:**
- **URL**: https://intel.twzrd.xyz/mcp
- **Protocol**: x402 v2 on `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (Solana mainnet)
- **Payment**: USDC on Solana (<1s settlement)
- **4 free tools**: `score_wallet`, `get_agent_profile`, `check_trust_level`, `list_top_agents`
- **Paid tool**: `get_trust_receipt` — returns signed `twzrd.receipt.v5` trust token via HTTP 402
- **MCP Registry**: `xyz.twzrd.intel/twzrd-agent-intel`

**Quickstart with this provider:**
```typescript
const provider = x402ActionProvider({
  registeredServices: ["https://intel.twzrd.xyz"],
  allowDynamicServiceRegistration: false,
});
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)