### PR TITLE
docs: fix python generator README link

### DIFF
--- a/CONTRIBUTING-PYTHON.md
+++ b/CONTRIBUTING-PYTHON.md
@@ -35,7 +35,7 @@ Once you have these installed, make sure you install the project dependencies by
 
 An Action is an interface for an AI Agent to interact with the real world: any Python function that you can think of can be used by an Agent via an Action! Actions are grouped by Action Providers, which are classes that contain a collection of actions along with configuration and helper functions.
 
-You can use the `generate-action-provider` script to generate a new action provider. See the [Generate Action Provider](./python/coinbase-agentkit/scripts/generate_action_provider/README.md) for more information.
+You can use the `generate-action-provider` script to generate a new action provider. The generator is documented in the [Action Provider Generator README](./typescript/agentkit/scripts/generate-action-provider/README.md).
 
 Action Components:
 


### PR DESCRIPTION
## Summary
- fix the dead link in `CONTRIBUTING-PYTHON.md`
- point contributors at the generator README that actually exists in the repository

## Validation
- verified the updated relative link resolves successfully
