### PR TITLE
fix(sushi): use parameterized GraphQL variables in findToken

### DIFF
--- a/typescript/agentkit/src/action-providers/sushi/sushiDataActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiDataActionProvider.ts
@@ -56,7 +56,17 @@ Important notes:
           "Content-Type": "application/json",
           Accept: "application/json",
         },
-        body: `{"query":"query { tokenList(chainId: ${chainId}, first: 10, search: \\"${args.search}\\") { address symbol name decimals } }"}`,
+        body: JSON.stringify({
+          query: `query FindToken($chainId: Int!, $search: String!) {
+  tokenList(chainId: $chainId, first: 10, search: $search) {
+    address
+    symbol
+    name
+    decimals
+  }
+}`,
+          variables: { chainId, search: args.search },
+        }),
       });
 
       const response = await request.json();


### PR DESCRIPTION
## What
`SushiDataActionProvider.findToken()` builds its GraphQL request body by interpolating the user-provided `args.search` directly into the query string. This switches to a parameterized query using GraphQL variables (with `JSON.stringify` for the body).

## Why
Interpolating `search` into the query string means special characters in the input can alter the GraphQL query structure rather than being treated purely as data — `FindTokenSchema` only enforces `z.string().min(2)`, so quotes, braces, and GraphQL keywords pass through unescaped. Using variables makes the input always a value, never query syntax, and removes the manual JSON escaping.

## Change
`typescript/agentkit/src/action-providers/sushi/sushiDataActionProvider.ts` — replace the string-interpolated body with a `query FindToken($chainId: Int!, $search: String!)` document plus `variables: { chainId, search: args.search }`. Behavior is unchanged for normal inputs and the returned shape is identical.