### PR TITLE
fix(ssh): run SSHConnectionParams auth validator on pydantic >=2.12

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/ssh/connection.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/ssh/connection.py
@@ -28,21 +28,20 @@ class SSHConnectionParams(BaseModel):
     )
     port: int = Field(22, description="SSH port number")
 
-    @classmethod
     @model_validator(mode="after")
-    def check_auth_method_provided(cls):
+    def check_auth_method_provided(self):
         """Ensure at least one authentication method is provided."""
-        if not any([cls.password, cls.private_key, cls.private_key_path]):
+        if not any([self.password, self.private_key, self.private_key_path]):
             raise ValueError(
                 "At least one authentication method must be provided (password, private_key, or private_key_path)"
             )
 
-        if not cls.host:
+        if not self.host:
             raise ValueError("Host must be provided")
-        if not cls.username:
+        if not self.username:
             raise ValueError("Username must be provided")
 
-        return cls
+        return self
 
 
 class SSHConnectionError(Exception):


### PR DESCRIPTION
## What
`SSHConnectionParams.check_auth_method_provided` is decorated with both `@classmethod` and `@model_validator(mode="after")`. On pydantic >= 2.12 that combination is deprecated and the validator is silently skipped (pydantic emits `PydanticDeprecatedSince212` and does not run it), so `SSHConnectionParams` can be constructed with no authentication method, empty host, or empty username.

## Why
The committed `uv.lock` pins pydantic 2.10.4 (where it still runs), but `pyproject.toml` allows `pydantic~=2.0` (i.e. >= 2.12), and pydantic 3.0 removes the pattern entirely — so on those installs the intended validation is lost.

## Change
`python/coinbase-agentkit/coinbase_agentkit/action_providers/ssh/connection.py` — make `check_auth_method_provided` an instance-method `mode="after"` validator (drop `@classmethod`, use `self`, `return self`), the supported pattern across pydantic 2.x and 3.0.