### PR TITLE
fix(ssh): reject control characters in ssh_add_host_key inputs

### DIFF
--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/ssh/schemas.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/ssh/schemas.py
@@ -6,7 +6,7 @@ for the ssh action provider's actions.
 @module ssh/schemas
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .connection import SSHConnectionParams
 
@@ -87,3 +87,17 @@ class AddHostKeySchema(BaseModel):
         default="~/.ssh/known_hosts",
         description="Path to the known_hosts file",
     )
+
+    @field_validator("host", "key", "key_type")
+    @classmethod
+    def _reject_control_characters(cls, value: str) -> str:
+        r"""Reject ASCII control characters (newline, CR, NUL, etc.).
+
+        ``ssh_add_host_key`` writes ``f"{host} {key_type} {key}\n"`` to the
+        line-oriented ``known_hosts`` file, so an embedded newline in any of
+        these fields would inject additional entries. Keeping them free of
+        control characters ensures each call writes a single, well-formed line.
+        """
+        if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+            raise ValueError("must not contain control characters (e.g. newlines)")
+        return value


### PR DESCRIPTION
## What
The `ssh_add_host_key` action builds a `known_hosts` line from the host, key_type, and key fields and writes it to the line-oriented known_hosts file. The `host`, `key`, and `key_type` fields on `AddHostKeySchema` are only length-validated, so a value containing a newline can write more than one line into `known_hosts`.

## Why
`known_hosts` is line-oriented; an embedded newline in any of these fields breaks the one-entry-per-line invariant and lets a single call add extra entries. Rejecting control characters keeps each call to a single, well-formed entry.

## Change
`python/coinbase-agentkit/coinbase_agentkit/action_providers/ssh/schemas.py` — add a `field_validator` on `host`, `key`, and `key_type` in `AddHostKeySchema` that rejects ASCII control characters (newline, CR, NUL, etc.).