### PR TITLE
feat: add invinoveritas action provider

### DIFF
--- a/.changeset/tame-lions-cheer.md
+++ b/.changeset/tame-lions-cheer.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added a new action provider to interact with invinoveritas

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -485,6 +485,19 @@ const agent = createAgent({
 </table>
 </details>
 <details>
+<summary><strong>invinoveritas</strong></summary>
+<table width="100%">
+<tr>
+    <td width="200"><code>review</code></td>
+    <td width="768">Gets an independent, capital/risk-aware verdict on a proposed action (trade, on-chain transaction, sanctions screening, code diff, etc.) before it executes. Advisory, never blocks; optionally returns a portable signed proof any third party can recompute.</td>
+</tr>
+<tr>
+    <td width="200"><code>verify_proof</code></td>
+    <td width="768">Verifies a signed invinoveritas proof another agent handed you — free, no auth, recomputed against a published key rather than trusted.</td>
+</tr>
+</table>
+</details>
+<details>
 <summary><strong>Messari</strong></summary>
 <table width="100%">
 <tr>

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -16,6 +16,7 @@ export * from "./enso";
 export * from "./erc20";
 export * from "./erc721";
 export * from "./erc8004";
+export * from "./invinoveritas";
 export * from "./farcaster";
 export * from "./jupiter";
 export * from "./messari";

--- a/typescript/agentkit/src/action-providers/invinoveritas/README.md
+++ b/typescript/agentkit/src/action-providers/invinoveritas/README.md
@@ -1,0 +1,89 @@
+# invinoveritas Action Provider
+
+This directory contains the invinoveritas action provider implementation, which provides actions to
+get an independent, capital/risk-aware verdict on a proposed agent action before it executes, and to
+verify a signed proof another agent hands you.
+
+invinoveritas is a verification layer for autonomous agents: a neutral second opinion before an
+irreversible action (`review`), and a free, no-auth way to check a proof another agent presents
+(`verify_proof`) without trusting the presenter or invinoveritas — only the math (BIP-340 schnorr
+against a published key). The verifier keeps a public, Bitcoin-anchored track record of past verdicts
+(wins and losses) at `/ledger`.
+
+Both actions are automated and advisory — the agent decides, and a review call never blocks or throws
+into the agent's main flow. This is not a human-in-the-loop approval step.
+
+## Getting Started
+
+`verify_proof` requires no configuration — it's free and unauthenticated. `review` needs an API key:
+
+1. Get one free: `POST https://api.babyblueviper.com/register {"label":"your-app"}` (free trial calls
+   included, no funding needed to start)
+2. Fund with Lightning sats, USDC (x402 on Base), or a card for continued paid use
+
+### Environment Variables
+
+```
+INVINOVERITAS_API_KEY
+```
+
+Alternatively, configure the provider directly:
+
+```typescript
+import { invinoveritasActionProvider } from "@coinbase/agentkit";
+
+const provider = invinoveritasActionProvider({
+  apiKey: "your_invinoveritas_api_key",
+});
+```
+
+## Directory Structure
+
+```
+invinoveritas/
+├── constants.ts                          # API base URL, timeout, error strings
+├── invinoveritasActionProvider.test.ts   # Tests for the provider
+├── invinoveritasActionProvider.ts        # Main provider: review + verify_proof
+├── index.ts                              # Main exports
+├── README.md                             # Documentation
+├── schemas.ts                            # Action input schemas
+├── types.ts                              # Type definitions
+└── utils.ts                              # postJson fetch helper (shared timeout/error handling)
+```
+
+## Actions
+
+- `review`: Get an independent verdict on a proposed action before executing it
+  - `artifactType='trade'` for a capital-scale-aware risk review (position size vs equity, drawdown, regime)
+  - `artifactType='onchain_action'` for deterministic checks (unlimited approvals, drainers, address poisoning, permit abuse, wrong-chain recipient)
+  - `artifactType='sanctions_screening'` for an overclaim-boundary check on a compliance verdict
+  - `sign=true` returns a portable signed proof any third party can recompute (`POST /verify-proof`), independent of trusting invinoveritas's pipeline
+  - Returns `{ verdict, confidence, summary, issues, alternative_approaches, onchain_risk, proof? }`
+  - Degrades to `{ verdict: "review_unavailable", reason }` on missing key, timeout, or a non-2xx response — never throws
+
+- `verify_proof`: Verify a signed invinoveritas proof another agent handed you (free, no auth)
+  - Recomputes the Nostr event id and checks the BIP-340 schnorr signature against the published key
+  - Pass the signed `event` object, or a stored `proofId`
+  - Returns `{ valid: true|false, checks: {...} }`
+
+## Network Support
+
+`invinoveritas` is API-only — it makes HTTP calls, not wallet operations — so `supportsNetwork` always
+returns `true`. No wallet provider is required to use this action provider.
+
+## Notes
+
+Unlike most action providers in this repo, the constructor does **not** throw when no API key is
+configured. `verify_proof` is a free action that works with zero configuration, and `review` is
+designed to degrade to an advisory `review_unavailable` result rather than block agent construction
+for a user who hasn't set up a key yet.
+
+## Adding New Actions
+
+To add new invinoveritas actions:
+
+1. Define your schema in `schemas.ts`
+2. Implement your action in `invinoveritasActionProvider.ts`
+3. Add corresponding tests in `invinoveritasActionProvider.test.ts`
+
+For more information on invinoveritas, visit [api.babyblueviper.com](https://api.babyblueviper.com).

--- a/typescript/agentkit/src/action-providers/invinoveritas/constants.ts
+++ b/typescript/agentkit/src/action-providers/invinoveritas/constants.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_BASE_URL = "https://api.babyblueviper.com";
+export const DEFAULT_TIMEOUT_MS = 20000;
+export const INVINOVERITAS_API_KEY_MISSING_ERROR =
+  'No invinoveritas API key. Set INVINOVERITAS_API_KEY or pass apiKey to invinoveritasActionProvider(). Get one free: POST https://api.babyblueviper.com/register {"label":"your-app"}.';

--- a/typescript/agentkit/src/action-providers/invinoveritas/index.ts
+++ b/typescript/agentkit/src/action-providers/invinoveritas/index.ts
@@ -1,0 +1,5 @@
+export * from "./invinoveritasActionProvider";
+export * from "./schemas";
+export * from "./types";
+export * from "./constants";
+export * from "./utils";

--- a/typescript/agentkit/src/action-providers/invinoveritas/invinoveritasActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/invinoveritas/invinoveritasActionProvider.test.ts
@@ -1,0 +1,214 @@
+import {
+  invinoveritasActionProvider,
+  InvinoveritasActionProvider,
+} from "./invinoveritasActionProvider";
+
+const MOCK_API_KEY = "invinoveritas-test-key";
+
+const MOCK_REVIEW_RESPONSE = {
+  verdict: "approve",
+  confidence: 0.9,
+  summary: "Looks fine.",
+  issues: [],
+};
+
+const MOCK_VERIFY_PROOF_RESPONSE = {
+  valid: true,
+  checks: {
+    id_integrity: true,
+    signature_valid: true,
+    issued_by_invinoveritas: true,
+    is_proof_event: true,
+  },
+};
+
+describe("InvinoveritasActionProvider", () => {
+  let provider: InvinoveritasActionProvider;
+
+  beforeEach(() => {
+    delete process.env.INVINOVERITAS_API_KEY;
+    provider = invinoveritasActionProvider({ apiKey: MOCK_API_KEY });
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete process.env.INVINOVERITAS_API_KEY;
+  });
+
+  describe("constructor", () => {
+    it("should initialize with API key from constructor", () => {
+      const customProvider = invinoveritasActionProvider({ apiKey: "custom-key" });
+      expect(customProvider["apiKey"]).toBe("custom-key");
+    });
+
+    it("should initialize with API key from environment variable", () => {
+      process.env.INVINOVERITAS_API_KEY = "env-key";
+      const envProvider = invinoveritasActionProvider();
+      expect(envProvider["apiKey"]).toBe("env-key");
+    });
+
+    it("should NOT throw when no API key is provided — verify_proof needs none, and review must degrade, not block construction", () => {
+      expect(() => invinoveritasActionProvider()).not.toThrow();
+    });
+
+    it("should default baseUrl and timeoutMs when not provided", () => {
+      const defaultProvider = invinoveritasActionProvider({ apiKey: "k" });
+      expect(defaultProvider["baseUrl"]).toBe("https://api.babyblueviper.com");
+      expect(defaultProvider["timeoutMs"]).toBe(20000);
+    });
+  });
+
+  describe("review", () => {
+    it("should return review_unavailable (not throw) when no API key is configured", async () => {
+      const noKeyProvider = invinoveritasActionProvider();
+      const response = await noKeyProvider.review({ artifact: "swap 1 ETH for USDC" });
+      const parsed = JSON.parse(response);
+      expect(parsed.verdict).toBe("review_unavailable");
+    });
+
+    it("should successfully fetch a review verdict", async () => {
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_REVIEW_RESPONSE,
+      } as Response);
+
+      const response = await provider.review({
+        artifact: "swap 1 ETH for USDC",
+        artifactType: "onchain_action",
+        sign: true,
+      });
+      const parsed = JSON.parse(response);
+
+      expect(fetchMock).toHaveBeenCalled();
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://api.babyblueviper.com/review");
+      expect(options).toEqual(
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${MOCK_API_KEY}`,
+          }),
+        }),
+      );
+      expect(JSON.parse(options!.body as string)).toEqual({
+        artifact: "swap 1 ETH for USDC",
+        artifact_type: "onchain_action",
+        context: undefined,
+        sign: true,
+      });
+      expect(parsed.verdict).toBe("approve");
+      expect(parsed.confidence).toBe(0.9);
+    });
+
+    it("should default artifact_type to 'general' when not provided", async () => {
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_REVIEW_RESPONSE,
+      } as Response);
+
+      await provider.review({ artifact: "rename a local variable" });
+
+      const [, options] = fetchMock.mock.calls[0];
+      expect(JSON.parse(options!.body as string).artifact_type).toBe("general");
+    });
+
+    it("should degrade to review_unavailable on a non-ok HTTP response, not throw", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 402,
+        json: async () => ({ detail: "Payment Required" }),
+      } as Response);
+
+      const response = await provider.review({ artifact: "swap 1 ETH for USDC" });
+      const parsed = JSON.parse(response);
+      expect(parsed.verdict).toBe("review_unavailable");
+      expect(parsed.reason).toContain("402");
+    });
+
+    it("should degrade to review_unavailable on a network error, not throw", async () => {
+      jest.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+
+      const response = await provider.review({ artifact: "swap 1 ETH for USDC" });
+      const parsed = JSON.parse(response);
+      expect(parsed.verdict).toBe("review_unavailable");
+    });
+
+    it("should surface the proof and recompute_proof_at only when sign=true and a proof is returned", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => ({ ...MOCK_REVIEW_RESPONSE, proof: { event: { id: "abc" } } }),
+      } as Response);
+
+      const response = await provider.review({ artifact: "swap 1 ETH for USDC", sign: true });
+      const parsed = JSON.parse(response);
+      expect(parsed.proof).toEqual({ event: { id: "abc" } });
+      expect(parsed.recompute_proof_at).toBe("https://api.babyblueviper.com/verify-proof");
+    });
+  });
+
+  describe("verifyProof", () => {
+    it("should require either event or proofId", async () => {
+      const response = await provider.verifyProof({});
+      const parsed = JSON.parse(response);
+      expect(parsed.valid).toBe(false);
+      expect(parsed.error).toContain("Provide");
+    });
+
+    it("should work with NO API key configured — free, no-auth action", async () => {
+      const noKeyProvider = invinoveritasActionProvider();
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_VERIFY_PROOF_RESPONSE,
+      } as Response);
+
+      const response = await noKeyProvider.verifyProof({ event: { id: "abc" } });
+      const parsed = JSON.parse(response);
+
+      const [, options] = fetchMock.mock.calls[0];
+      expect((options!.headers as Record<string, string>)["Authorization"]).toBeUndefined();
+      expect(parsed.valid).toBe(true);
+    });
+
+    it("should verify a proof event and return the result unmodified", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_VERIFY_PROOF_RESPONSE,
+      } as Response);
+
+      const response = await provider.verifyProof({ event: { id: "abc" } });
+      expect(JSON.parse(response)).toEqual(MOCK_VERIFY_PROOF_RESPONSE);
+    });
+
+    it("should verify by proofId when event is not provided", async () => {
+      const fetchMock = jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_VERIFY_PROOF_RESPONSE,
+      } as Response);
+
+      await provider.verifyProof({ proofId: "proof-123" });
+
+      const [, options] = fetchMock.mock.calls[0];
+      expect(JSON.parse(options!.body as string)).toEqual({
+        event: undefined,
+        proof_id: "proof-123",
+      });
+    });
+
+    it("should degrade to valid:false on a network error, not throw", async () => {
+      jest.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+
+      const response = await provider.verifyProof({ event: { id: "abc" } });
+      const parsed = JSON.parse(response);
+      expect(parsed.valid).toBe(false);
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should return true for any network — invinoveritas is API-only, no wallet operations", () => {
+      expect(provider.supportsNetwork({ protocolFamily: "evm" } as never)).toBe(true);
+      expect(provider.supportsNetwork({ protocolFamily: "svm" } as never)).toBe(true);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/invinoveritas/invinoveritasActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/invinoveritas/invinoveritasActionProvider.ts
@@ -1,0 +1,174 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { Network } from "../../network";
+import { ReviewSchema, VerifyProofSchema } from "./schemas";
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_TIMEOUT_MS,
+  INVINOVERITAS_API_KEY_MISSING_ERROR,
+} from "./constants";
+import { InvinoveritasActionProviderConfig, ReviewApiResponse } from "./types";
+import { postJson } from "./utils";
+
+/**
+ * InvinoveritasActionProvider — the verification layer for AI agents, as an AgentKit action provider.
+ *
+ * What makes this different from a generic reasoning-verifier (and why an agent should prefer it):
+ *  - **Recomputable proof, not a trust-us score.** With `sign: true`, `review` returns a signed
+ *    verdict any third party re-derives from public data (NIP-01 id + BIP-340 schnorr vs a published
+ *    key). You trust the math, not the pipeline.
+ *  - **Independent + a public track record.** The verifier publishes its own hit rate (wins AND
+ *    losses), Nostr + Bitcoin anchored. It is audited, not a black box.
+ *  - **Specialized for the high-stakes actions a wallet/trading agent actually takes** — capital-
+ *    scale-aware trade review and a deterministic on-chain risk engine (unlimited approvals,
+ *    drainers, address poisoning), not generic claim-checking.
+ *  - **Free verification of proofs you receive** — the other half of the trust handshake, no key.
+ *
+ * Automated, agent-decides, never blocks: this is a second opinion the agent calls before an
+ * irreversible step and can override, not a human-in-the-loop approval gate.
+ *
+ * @augments ActionProvider
+ */
+export class InvinoveritasActionProvider extends ActionProvider {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly timeoutMs: number;
+
+  /**
+   * Constructor for the InvinoveritasActionProvider class.
+   *
+   * Deliberately does NOT throw when no API key is configured (unlike most action providers in this
+   * repo) — `verifyProof` is a free, no-auth action that works with zero configuration, and `review`
+   * degrades to an advisory `review_unavailable` result rather than blocking agent construction.
+   *
+   * @param config - The configuration options for the InvinoveritasActionProvider
+   */
+  constructor(config: InvinoveritasActionProviderConfig = {}) {
+    super("invinoveritas", []);
+    this.apiKey = config.apiKey ?? process.env.INVINOVERITAS_API_KEY;
+    this.baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  /**
+   * Requests an independent, capital/risk-aware verdict on a proposed action before it executes.
+   *
+   * @param args - The artifact to review, its type, optional context, and whether to sign the verdict
+   * @returns A JSON string with verdict, confidence, summary, issues, and (if sign=true) a portable proof
+   */
+  @CreateAction({
+    name: "review",
+    description: `Get an INDEPENDENT, capital/risk-aware verdict on a proposed action BEFORE you execute it — the independent second opinion an agent can't self-issue — automated, the agent decides, never blocks.
+
+USE BEFORE any irreversible step:
+- a trade -> set artifactType='trade' for a capital-scale-aware risk review (position size vs equity, drawdown, regime, fee-adjusted edge)
+- a prepared on-chain transaction -> set artifactType='onchain_action' for DETERMINISTIC, recomputable checks (unlimited ERC-20 approval, setApprovalForAll, permit drainers, address poisoning, wrong-chain recipient)
+- a compliance/sanctions-screening result -> set artifactType='sanctions_screening' for an overclaim-boundary check
+- a deploy, config change, code diff, or destructive command
+
+Returns: verdict (approve | approve_with_concerns | reject), confidence (0-1), a summary, and a list of issues.
+
+WHY THIS over a generic reasoning-verifier: set sign=true and you also get a PORTABLE SIGNED PROOF of the verdict that anyone can recompute from public data (POST /verify-proof, or NIP-01 against the published key) — you trust the math, not the pipeline. The verifier itself keeps a PUBLIC, Bitcoin-anchored track record (/ledger) of being right, wins and losses. It is advisory: it informs your decision, it never blocks it. Pay-per-call in USDC (x402 on Base) or Lightning sats; free trial calls on registration.`,
+    schema: ReviewSchema,
+  })
+  async review(args: z.infer<typeof ReviewSchema>): Promise<string> {
+    if (!this.apiKey) {
+      return JSON.stringify({
+        verdict: "review_unavailable",
+        reason: INVINOVERITAS_API_KEY_MISSING_ERROR,
+      });
+    }
+    try {
+      const { ok, status, data } = await postJson(
+        `${this.baseUrl}/review`,
+        {
+          artifact: args.artifact,
+          artifact_type: args.artifactType ?? "general",
+          context: args.context,
+          sign: args.sign ?? false,
+        },
+        { apiKey: this.apiKey, timeoutMs: this.timeoutMs },
+      );
+      // Advisory contract: degrade gracefully, never throw into the agent's main flow.
+      const review = data as ReviewApiResponse | null;
+      if (!ok || !review || typeof review.verdict !== "string") {
+        return JSON.stringify({
+          verdict: "review_unavailable",
+          reason: `Review unavailable (HTTP ${status}). Proceed on your own judgment; this check is advisory and never blocks.`,
+        });
+      }
+      return JSON.stringify({
+        verdict: review.verdict,
+        confidence: review.confidence,
+        summary: review.summary,
+        issues: review.issues ?? [],
+        alternative_approaches: review.alternative_approaches ?? [],
+        onchain_risk: review.onchain_risk,
+        proof: review.proof, // present only when sign=true — recomputable by anyone at /verify-proof
+        recompute_proof_at: review.proof ? `${this.baseUrl}/verify-proof` : undefined,
+      });
+    } catch {
+      return JSON.stringify({
+        verdict: "review_unavailable",
+        reason:
+          "Review timed out or errored. Proceed on your own judgment; this check is advisory and never blocks.",
+      });
+    }
+  }
+
+  /**
+   * Verifies a signed invinoveritas proof handed over by another agent — free, no auth.
+   *
+   * @param args - The signed proof event object, or a stored proof id
+   * @returns A JSON string with `valid` and what was checked
+   */
+  @CreateAction({
+    name: "verify_proof",
+    description: `Verify a signed invinoveritas proof another agent handed you — the RECEIVING half of the agent-to-agent trust handshake. FREE, no auth, no API key.
+
+Recomputes the Nostr event id and checks the BIP-340 schnorr signature against the published key, so you trust NEITHER the presenter NOR invinoveritas — only the math. Use it before you act on a verdict/output another agent claims was verified. Pass the signed 'event' object they gave you (or a 'proofId'). Returns { valid: true|false } plus what was checked.`,
+    schema: VerifyProofSchema,
+  })
+  async verifyProof(args: z.infer<typeof VerifyProofSchema>): Promise<string> {
+    if (!args.event && !args.proofId) {
+      return JSON.stringify({
+        valid: false,
+        error: "Provide `event` (the signed proof object) or `proofId`.",
+      });
+    }
+    try {
+      const { ok, status, data } = await postJson(
+        `${this.baseUrl}/verify-proof`,
+        { event: args.event, proof_id: args.proofId },
+        { timeoutMs: this.timeoutMs }, // free, no auth
+      );
+      if (!ok || !data) {
+        return JSON.stringify({ valid: false, error: `verify-proof unavailable (HTTP ${status})` });
+      }
+      return JSON.stringify(data);
+    } catch {
+      return JSON.stringify({ valid: false, error: "verify-proof timed out or errored." });
+    }
+  }
+
+  /**
+   * Checks if the action provider supports the given network.
+   * invinoveritas is API-only (no wallet operations), so it supports all networks.
+   *
+   * @param _network - The network to check
+   * @returns Always returns true
+   */
+  supportsNetwork(_network: Network): boolean {
+    return true;
+  }
+}
+
+/**
+ * Factory function to create a new InvinoveritasActionProvider instance.
+ *
+ * @param config - The configuration options for the InvinoveritasActionProvider
+ * @returns A new instance of InvinoveritasActionProvider
+ */
+export const invinoveritasActionProvider = (config: InvinoveritasActionProviderConfig = {}) =>
+  new InvinoveritasActionProvider(config);

--- a/typescript/agentkit/src/action-providers/invinoveritas/schemas.ts
+++ b/typescript/agentkit/src/action-providers/invinoveritas/schemas.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Artifact types the /review endpoint specializes on. `trade` triggers a
+ * capital-scale-aware risk review; `onchain_action` triggers deterministic
+ * scam / drainer / unlimited-approval / address-poisoning checks;
+ * `sanctions_screening` triggers overclaim-boundary checks on a compliance verdict.
+ */
+export const ARTIFACT_TYPES = [
+  "code_diff",
+  "patch",
+  "shell_command",
+  "plan",
+  "config_change",
+  "analysis",
+  "agent_output",
+  "trade",
+  "onchain_action",
+  "sanctions_screening",
+  "general",
+] as const;
+
+export const ReviewSchema = z
+  .object({
+    artifact: z
+      .string()
+      .min(1)
+      .max(20000)
+      .describe(
+        "The proposed action to review BEFORE you execute it: a trade, a prepared on-chain transaction, a plan, a code diff, a shell command, or an agent output.",
+      ),
+    artifactType: z
+      .enum(ARTIFACT_TYPES)
+      .optional()
+      .describe(
+        "Tailors the review. Use 'trade' for a proposed entry/exit (capital-scale-aware risk review), 'onchain_action' for a prepared transaction (deterministic scam/drainer/approval/poisoning checks), or 'sanctions_screening' for a compliance verdict. Defaults to 'general'.",
+      ),
+    context: z
+      .string()
+      .max(8000)
+      .optional()
+      .describe("Optional: what you are doing and why — improves the verdict."),
+    sign: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, also returns a portable signed proof of this verdict that anyone can recompute (POST /verify-proof or NIP-01) without trusting you or us. Attach it to whatever you ship.",
+      ),
+  })
+  .strip()
+  .describe("Input schema for requesting an independent pre-action verdict from invinoveritas");
+
+export const VerifyProofSchema = z
+  .object({
+    event: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe(
+        "The signed proof object {id,pubkey,created_at,kind,tags,content,sig} another agent handed you (from their /review sign=true or /prove response). Trustless path — verified locally against the published key.",
+      ),
+    proofId: z
+      .string()
+      .optional()
+      .describe("Alternatively, a stored attestation proof_id to fetch and verify."),
+  })
+  .strip()
+  .describe("Input schema for verifying a signed invinoveritas proof, free and no auth");

--- a/typescript/agentkit/src/action-providers/invinoveritas/types.ts
+++ b/typescript/agentkit/src/action-providers/invinoveritas/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Configuration for the invinoveritas action provider.
+ */
+export interface InvinoveritasActionProviderConfig {
+  /** Bearer API key for paid /review calls. Free: POST /register {"label":"your-app"}. Falls back to env INVINOVERITAS_API_KEY. */
+  apiKey?: string;
+  /** Override the API base URL (default https://api.babyblueviper.com). */
+  baseUrl?: string;
+  /** Per-call timeout in ms (default 20000). Reviews are advisory and must never stall the agent. */
+  timeoutMs?: number;
+}
+
+export interface PostJsonResult {
+  ok: boolean;
+  status: number;
+  data: unknown;
+}
+
+/** Shape of a successful /review response — only the fields this provider reads. */
+export interface ReviewApiResponse {
+  verdict: string;
+  confidence?: number;
+  summary?: string;
+  issues?: unknown[];
+  alternative_approaches?: unknown[];
+  onchain_risk?: unknown;
+  proof?: unknown;
+}

--- a/typescript/agentkit/src/action-providers/invinoveritas/utils.ts
+++ b/typescript/agentkit/src/action-providers/invinoveritas/utils.ts
@@ -1,0 +1,41 @@
+import { PostJsonResult } from "./types";
+
+/**
+ * Minimal fetch-based JSON POST helper with a hard timeout. invinoveritas actions are advisory —
+ * a slow or failed call must never hang or throw into the agent's main flow, so every caller wraps
+ * this in a try/catch and treats a non-ok response as "unavailable", not an error to propagate.
+ *
+ * @param url - The full URL to POST to
+ * @param body - The JSON-serializable request body
+ * @param opts - Optional Bearer apiKey and a required timeoutMs
+ * @param opts.apiKey - Bearer token to send as an Authorization header, omitted for free/no-auth calls
+ * @param opts.timeoutMs - Abort the request after this many milliseconds
+ * @returns The parsed response, or `data: null` if the body wasn't valid JSON
+ */
+export async function postJson(
+  url: string,
+  body: unknown,
+  opts: { apiKey?: string; timeoutMs: number },
+): Promise<PostJsonResult> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), opts.timeoutMs);
+  try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (opts.apiKey) headers["Authorization"] = `Bearer ${opts.apiKey}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+    let data: unknown = null;
+    try {
+      data = await res.json();
+    } catch {
+      data = null;
+    }
+    return { ok: res.ok, status: res.status, data };
+  } finally {
+    clearTimeout(t);
+  }
+}


### PR DESCRIPTION
## What changed

Adds a new action provider for [invinoveritas](https://api.babyblueviper.com) — a verification layer for AI agents: an independent, capital/risk-aware verdict on a proposed action before it executes, plus a free way to verify a signed proof another agent hands you.

Two actions, following the existing pattern of a read-API provider like `messari` or `pyth` (no wallet interaction):

- **`review`** — an independent verdict on a proposed trade, on-chain transaction, sanctions-screening result, code diff, or other agent action, called *before* it executes.
  - `artifactType='trade'` → capital-scale-aware risk review (position size vs equity, drawdown, regime)
  - `artifactType='onchain_action'` → deterministic checks (unlimited approvals, drainers, address poisoning, permit abuse, wrong-chain recipient) — complements `erc20`/`erc721`'s mint/transfer actions with a pre-execution check
  - `sign=true` → also returns a portable signed proof any third party can independently recompute (BIP-340 schnorr against a published key), rather than a trust-us score
  - Advisory only: degrades to `{ verdict: "review_unavailable", reason }` on a missing key, timeout, or non-2xx response — **never throws into the agent's main flow**
- **`verify_proof`** — verifies a signed invinoveritas proof another agent handed over. Free, no auth. Recomputes the Nostr event id and checks the signature against a published key, so neither the presenter nor invinoveritas needs to be trusted.

API-only (no wallet operations), so `supportsNetwork` always returns `true` — no wallet provider required, matching `messari`.

One deliberate deviation from the usual pattern, called out in the provider's README: the constructor does **not** throw when no API key is configured (most providers do). `verify_proof` is free/no-auth and works with zero configuration, and `review` is designed to degrade rather than block agent construction for a user who hasn't set up a key yet.

## Testing

- 16 new unit tests (`invinoveritasActionProvider.test.ts`) covering the constructor, both actions' happy paths, and every degrade-not-throw path (missing key, non-2xx, network error, malformed args).
- `tsc --noEmit` clean across the whole `agentkit` package.
- `eslint --max-warnings=0` clean on the new directory.
- Full existing test suite (1607 tests) shows the **identical** pass/fail count with and without this change (34 pre-existing suite failures, confirmed via `git stash`, all in an unrelated provider's `graphql-request` ESM transform — not introduced by this PR).
- Added a changeset (`patch`) per `CONTRIBUTING-TYPESCRIPT.md`.

## Notes

Disclosure: I'm the maintainer of invinoveritas. Happy to adjust naming, scope, or framing to whatever fits AgentKit's conventions best — this follows the `messari` template as closely as I could for a stateless read/verify API provider.