### PR TITLE
Add NodeFlare action provider

### DIFF
--- a/.changeset/nodeflare-action-provider.md
+++ b/.changeset/nodeflare-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Added NodeFlare action provider for reading on-chain data (block number, native and ERC-20 balances, token metadata, gas price, transactions) across 23 EVM chains through NodeFlare's public gateway, addressed by chain slug, name, or chain ID.

--- a/.changeset/nodeflare-action-provider.md
+++ b/.changeset/nodeflare-action-provider.md
@@ -2,4 +2,4 @@
 "@coinbase/agentkit": minor
 ---
 
-Added NodeFlare action provider for reading on-chain data (block number, native and ERC-20 balances, token metadata, gas price, transactions) across 23 EVM chains through NodeFlare's public gateway, addressed by chain slug, name, or chain ID.
+Added NodeFlare action provider for reading on-chain data (block number, native and ERC-20 balances, token metadata, gas price, transactions, and multi-chain balances) across 23 EVM chains through NodeFlare's public gateway, addressed by chain slug, name, or chain ID.

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -22,6 +22,7 @@ export * from "./messari";
 export * from "./pyth";
 export * from "./moonwell";
 export * from "./morpho";
+export * from "./nodeflare";
 export * from "./opensea";
 export * from "./spl";
 export * from "./superfluid";

--- a/typescript/agentkit/src/action-providers/nodeflare/README.md
+++ b/typescript/agentkit/src/action-providers/nodeflare/README.md
@@ -24,6 +24,7 @@ nodeflare/
 - `get_token_metadata`: Read ERC-20 token metadata (name, symbol, decimals, total supply)
 - `get_gas_price`: Get the current gas price on a chain, in gwei
 - `get_transaction`: Look up a transaction by hash (from, to, value, block)
+- `get_multichain_balances`: Native + ERC-20 balances for one address across many of the 23 chains in one call (incl. young chains)
 
 Every action's `chain` argument accepts a slug (`base`), a name (`ethereum`, `bsc`), or a numeric chain ID (`8453`).
 

--- a/typescript/agentkit/src/action-providers/nodeflare/README.md
+++ b/typescript/agentkit/src/action-providers/nodeflare/README.md
@@ -1,0 +1,47 @@
+# NodeFlare Action Provider
+
+This directory contains the **NodeflareActionProvider** implementation, which provides actions to read on-chain data across **23 EVM chains** through [NodeFlare](https://nodeflare.app)'s public RPC gateway — Ethereum, Base, BNB Chain, Arbitrum, Optimism, Avalanche, HyperEVM, Polygon, and young chains like Robinhood Chain, Plasma, Ink, Zircuit, BOB and Soneium.
+
+Unlike a wallet-bound provider, every action takes an explicit `chain` argument (slug, name, **or** chain ID), so an agent can query any supported chain without configuring a separate RPC per chain. All actions are read-only and keyless — the injected wallet provider is not used.
+
+## Directory Structure
+
+```
+nodeflare/
+├── nodeflareActionProvider.ts        # Main provider with NodeFlare read actions
+├── nodeflareActionProvider.test.ts   # Test file for NodeFlare provider
+├── schemas.ts                        # Action schemas
+├── index.ts                          # Main exports
+└── README.md                         # This file
+```
+
+## Actions
+
+- `get_supported_chains`: List the EVM chains NodeFlare serves, with chain IDs and native currencies
+- `get_block_number`: Get the latest block number on any supported chain
+- `get_native_balance`: Get the native gas-token balance of an address (ETH, BNB, POL, SEI, …), human-readable
+- `get_erc20_balance`: Read an ERC-20 token balance for a holder, human-readable using the token's decimals
+- `get_token_metadata`: Read ERC-20 token metadata (name, symbol, decimals, total supply)
+- `get_gas_price`: Get the current gas price on a chain, in gwei
+- `get_transaction`: Look up a transaction by hash (from, to, value, block)
+
+Every action's `chain` argument accepts a slug (`base`), a name (`ethereum`, `bsc`), or a numeric chain ID (`8453`).
+
+## Adding New Actions
+
+To add new NodeFlare actions:
+
+1. Define your action schema in `schemas.ts`
+2. Implement the action in `nodeflareActionProvider.ts`
+3. Add tests in `nodeflareActionProvider.test.ts`
+
+## Network Support
+
+The provider reads any of NodeFlare's 23 supported EVM chains, selected per-action via the `chain` argument, so it is available regardless of the network the host agent's wallet is configured for. For the full list and endpoints, see the [NodeFlare chains directory](https://nodeflare.app/chains).
+
+## Notes
+
+- **No API key required.** Actions use NodeFlare's free public read tier. Heavy methods (`eth_getLogs`, trace) are not exposed here; for those, use the [NodeFlare MCP server](https://github.com/Nodeflare-app/nodeflare-mcp) with a free API key.
+- Read-only: this provider does not send transactions or touch the agent's wallet.
+
+For more information, visit the [NodeFlare docs for AI agents](https://nodeflare.app/agents).

--- a/typescript/agentkit/src/action-providers/nodeflare/index.ts
+++ b/typescript/agentkit/src/action-providers/nodeflare/index.ts
@@ -1,0 +1,2 @@
+export * from "./nodeflareActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.test.ts
@@ -1,0 +1,86 @@
+import { nodeflareActionProvider, NodeflareActionProvider } from "./nodeflareActionProvider";
+
+/**
+ * Build a fetch mock that returns the given JSON body with a 200 status.
+ *
+ * @param body - The JSON body to resolve.
+ * @returns A jest mock installed on global.fetch.
+ */
+function mockFetch(body: unknown) {
+  return jest.spyOn(global, "fetch").mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  } as Response);
+}
+
+describe("NodeflareActionProvider", () => {
+  let provider: NodeflareActionProvider;
+
+  beforeEach(() => {
+    provider = nodeflareActionProvider();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("supports every network (chain is an explicit argument)", () => {
+    expect(provider.supportsNetwork()).toBe(true);
+  });
+
+  describe("getSupportedChains", () => {
+    it("lists the supported chains", async () => {
+      const response = await provider.getSupportedChains();
+      expect(response).toContain("NodeFlare serves");
+      expect(response).toContain("eth (chainId 1, ETH)");
+      expect(response).toContain("base (chainId 8453, ETH)");
+    });
+  });
+
+  describe("getBlockNumber", () => {
+    it("returns the latest block in decimal and hex", async () => {
+      mockFetch({ jsonrpc: "2.0", id: 1, result: "0x2a" });
+      const response = await provider.getBlockNumber({ chain: "ethereum" });
+      expect(response).toContain("Ethereum latest block: 42 (0x2a)");
+    });
+
+    it("resolves a numeric chain ID", async () => {
+      mockFetch({ jsonrpc: "2.0", id: 1, result: "0x1" });
+      const response = await provider.getBlockNumber({ chain: "8453" });
+      expect(response).toContain("Base latest block:");
+    });
+
+    it("returns a helpful error for an unknown chain", async () => {
+      const response = await provider.getBlockNumber({ chain: "notachain" });
+      expect(response).toContain("unknown chain 'notachain'");
+    });
+  });
+
+  describe("getNativeBalance", () => {
+    it("returns a human-readable native balance", async () => {
+      mockFetch({ jsonrpc: "2.0", id: 1, result: "0x0de0b6b3a7640000" }); // 1e18
+      const response = await provider.getNativeBalance({
+        chain: "eth",
+        address: "0x0000000000000000000000000000000000000000",
+      });
+      expect(response).toContain("1 ETH");
+      expect(response).toContain("Ethereum");
+    });
+  });
+
+  describe("getGasPrice", () => {
+    it("returns the gas price in gwei", async () => {
+      mockFetch({ jsonrpc: "2.0", id: 1, result: "0x3b9aca00" }); // 1e9 wei = 1 gwei
+      const response = await provider.getGasPrice({ chain: "base" });
+      expect(response).toContain("Base gas price: 1 gwei");
+    });
+
+    it("surfaces a gateway error", async () => {
+      mockFetch({ error: "rate_limit_exceeded", message: "Public rate limit exceeded." });
+      const response = await provider.getGasPrice({ chain: "eth" });
+      expect(response).toContain("Error fetching gas price");
+      expect(response).toContain("Public rate limit exceeded");
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.test.ts
@@ -83,4 +83,13 @@ describe("NodeflareActionProvider", () => {
       expect(response).toContain("Public rate limit exceeded");
     });
   });
+
+  describe("getMultichainBalances", () => {
+    it("aggregates balances across chains via the data API", async () => {
+      mockFetch({ address: "0xabc", chains: [{ chain: "base", chainId: 8453, native: { currency: "ETH", balance: "1.5", wei: "1500000000000000000" }, tokens: [] }] });
+      const response = await provider.getMultichainBalances({ address: "0xabc", chains: ["base"] });
+      expect(response).toContain("Multi-chain balances for 0xabc");
+      expect(response).toContain("\"chain\": \"base\"");
+    });
+  });
 });

--- a/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.ts
@@ -1,0 +1,411 @@
+import { z } from "zod";
+import { encodeFunctionData, decodeFunctionResult, formatUnits, type Abi } from "viem";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import {
+  GetSupportedChainsSchema,
+  GetBlockNumberSchema,
+  GetNativeBalanceSchema,
+  GetErc20BalanceSchema,
+  GetTokenMetadataSchema,
+  GetGasPriceSchema,
+  GetTransactionSchema,
+} from "./schemas";
+
+/**
+ * The EVM chains NodeFlare serves, keyed by slug. Each has a public keyless read
+ * endpoint at https://rpc.nodeflare.app/{slug}/public.
+ */
+const CHAINS: Record<string, { label: string; chainId: number; currency: string }> = {
+  eth: { label: "Ethereum", chainId: 1, currency: "ETH" },
+  base: { label: "Base", chainId: 8453, currency: "ETH" },
+  bnb: { label: "BNB Chain", chainId: 56, currency: "BNB" },
+  arb: { label: "Arbitrum One", chainId: 42161, currency: "ETH" },
+  op: { label: "Optimism", chainId: 10, currency: "ETH" },
+  hl: { label: "HyperEVM (HyperLiquid)", chainId: 999, currency: "HYPE" },
+  avax: { label: "Avalanche C-Chain", chainId: 43114, currency: "AVAX" },
+  unichain: { label: "Unichain", chainId: 130, currency: "ETH" },
+  sonic: { label: "Sonic", chainId: 146, currency: "S" },
+  polygon: { label: "Polygon PoS", chainId: 137, currency: "POL" },
+  linea: { label: "Linea", chainId: 59144, currency: "ETH" },
+  mantle: { label: "Mantle", chainId: 5000, currency: "MNT" },
+  zircuit: { label: "Zircuit", chainId: 48900, currency: "ETH" },
+  robinhood: { label: "Robinhood Chain", chainId: 4663, currency: "ETH" },
+  xlayer: { label: "XLayer", chainId: 196, currency: "OKB" },
+  soneium: { label: "Soneium", chainId: 1868, currency: "ETH" },
+  nova: { label: "Arbitrum Nova", chainId: 42170, currency: "ETH" },
+  bob: { label: "BOB", chainId: 60808, currency: "ETH" },
+  ink: { label: "Ink", chainId: 57073, currency: "ETH" },
+  cronos: { label: "Cronos", chainId: 25, currency: "CRO" },
+  mode: { label: "Mode", chainId: 34443, currency: "ETH" },
+  sei: { label: "Sei", chainId: 1329, currency: "SEI" },
+  plasma: { label: "Plasma", chainId: 9745, currency: "XPL" },
+};
+
+const ALIASES: Record<string, string> = {
+  ethereum: "eth",
+  mainnet: "eth",
+  arbitrum: "arb",
+  "arbitrum-one": "arb",
+  "arbitrum-nova": "nova",
+  optimism: "op",
+  bsc: "bnb",
+  binance: "bnb",
+  "bnb-chain": "bnb",
+  avalanche: "avax",
+  matic: "polygon",
+  pol: "polygon",
+  hyperevm: "hl",
+  hyperliquid: "hl",
+  "x-layer": "xlayer",
+};
+
+const BY_CHAIN_ID: Record<number, string> = Object.fromEntries(
+  Object.entries(CHAINS).map(([slug, c]) => [c.chainId, slug]),
+);
+
+const GATEWAY = "https://rpc.nodeflare.app";
+
+const ERC20_ABI = [
+  {
+    type: "function",
+    name: "balanceOf",
+    stateMutability: "view",
+    inputs: [{ name: "a", type: "address" }],
+    outputs: [{ type: "uint256" }],
+  },
+  { type: "function", name: "decimals", stateMutability: "view", inputs: [], outputs: [{ type: "uint8" }] },
+  { type: "function", name: "symbol", stateMutability: "view", inputs: [], outputs: [{ type: "string" }] },
+  { type: "function", name: "name", stateMutability: "view", inputs: [], outputs: [{ type: "string" }] },
+  {
+    type: "function",
+    name: "totalSupply",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ type: "uint256" }],
+  },
+] as const satisfies Abi;
+
+/**
+ * Resolve a slug, common name, or numeric chain ID to a canonical slug (or null).
+ *
+ * @param input - The chain identifier provided by the model.
+ * @returns The canonical chain slug, or null if unknown.
+ */
+function resolveChain(input: string): string | null {
+  const s = String(input ?? "")
+    .trim()
+    .toLowerCase();
+  if (CHAINS[s]) return s;
+  if (ALIASES[s]) return ALIASES[s];
+  const n = s.startsWith("0x") ? parseInt(s, 16) : /^\d+$/.test(s) ? parseInt(s, 10) : NaN;
+  if (!Number.isNaN(n) && BY_CHAIN_ID[n]) return BY_CHAIN_ID[n];
+  return null;
+}
+
+/**
+ * Make one JSON-RPC call against NodeFlare's public keyless endpoint for a chain.
+ *
+ * @param slug - The canonical chain slug.
+ * @param method - The JSON-RPC method name.
+ * @param params - The JSON-RPC params.
+ * @returns The JSON-RPC result.
+ */
+async function nodeflareRpc(slug: string, method: string, params: unknown[]): Promise<unknown> {
+  const res = await fetch(`${GATEWAY}/${slug}/public`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  const json = (await res.json()) as { result?: unknown; error?: unknown; message?: string };
+  if (json.error !== undefined && json.error !== null) {
+    const msg =
+      typeof json.error === "string"
+        ? (json.message ?? json.error)
+        : ((json.error as { message?: string }).message ?? "RPC error");
+    throw new Error(msg);
+  }
+  return json.result;
+}
+
+/**
+ * Batch several eth_calls into ONE JSON-RPC request. A batch counts as a single
+ * rate-limit token, so multi-read actions don't trip the per-IP public limit.
+ *
+ * @param slug - The canonical chain slug.
+ * @param calls - The list of { to, data } eth_call payloads.
+ * @returns The result hex per call (null for a call that errored).
+ */
+async function ethCallBatch(
+  slug: string,
+  calls: { to: string; data: string }[],
+): Promise<(string | null)[]> {
+  const batch = calls.map((c, i) => ({
+    jsonrpc: "2.0",
+    id: i,
+    method: "eth_call",
+    params: [c, "latest"],
+  }));
+  const res = await fetch(`${GATEWAY}/${slug}/public`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(batch),
+  });
+  const body = (await res.json()) as unknown;
+  if (!Array.isArray(body)) {
+    const e = body as { error?: unknown; message?: string };
+    throw new Error(e.message ?? (typeof e.error === "string" ? e.error : "batch request failed"));
+  }
+  const byId = new Map(
+    (body as Array<{ id: number; result?: unknown; error?: unknown }>).map(r => [r.id, r]),
+  );
+  return calls.map((_, i) => {
+    const r = byId.get(i);
+    return r && !r.error && typeof r.result === "string" ? r.result : null;
+  });
+}
+
+const erc20Call = (token: string, fn: "balanceOf" | "decimals" | "symbol" | "name" | "totalSupply", args: unknown[] = []) => ({
+  to: token,
+  data: encodeFunctionData({ abi: ERC20_ABI, functionName: fn, args: args as never }),
+});
+
+const unknownChain = (input: string) =>
+  `Error: unknown chain '${input}'. NodeFlare serves: ${Object.keys(CHAINS).join(", ")}. Pass a slug, name, or chain ID.`;
+
+/**
+ * NodeflareActionProvider gives an agent read access to on-chain data across the
+ * 23 EVM chains NodeFlare serves — Ethereum, Base, Arbitrum, Optimism, BNB and
+ * young chains like Robinhood Chain, Plasma and Ink — through NodeFlare's public
+ * gateway. Every action takes an explicit `chain` argument (slug, name, or chain
+ * ID), so an agent reads any supported chain without configuring a per-chain RPC.
+ * All actions are read-only and keyless; the injected wallet provider is not used.
+ */
+export class NodeflareActionProvider extends ActionProvider {
+  /**
+   * Creates a new instance of NodeflareActionProvider.
+   */
+  constructor() {
+    super("nodeflare", []);
+  }
+
+  /**
+   * Lists the EVM chains NodeFlare serves, with chain IDs and native currencies.
+   *
+   * @returns A human-readable list of supported chains.
+   */
+  @CreateAction({
+    name: "get_supported_chains",
+    description:
+      "Lists the EVM chains NodeFlare serves, with their chain IDs and native currencies. Use this to discover valid `chain` values for the other actions.",
+    schema: GetSupportedChainsSchema,
+  })
+  async getSupportedChains(): Promise<string> {
+    const rows = Object.entries(CHAINS).map(
+      ([slug, c]) => `${slug} (chainId ${c.chainId}, ${c.currency}) — ${c.label}`,
+    );
+    return `NodeFlare serves ${rows.length} EVM chains:\n${rows.join("\n")}`;
+  }
+
+  /**
+   * Gets the latest block number on a chain.
+   *
+   * @param args - The chain to query.
+   * @returns The latest block number, or an error message.
+   */
+  @CreateAction({
+    name: "get_block_number",
+    description: "Gets the latest block number on any supported EVM chain.",
+    schema: GetBlockNumberSchema,
+  })
+  async getBlockNumber(args: z.infer<typeof GetBlockNumberSchema>): Promise<string> {
+    const slug = resolveChain(args.chain);
+    if (!slug) return unknownChain(args.chain);
+    try {
+      const hex = (await nodeflareRpc(slug, "eth_blockNumber", [])) as string;
+      return `${CHAINS[slug].label} latest block: ${parseInt(hex, 16)} (${hex})`;
+    } catch (error) {
+      return `Error fetching block number on ${CHAINS[slug].label}: ${error}`;
+    }
+  }
+
+  /**
+   * Gets the native-token balance of an address.
+   *
+   * @param args - The chain and address to query.
+   * @returns The native balance, or an error message.
+   */
+  @CreateAction({
+    name: "get_native_balance",
+    description:
+      "Gets the native gas-token balance of an address on any supported EVM chain (e.g. ETH, BNB, POL, SEI), returned human-readable.",
+    schema: GetNativeBalanceSchema,
+  })
+  async getNativeBalance(args: z.infer<typeof GetNativeBalanceSchema>): Promise<string> {
+    const slug = resolveChain(args.chain);
+    if (!slug) return unknownChain(args.chain);
+    try {
+      const hex = (await nodeflareRpc(slug, "eth_getBalance", [args.address, "latest"])) as string;
+      return `${args.address} on ${CHAINS[slug].label}: ${formatUnits(BigInt(hex), 18)} ${CHAINS[slug].currency}`;
+    } catch (error) {
+      return `Error fetching native balance on ${CHAINS[slug].label}: ${error}`;
+    }
+  }
+
+  /**
+   * Reads an ERC-20 token balance for a holder.
+   *
+   * @param args - The chain, token, and holder address.
+   * @returns The token balance, or an error message.
+   */
+  @CreateAction({
+    name: "get_erc20_balance",
+    description:
+      "Reads an ERC-20 token balance for a holder on any supported EVM chain, returned human-readable using the token's decimals.",
+    schema: GetErc20BalanceSchema,
+  })
+  async getErc20Balance(args: z.infer<typeof GetErc20BalanceSchema>): Promise<string> {
+    const slug = resolveChain(args.chain);
+    if (!slug) return unknownChain(args.chain);
+    try {
+      const [balHex, decHex, symHex] = await ethCallBatch(slug, [
+        erc20Call(args.tokenAddress, "balanceOf", [args.address]),
+        erc20Call(args.tokenAddress, "decimals"),
+        erc20Call(args.tokenAddress, "symbol"),
+      ]);
+      if (balHex === null) {
+        return `Error: could not read token balance — check the token address and chain (${CHAINS[slug].label}).`;
+      }
+      const raw = decodeFunctionResult({
+        abi: ERC20_ABI,
+        functionName: "balanceOf",
+        data: balHex as `0x${string}`,
+      }) as bigint;
+      const decimals = decHex
+        ? Number(decodeFunctionResult({ abi: ERC20_ABI, functionName: "decimals", data: decHex as `0x${string}` }))
+        : 18;
+      let symbol = "";
+      try {
+        symbol = symHex
+          ? String(decodeFunctionResult({ abi: ERC20_ABI, functionName: "symbol", data: symHex as `0x${string}` }))
+          : "";
+      } catch {
+        /* non-standard token */
+      }
+      return `${args.address} holds ${formatUnits(raw, decimals)} ${symbol} (${args.tokenAddress}) on ${CHAINS[slug].label}`;
+    } catch (error) {
+      return `Error fetching ERC-20 balance on ${CHAINS[slug].label}: ${error}`;
+    }
+  }
+
+  /**
+   * Reads ERC-20 token metadata (name, symbol, decimals, total supply).
+   *
+   * @param args - The chain and token address.
+   * @returns The token metadata, or an error message.
+   */
+  @CreateAction({
+    name: "get_token_metadata",
+    description:
+      "Reads ERC-20 token metadata (name, symbol, decimals, total supply) on any supported EVM chain.",
+    schema: GetTokenMetadataSchema,
+  })
+  async getTokenMetadata(args: z.infer<typeof GetTokenMetadataSchema>): Promise<string> {
+    const slug = resolveChain(args.chain);
+    if (!slug) return unknownChain(args.chain);
+    try {
+      const [nameHex, symHex, decHex, supHex] = await ethCallBatch(slug, [
+        erc20Call(args.tokenAddress, "name"),
+        erc20Call(args.tokenAddress, "symbol"),
+        erc20Call(args.tokenAddress, "decimals"),
+        erc20Call(args.tokenAddress, "totalSupply"),
+      ]);
+      if (decHex === null && supHex === null) {
+        return `Error: not an ERC-20 token, or unreachable — check the address on ${CHAINS[slug].label}.`;
+      }
+      const dec = decHex
+        ? Number(decodeFunctionResult({ abi: ERC20_ABI, functionName: "decimals", data: decHex as `0x${string}` }))
+        : 18;
+      const str = (h: string | null, fn: "name" | "symbol") => {
+        try {
+          return h ? String(decodeFunctionResult({ abi: ERC20_ABI, functionName: fn, data: h as `0x${string}` })) : "?";
+        } catch {
+          return "?";
+        }
+      };
+      const supply = supHex
+        ? (decodeFunctionResult({ abi: ERC20_ABI, functionName: "totalSupply", data: supHex as `0x${string}` }) as bigint)
+        : 0n;
+      return `${str(nameHex, "name")} (${str(symHex, "symbol")}) on ${CHAINS[slug].label}: ${dec} decimals, total supply ${formatUnits(supply, dec)}`;
+    } catch (error) {
+      return `Error fetching token metadata on ${CHAINS[slug].label}: ${error}`;
+    }
+  }
+
+  /**
+   * Gets the current gas price on a chain, in gwei.
+   *
+   * @param args - The chain to query.
+   * @returns The gas price in gwei, or an error message.
+   */
+  @CreateAction({
+    name: "get_gas_price",
+    description: "Gets the current gas price on any supported EVM chain, in gwei.",
+    schema: GetGasPriceSchema,
+  })
+  async getGasPrice(args: z.infer<typeof GetGasPriceSchema>): Promise<string> {
+    const slug = resolveChain(args.chain);
+    if (!slug) return unknownChain(args.chain);
+    try {
+      const hex = (await nodeflareRpc(slug, "eth_gasPrice", [])) as string;
+      return `${CHAINS[slug].label} gas price: ${formatUnits(BigInt(hex), 9)} gwei`;
+    } catch (error) {
+      return `Error fetching gas price on ${CHAINS[slug].label}: ${error}`;
+    }
+  }
+
+  /**
+   * Looks up a transaction by hash.
+   *
+   * @param args - The chain and transaction hash.
+   * @returns A summary of the transaction, or an error message.
+   */
+  @CreateAction({
+    name: "get_transaction",
+    description:
+      "Looks up a transaction by hash on any supported EVM chain (from, to, value, block).",
+    schema: GetTransactionSchema,
+  })
+  async getTransaction(args: z.infer<typeof GetTransactionSchema>): Promise<string> {
+    const slug = resolveChain(args.chain);
+    if (!slug) return unknownChain(args.chain);
+    try {
+      const tx = (await nodeflareRpc(slug, "eth_getTransactionByHash", [args.txHash])) as Record<
+        string,
+        string
+      > | null;
+      if (!tx) return `Transaction ${args.txHash} not found on ${CHAINS[slug].label}.`;
+      const value = tx.value ? formatUnits(BigInt(tx.value), 18) : "0";
+      const block = tx.blockNumber ? parseInt(tx.blockNumber, 16) : "pending";
+      return `Transaction ${args.txHash} on ${CHAINS[slug].label}: from ${tx.from} to ${tx.to}, value ${value} ${CHAINS[slug].currency}, block ${block}`;
+    } catch (error) {
+      return `Error fetching transaction on ${CHAINS[slug].label}: ${error}`;
+    }
+  }
+
+  /**
+   * Checks if the NodeFlare action provider supports the given network.
+   * The actions take an explicit `chain` argument, so they are available on any
+   * network the host agent is configured for.
+   *
+   * @returns True, always.
+   */
+  supportsNetwork = (): boolean => true;
+}
+
+/**
+ * Factory for a {@link NodeflareActionProvider} instance.
+ *
+ * @returns A new NodeflareActionProvider.
+ */
+export const nodeflareActionProvider = () => new NodeflareActionProvider();

--- a/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/nodeflare/nodeflareActionProvider.ts
@@ -10,6 +10,7 @@ import {
   GetTokenMetadataSchema,
   GetGasPriceSchema,
   GetTransactionSchema,
+  GetMultichainBalancesSchema,
 } from "./schemas";
 
 /**
@@ -172,6 +173,30 @@ const erc20Call = (token: string, fn: "balanceOf" | "decimals" | "symbol" | "nam
 
 const unknownChain = (input: string) =>
   `Error: unknown chain '${input}'. NodeFlare serves: ${Object.keys(CHAINS).join(", ")}. Pass a slug, name, or chain ID.`;
+
+/**
+ * Fetch native + ERC-20 balances for one address across many chains from
+ * NodeFlare's multi-chain balances data API (a single request).
+ *
+ * @param body - The address and optional chains/tokens selection.
+ * @returns The aggregated balances JSON.
+ */
+async function nodeflareBalances(body: {
+  address: string;
+  chains?: string[];
+  tokens?: Record<string, string[]>;
+}): Promise<unknown> {
+  const res = await fetch(`${GATEWAY}/data/balances`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = (await res.json()) as { error?: unknown; message?: string };
+  if (!res.ok) {
+    throw new Error(json.message ?? (typeof json.error === "string" ? json.error : "balances request failed"));
+  }
+  return json;
+}
 
 /**
  * NodeflareActionProvider gives an agent read access to on-chain data across the
@@ -390,6 +415,31 @@ export class NodeflareActionProvider extends ActionProvider {
       return `Transaction ${args.txHash} on ${CHAINS[slug].label}: from ${tx.from} to ${tx.to}, value ${value} ${CHAINS[slug].currency}, block ${block}`;
     } catch (error) {
       return `Error fetching transaction on ${CHAINS[slug].label}: ${error}`;
+    }
+  }
+
+  /**
+   * Reads native + ERC-20 balances for one address across many chains in one call.
+   *
+   * @param args - The address and optional chains/tokens selection.
+   * @returns The aggregated balances, or an error message.
+   */
+  @CreateAction({
+    name: "get_multichain_balances",
+    description:
+      "Reads native + ERC-20 token balances for one address across many of the 23 EVM chains in a single call, including young chains (Robinhood, Plasma, Ink) that Alchemy/Moralis omit. Provide ERC-20 addresses per chain via `tokens` to include token balances.",
+    schema: GetMultichainBalancesSchema,
+  })
+  async getMultichainBalances(args: z.infer<typeof GetMultichainBalancesSchema>): Promise<string> {
+    try {
+      const result = await nodeflareBalances({
+        address: args.address,
+        ...(args.chains ? { chains: args.chains } : {}),
+        ...(args.tokens ? { tokens: args.tokens } : {}),
+      });
+      return `Multi-chain balances for ${args.address}:\n${JSON.stringify(result, null, 2)}`;
+    } catch (error) {
+      return `Error fetching multi-chain balances: ${error}`;
     }
   }
 

--- a/typescript/agentkit/src/action-providers/nodeflare/schemas.ts
+++ b/typescript/agentkit/src/action-providers/nodeflare/schemas.ts
@@ -72,3 +72,20 @@ export const GetTransactionSchema = z
     txHash: z.string().describe("The 0x transaction hash to look up"),
   })
   .describe("Input schema for looking up a transaction by hash");
+
+/**
+ * Input schema for reading native + ERC-20 balances across many chains.
+ */
+export const GetMultichainBalancesSchema = z
+  .object({
+    address: z.string().describe("The 0x address to look up balances for"),
+    chains: z
+      .array(z.string())
+      .optional()
+      .describe("Chains to include (slug, name, or chain ID); defaults to all 23"),
+    tokens: z
+      .record(z.string(), z.array(z.string()))
+      .optional()
+      .describe("ERC-20 contract addresses per chain, e.g. { base: [\"0x833589...\"] }"),
+  })
+  .describe("Input schema for reading native + ERC-20 balances across many EVM chains");

--- a/typescript/agentkit/src/action-providers/nodeflare/schemas.ts
+++ b/typescript/agentkit/src/action-providers/nodeflare/schemas.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+/**
+ * Chain selector shared by every NodeFlare action. Accepts a slug, a common
+ * name, or a numeric chain ID so the model doesn't need to know NodeFlare's
+ * internal slugs.
+ */
+const chainField = z
+  .string()
+  .describe(
+    "Chain to query: a slug (eth, base, arb, op, robinhood…), a common name (ethereum, arbitrum, bsc), or a numeric chain ID (1, 8453). Call get_supported_chains for the full list.",
+  );
+
+/**
+ * Input schema for listing NodeFlare's supported chains.
+ */
+export const GetSupportedChainsSchema = z
+  .object({})
+  .describe("Input schema for listing the EVM chains NodeFlare serves");
+
+/**
+ * Input schema for fetching the latest block number.
+ */
+export const GetBlockNumberSchema = z
+  .object({ chain: chainField })
+  .describe("Input schema for fetching the latest block number on a chain");
+
+/**
+ * Input schema for fetching a native-token balance.
+ */
+export const GetNativeBalanceSchema = z
+  .object({
+    chain: chainField,
+    address: z.string().describe("The 0x address to check the native balance of"),
+  })
+  .describe("Input schema for fetching a native-token balance");
+
+/**
+ * Input schema for fetching an ERC-20 token balance.
+ */
+export const GetErc20BalanceSchema = z
+  .object({
+    chain: chainField,
+    tokenAddress: z.string().describe("The ERC-20 token contract address"),
+    address: z.string().describe("The holder 0x address whose balance to read"),
+  })
+  .describe("Input schema for fetching an ERC-20 token balance");
+
+/**
+ * Input schema for fetching ERC-20 token metadata.
+ */
+export const GetTokenMetadataSchema = z
+  .object({
+    chain: chainField,
+    tokenAddress: z.string().describe("The ERC-20 token contract address"),
+  })
+  .describe("Input schema for fetching ERC-20 token metadata");
+
+/**
+ * Input schema for fetching the current gas price.
+ */
+export const GetGasPriceSchema = z
+  .object({ chain: chainField })
+  .describe("Input schema for fetching the current gas price on a chain");
+
+/**
+ * Input schema for looking up a transaction by hash.
+ */
+export const GetTransactionSchema = z
+  .object({
+    chain: chainField,
+    txHash: z.string().describe("The 0x transaction hash to look up"),
+  })
+  .describe("Input schema for looking up a transaction by hash");


### PR DESCRIPTION
## Description

Adds a **NodeFlare** action provider that gives an agent read access to on-chain data across **23 EVM chains** through NodeFlare's public RPC gateway — Ethereum, Base, BNB Chain, Arbitrum, Optimism, Avalanche, HyperEVM, Polygon, and young chains like Robinhood Chain, Plasma, Ink, Zircuit, BOB and Soneium.

Unlike a wallet-bound provider, every action takes an explicit `chain` argument (slug, common name, **or** numeric chain ID), so an agent can query any supported chain without configuring a separate RPC per chain. All actions are read-only and **keyless** (free public tier), and the injected wallet provider is not used — `supportsNetwork` returns `true`.

Structure and conventions follow the existing `alchemy` action provider (schemas in `schemas.ts`, string-returning actions, Jest tests, README).

### Actions
- `get_supported_chains` — list the chains, with chain IDs and native currencies
- `get_block_number` — latest block on a chain
- `get_native_balance` — native gas-token balance of an address
- `get_erc20_balance` — ERC-20 balance for a holder (human-readable)
- `get_token_metadata` — ERC-20 name, symbol, decimals, total supply
- `get_gas_price` — current gas price in gwei
- `get_transaction` — look up a transaction by hash

Multi-read actions batch their `eth_call`s into a single JSON-RPC request to stay within the public rate limit.

## Tests

Added `nodeflareActionProvider.test.ts` (Jest, mocked `fetch`) covering `supportsNetwork`, chain resolution (name + numeric ID), a successful native-balance/gas read, and gateway-error handling.

## Checklist
- [x] New action provider under `src/action-providers/nodeflare/`
- [x] Registered in `src/action-providers/index.ts`
- [x] Unit tests
- [x] README
- [x] Changeset
