### PR TITLE
feat(action-providers): add GBLIN treasury index (Base)

### DIFF
--- a/.changeset/gblin-action-provider.md
+++ b/.changeset/gblin-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added a GBLIN action provider to buy, redeem, and read GBLIN — a collateral-backed treasury index with an on-chain crash shield on Base.

--- a/typescript/agentkit/README.md
+++ b/typescript/agentkit/README.md
@@ -485,6 +485,23 @@ const agent = createAgent({
 </table>
 </details>
 <details>
+<summary><strong>GBLIN</strong></summary>
+<table width="100%">
+<tr>
+    <td width="200"><code>buy_gblin</code></td>
+    <td width="768">Buys GBLIN, a collateral-backed treasury index on Base, with ETH. Derives a slippage-bounded minimum output from the on-chain quote.</td>
+</tr>
+<tr>
+    <td width="200"><code>sell_gblin_for_eth</code></td>
+    <td width="768">Redeems GBLIN back to ETH. Derives a slippage-bounded minimum output from the on-chain quote.</td>
+</tr>
+<tr>
+    <td width="200"><code>get_gblin_state</code></td>
+    <td width="768">Reads the live per-GBLIN ETH redemption value and total supply.</td>
+</tr>
+</table>
+</details>
+<details>
 <summary><strong>Messari</strong></summary>
 <table width="100%">
 <tr>

--- a/typescript/agentkit/src/action-providers/gblin/README.md
+++ b/typescript/agentkit/src/action-providers/gblin/README.md
@@ -1,0 +1,38 @@
+# GBLIN Action Provider
+
+Actions for interacting with [GBLIN](https://gblin.digital), a collateral-backed,
+self-defending treasury index on Base (WETH / cbBTC / USDC) with an autonomous
+on-chain "Crash Shield" that reduces risk during drawdowns. It is intended for
+parking surplus agent capital with capped drawdown — managed crypto exposure,
+**not** a stablecoin and not financial advice.
+
+Contract (verified): [`0x36C81d7E1966310F305eA637e761Cf77F90852f0`](https://basescan.org/address/0x36C81d7E1966310F305eA637e761Cf77F90852f0#code)
+
+## Actions
+
+| Action | Description |
+| --- | --- |
+| `buy_gblin` | Buy GBLIN with ETH. Reads `quoteBuyGBLIN` on-chain and submits `buyGBLIN` with a slippage-bounded minimum output. |
+| `sell_gblin_for_eth` | Redeem GBLIN back to ETH (e.g. to fund an x402 payment). Reads `quoteSellGBLIN` and submits `sellGBLINForEth` with a min-out. |
+| `get_gblin_state` | Read per-GBLIN ETH redemption value and total supply. |
+
+Every state-changing action derives its minimum output from the contract's own
+quote function, so the agent is never exposed to an unbounded swap.
+
+## Network support
+
+Base mainnet (`base-mainnet`) only.
+
+## Example
+
+```typescript
+import { gblinActionProvider } from "@coinbase/agentkit";
+
+const provider = gblinActionProvider();
+```
+
+## Notes
+
+- GBLIN enforces a short post-purchase cooldown before redemption.
+- The risk policy is public code governed by a 48h timelock, and has executed
+  autonomously on mainnet ([activation tx](https://basescan.org/tx/0x896be221989930776972c78f81e2be9081c90d0027c14f7cd74bf51b9ad0acca)).

--- a/typescript/agentkit/src/action-providers/gblin/constants.ts
+++ b/typescript/agentkit/src/action-providers/gblin/constants.ts
@@ -1,0 +1,50 @@
+export const GBLIN_ADDRESS = "0x36C81d7E1966310F305eA637e761Cf77F90852f0";
+
+/**
+ * Minimal ABI for the GBLIN V6 index (Global Balanced Liquidity Index) on Base.
+ * Verified on Basescan: https://basescan.org/address/0x36C81d7E1966310F305eA637e761Cf77F90852f0#code
+ */
+export const GBLIN_ABI = [
+  {
+    type: "function",
+    name: "buyGBLIN",
+    stateMutability: "payable",
+    inputs: [{ name: "minGblinOut", type: "uint256" }],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "sellGBLINForEth",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "gblinAmount", type: "uint256" },
+      { name: "minEthOut", type: "uint256" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "quoteBuyGBLIN",
+    stateMutability: "view",
+    inputs: [{ name: "ethAmount", type: "uint256" }],
+    outputs: [
+      { name: "gblinOut", type: "uint256" },
+      { name: "founderFee", type: "uint256" },
+      { name: "stabilityFee", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "quoteSellGBLIN",
+    stateMutability: "view",
+    inputs: [{ name: "gblinAmount", type: "uint256" }],
+    outputs: [{ name: "ethOut", type: "uint256" }],
+  },
+  {
+    type: "function",
+    name: "totalSupply",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;

--- a/typescript/agentkit/src/action-providers/gblin/gblinActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/gblin/gblinActionProvider.test.ts
@@ -1,0 +1,120 @@
+import { encodeFunctionData, parseEther, parseUnits } from "viem";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { GblinActionProvider } from "./gblinActionProvider";
+import { GBLIN_ADDRESS, GBLIN_ABI } from "./constants";
+
+const MOCK_TX_HASH = "0xabcdef1234567890";
+const MOCK_RECEIPT = { status: 1, blockNumber: 1234567 };
+const BPS = 10_000n;
+const DEFAULT_SLIPPAGE_BPS = 100n;
+
+describe("GBLIN Action Provider", () => {
+  const actionProvider = new GblinActionProvider();
+  let mockWallet: jest.Mocked<EvmWalletProvider>;
+
+  beforeEach(() => {
+    mockWallet = {
+      getAddress: jest.fn().mockReturnValue("0x9876543210987654321098765432109876543210"),
+      getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" }),
+      sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+      waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
+      readContract: jest.fn(),
+    } as unknown as jest.Mocked<EvmWalletProvider>;
+  });
+
+  describe("buyGblin", () => {
+    it("should buy GBLIN with ETH using a quote-derived minOut", async () => {
+      const expectedOut = parseUnits("30", 18);
+      const minOut = (expectedOut * (BPS - DEFAULT_SLIPPAGE_BPS)) / BPS;
+      mockWallet.readContract.mockResolvedValueOnce([expectedOut, 0n, 0n]);
+
+      const response = await actionProvider.buyGblin(mockWallet, { ethAmount: "0.1" });
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+        to: GBLIN_ADDRESS as `0x${string}`,
+        data: encodeFunctionData({
+          abi: GBLIN_ABI,
+          functionName: "buyGBLIN",
+          args: [minOut],
+        }),
+        value: parseEther("0.1"),
+      });
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+      expect(response).toContain(MOCK_TX_HASH);
+    });
+
+    it("should reject a non-positive amount", async () => {
+      const response = await actionProvider.buyGblin(mockWallet, { ethAmount: "0" });
+      expect(response).toContain("must be greater than 0");
+    });
+
+    it("should handle a zero on-chain quote (stale oracles)", async () => {
+      mockWallet.readContract.mockResolvedValueOnce([0n, 0n, 0n]);
+      const response = await actionProvider.buyGblin(mockWallet, { ethAmount: "0.1" });
+      expect(response).toContain("zero");
+    });
+  });
+
+  describe("sellGblinForEth", () => {
+    it("should redeem GBLIN for ETH using a quote-derived minOut", async () => {
+      const atomic = parseUnits("5", 18);
+      const expectedEth = parseEther("0.02");
+      const minEthOut = (expectedEth * (BPS - DEFAULT_SLIPPAGE_BPS)) / BPS;
+      mockWallet.readContract.mockResolvedValueOnce(expectedEth);
+
+      const response = await actionProvider.sellGblinForEth(mockWallet, { gblinAmount: "5" });
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+        to: GBLIN_ADDRESS as `0x${string}`,
+        data: encodeFunctionData({
+          abi: GBLIN_ABI,
+          functionName: "sellGBLINForEth",
+          args: [atomic, minEthOut],
+        }),
+      });
+      expect(response).toContain(MOCK_TX_HASH);
+    });
+
+    it("should handle errors when redeeming", async () => {
+      mockWallet.readContract.mockResolvedValueOnce(parseEther("0.02"));
+      mockWallet.sendTransaction.mockRejectedValue(new Error("Failed"));
+      const response = await actionProvider.sellGblinForEth(mockWallet, { gblinAmount: "5" });
+      expect(response).toContain("Error redeeming GBLIN");
+    });
+  });
+
+  describe("getGblinState", () => {
+    it("should return live state as JSON", async () => {
+      mockWallet.readContract
+        .mockResolvedValueOnce(parseEther("0.0012")) // quoteSellGBLIN(1)
+        .mockResolvedValueOnce(parseUnits("0.5", 18)); // totalSupply
+
+      const response = await actionProvider.getGblinState(mockWallet, {});
+      const parsed = JSON.parse(response);
+      expect(parsed.contract).toBe(GBLIN_ADDRESS);
+      expect(parsed.network).toBe("base-mainnet");
+      expect(parsed).toHaveProperty("ethValuePerGblin");
+      expect(parsed).toHaveProperty("totalSupply");
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should return true for Base Mainnet", () => {
+      expect(
+        actionProvider.supportsNetwork({ protocolFamily: "evm", networkId: "base-mainnet" }),
+      ).toBe(true);
+    });
+
+    it("should return false for other EVM networks", () => {
+      expect(
+        actionProvider.supportsNetwork({ protocolFamily: "evm", networkId: "ethereum" }),
+      ).toBe(false);
+    });
+
+    it("should return false for non-EVM networks", () => {
+      expect(
+        actionProvider.supportsNetwork({ protocolFamily: "bitcoin", networkId: "base-mainnet" }),
+      ).toBe(false);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/gblin/gblinActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/gblin/gblinActionProvider.ts
@@ -1,0 +1,215 @@
+import { z } from "zod";
+import { Decimal } from "decimal.js";
+import { encodeFunctionData, formatEther, formatUnits, Hex, parseEther, parseUnits } from "viem";
+import { ActionProvider } from "../actionProvider";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { CreateAction } from "../actionDecorator";
+import { Network } from "../../network";
+import { GBLIN_ADDRESS, GBLIN_ABI } from "./constants";
+import { BuyGblinSchema, SellGblinForEthSchema, GetTreasuryStateSchema } from "./schemas";
+
+export const SUPPORTED_NETWORKS = ["base-mainnet"];
+
+const DEFAULT_SLIPPAGE_BPS = 100n; // 1%
+const BPS = 10_000n;
+
+/**
+ * GblinActionProvider lets an agent hold and redeem GBLIN — the collateral-backed,
+ * self-defending treasury index on Base (WETH/cbBTC/USDC with an autonomous Crash
+ * Shield). It is designed for parking surplus agent capital with capped drawdown,
+ * not as a USDC substitute. All actions set an on-chain-quote-derived minOut, so
+ * the agent is never exposed to an unbounded swap.
+ *
+ * Contract (verified): https://basescan.org/address/0x36C81d7E1966310F305eA637e761Cf77F90852f0
+ */
+export class GblinActionProvider extends ActionProvider<EvmWalletProvider> {
+  /**
+   * Constructor for the GblinActionProvider class.
+   */
+  constructor() {
+    super("gblin", []);
+  }
+
+  /**
+   * Buys GBLIN with ETH, protected by a min-out derived from the on-chain quote.
+   *
+   * @param wallet - The wallet instance to execute the transaction
+   * @param args - The input arguments for the action
+   * @returns A success message with transaction details or an error message
+   */
+  @CreateAction({
+    name: "buy_gblin",
+    description: `
+Buy GBLIN, a collateral-backed, self-defending treasury index on Base, using ETH.
+Use this to park surplus agent capital with capped drawdown (managed crypto exposure, NOT a stablecoin).
+
+It takes:
+- ethAmount: amount of ETH to spend in whole units (e.g. "0.1")
+- slippageBps: optional max slippage vs the on-chain quote, in basis points (default 100 = 1%)
+
+The action reads quoteBuyGBLIN on-chain and submits buyGBLIN with a safe minimum output; it never sends an unbounded swap.
+`,
+    schema: BuyGblinSchema,
+  })
+  async buyGblin(wallet: EvmWalletProvider, args: z.infer<typeof BuyGblinSchema>): Promise<string> {
+    const eth = new Decimal(args.ethAmount);
+    if (eth.comparedTo(new Decimal(0)) != 1) {
+      return "Error: ethAmount must be greater than 0";
+    }
+
+    try {
+      const valueWei = parseEther(args.ethAmount);
+      const slippage = args.slippageBps != null ? BigInt(args.slippageBps) : DEFAULT_SLIPPAGE_BPS;
+
+      const quote = (await wallet.readContract({
+        address: GBLIN_ADDRESS as Hex,
+        abi: GBLIN_ABI,
+        functionName: "quoteBuyGBLIN",
+        args: [valueWei],
+      })) as readonly [bigint, bigint, bigint];
+
+      const expectedOut = quote[0];
+      if (expectedOut <= 0n) {
+        return "Error: on-chain quote returned zero (oracles may be stale). Try again shortly.";
+      }
+      const minOut = (expectedOut * (BPS - slippage)) / BPS;
+
+      const data = encodeFunctionData({
+        abi: GBLIN_ABI,
+        functionName: "buyGBLIN",
+        args: [minOut],
+      });
+
+      const txHash = await wallet.sendTransaction({
+        to: GBLIN_ADDRESS as `0x${string}`,
+        data,
+        value: valueWei,
+      });
+      const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+      return `Bought GBLIN with ${args.ethAmount} ETH (min out ${formatUnits(minOut, 18)} GBLIN, expected ${formatUnits(expectedOut, 18)}). Tx: ${txHash}\nReceipt: ${JSON.stringify(receipt)}`;
+    } catch (error) {
+      return `Error buying GBLIN: ${error}`;
+    }
+  }
+
+  /**
+   * Redeems GBLIN back to ETH, protected by a min-out derived from the on-chain quote.
+   *
+   * @param wallet - The wallet instance to execute the transaction
+   * @param args - The input arguments for the action
+   * @returns A success message with transaction details or an error message
+   */
+  @CreateAction({
+    name: "sell_gblin_for_eth",
+    description: `
+Redeem GBLIN back to ETH (e.g. to free capital for an x402 payment).
+
+It takes:
+- gblinAmount: amount of GBLIN to redeem in whole units (e.g. "5")
+- slippageBps: optional max slippage vs the on-chain quote, in basis points (default 100 = 1%)
+
+Note: GBLIN enforces a short post-purchase cooldown before redemption; if you just bought, wait a couple of minutes.
+`,
+    schema: SellGblinForEthSchema,
+  })
+  async sellGblinForEth(
+    wallet: EvmWalletProvider,
+    args: z.infer<typeof SellGblinForEthSchema>,
+  ): Promise<string> {
+    const amount = new Decimal(args.gblinAmount);
+    if (amount.comparedTo(new Decimal(0)) != 1) {
+      return "Error: gblinAmount must be greater than 0";
+    }
+
+    try {
+      const atomic = parseUnits(args.gblinAmount, 18);
+      const slippage = args.slippageBps != null ? BigInt(args.slippageBps) : DEFAULT_SLIPPAGE_BPS;
+
+      const expectedEth = (await wallet.readContract({
+        address: GBLIN_ADDRESS as Hex,
+        abi: GBLIN_ABI,
+        functionName: "quoteSellGBLIN",
+        args: [atomic],
+      })) as bigint;
+
+      if (expectedEth <= 0n) {
+        return "Error: on-chain quote returned zero (oracles may be stale). Try again shortly.";
+      }
+      const minEthOut = (expectedEth * (BPS - slippage)) / BPS;
+
+      const data = encodeFunctionData({
+        abi: GBLIN_ABI,
+        functionName: "sellGBLINForEth",
+        args: [atomic, minEthOut],
+      });
+
+      const txHash = await wallet.sendTransaction({
+        to: GBLIN_ADDRESS as `0x${string}`,
+        data,
+      });
+      const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+      return `Redeemed ${args.gblinAmount} GBLIN for ~${formatEther(minEthOut)} ETH (min). Tx: ${txHash}\nReceipt: ${JSON.stringify(receipt)}`;
+    } catch (error) {
+      return `Error redeeming GBLIN: ${error}`;
+    }
+  }
+
+  /**
+   * Reads live GBLIN treasury state (per-unit ETH value and supply).
+   *
+   * @param wallet - The wallet instance used for on-chain reads
+   * @param _ - Empty args
+   * @returns A JSON string with treasury state or an error message
+   */
+  @CreateAction({
+    name: "get_gblin_state",
+    description:
+      "Read live GBLIN state: per-GBLIN ETH redemption value (from quoteSellGBLIN of 1 GBLIN) and total supply. Use before buying/redeeming to make an informed decision.",
+    schema: GetTreasuryStateSchema,
+  })
+  async getGblinState(
+    wallet: EvmWalletProvider,
+    _: z.infer<typeof GetTreasuryStateSchema>,
+  ): Promise<string> {
+    try {
+      const oneGblin = parseUnits("1", 18);
+      const [ethPerGblin, supply] = await Promise.all([
+        wallet.readContract({
+          address: GBLIN_ADDRESS as Hex,
+          abi: GBLIN_ABI,
+          functionName: "quoteSellGBLIN",
+          args: [oneGblin],
+        }) as Promise<bigint>,
+        wallet.readContract({
+          address: GBLIN_ADDRESS as Hex,
+          abi: GBLIN_ABI,
+          functionName: "totalSupply",
+          args: [],
+        }) as Promise<bigint>,
+      ]);
+
+      return JSON.stringify({
+        contract: GBLIN_ADDRESS,
+        network: "base-mainnet",
+        ethValuePerGblin: formatEther(ethPerGblin),
+        totalSupply: formatUnits(supply, 18),
+        note: "Managed crypto exposure with an autonomous Crash Shield; capped drawdown, not a stablecoin.",
+      });
+    } catch (error) {
+      return `Error reading GBLIN state: ${error}`;
+    }
+  }
+
+  /**
+   * Checks if the GBLIN action provider supports the given network.
+   *
+   * @param network - The network to check.
+   * @returns True if supported (Base mainnet), false otherwise.
+   */
+  supportsNetwork = (network: Network) =>
+    network.protocolFamily === "evm" && SUPPORTED_NETWORKS.includes(network.networkId!);
+}
+
+export const gblinActionProvider = () => new GblinActionProvider();

--- a/typescript/agentkit/src/action-providers/gblin/index.ts
+++ b/typescript/agentkit/src/action-providers/gblin/index.ts
@@ -1,0 +1,2 @@
+export * from "./gblinActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/gblin/schemas.ts
+++ b/typescript/agentkit/src/action-providers/gblin/schemas.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+/**
+ * Input schema for buying GBLIN with ETH.
+ */
+export const BuyGblinSchema = z
+  .object({
+    ethAmount: z
+      .string()
+      .describe("Amount of ETH to spend, in whole units (e.g. '0.1' for 0.1 ETH)"),
+    slippageBps: z
+      .number()
+      .int()
+      .min(0)
+      .max(2000)
+      .optional()
+      .describe("Max slippage in basis points applied to the on-chain quote. Default 100 (1%)."),
+  })
+  .strip()
+  .describe("Instructions for buying GBLIN with ETH");
+
+/**
+ * Input schema for redeeming GBLIN back to ETH.
+ */
+export const SellGblinForEthSchema = z
+  .object({
+    gblinAmount: z
+      .string()
+      .describe("Amount of GBLIN to redeem, in whole units (e.g. '5' for 5 GBLIN)"),
+    slippageBps: z
+      .number()
+      .int()
+      .min(0)
+      .max(2000)
+      .optional()
+      .describe("Max slippage in basis points applied to the on-chain quote. Default 100 (1%)."),
+  })
+  .strip()
+  .describe("Instructions for redeeming GBLIN back to ETH");
+
+/**
+ * Input schema for reading GBLIN treasury state (no arguments).
+ */
+export const GetTreasuryStateSchema = z
+  .object({})
+  .strip()
+  .describe("Read live GBLIN treasury state (NAV, supply, Crash Shield status)");

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -17,6 +17,7 @@ export * from "./erc20";
 export * from "./erc721";
 export * from "./erc8004";
 export * from "./farcaster";
+export * from "./gblin";
 export * from "./jupiter";
 export * from "./messari";
 export * from "./pyth";


### PR DESCRIPTION
## Description

Adds a `gblin` action provider so an agent can buy, redeem, and read GBLIN — a collateral-backed treasury index on Base (WETH / cbBTC / USDC) with an autonomous on-chain "Crash Shield" that reduces exposure to an asset during a drawdown. It is intended for parking surplus agent capital with capped drawdown: managed crypto exposure, explicitly **not** a stablecoin and not financial advice.

| Action | Description |
| --- | --- |
| `buy_gblin` | Buy GBLIN with ETH. Reads `quoteBuyGBLIN` on-chain and submits `buyGBLIN` with a slippage-bounded minimum output. |
| `sell_gblin_for_eth` | Redeem GBLIN back to ETH (e.g. to free capital for an x402 payment). Reads `quoteSellGBLIN` and submits `sellGBLINForEth` with a min-out. |
| `get_gblin_state` | Read the live per-GBLIN ETH redemption value and total supply. |

Design notes:

- Modeled on the existing Morpho provider (deposit/withdraw pattern).
- Every state-changing action derives its minimum output from the contract's own quote function, so the agent is never exposed to an unbounded swap.
- Base mainnet only (`supportsNetwork`).
- The contract is verified on Basescan and the included ABI is minimal and matches it 1:1: https://basescan.org/address/0x36C81d7E1966310F305eA637e761Cf77F90852f0#code

## Tests

Unit tests are included at `typescript/agentkit/src/action-providers/gblin/gblinActionProvider.test.ts`, following the structure of the existing Morpho provider tests. They cover the buy and redeem paths (asserting the exact encoded calldata and the quote-derived minimum output), input validation, a zero/stale-oracle quote, error handling, and `supportsNetwork`.

I have **not** included an end-to-end chatbot transcript yet, and I'd rather flag that than pad this section. GBLIN is deployed on Base **mainnet** only (no Sepolia deployment), so an end-to-end run spends real funds. If a transcript is required for review, I'm happy to run one of the chatbots in `typescript/examples/` against mainnet with a small amount and paste the full output here — just let me know which chatbot you'd prefer.

## Checklist

- [x] Added documentation to all relevant README.md files
- [x] Added a changelog entry

Happy to adjust naming, structure, or scope (e.g. dropping an action) to match maintainer preferences.