### PR TITLE
feat: add Aave V3 action provider (supply/withdraw)

### DIFF
--- a/typescript/.changeset/aave-action-provider.md
+++ b/typescript/.changeset/aave-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Added a new Aave V3 action provider for supply/withdraw of ERC-20 reserves on Base

--- a/typescript/agentkit/src/action-providers/aave/README.md
+++ b/typescript/agentkit/src/action-providers/aave/README.md
@@ -1,0 +1,38 @@
+# Aave Action Provider
+
+This directory contains the **AaveActionProvider** implementation, which provides actions to interact with the **Aave V3 Protocol** for supply/withdraw (lending) operations.
+
+## Directory Structure
+
+```
+aave/
+├── aaveActionProvider.ts       # Main provider with Aave V3 supply/withdraw functionality
+├── aaveActionProvider.test.ts  # Test file for Aave provider
+├── constants.ts                # Protocol addresses & ABI
+├── schemas.ts                  # Supply/withdraw action schemas
+├── index.ts                    # Main exports
+└── README.md                   # This file
+```
+
+## Actions
+
+- `supply`: Supply (deposit) an ERC-20 asset into the Aave V3 lending pool
+- `withdraw`: Withdraw a previously supplied ERC-20 asset from the Aave V3 lending pool
+
+## Adding New Actions
+
+To add new Aave actions:
+
+1. Define your action schema in `schemas.ts`
+2. Implement the action in `aaveActionProvider.ts`
+3. Add tests in `aaveActionProvider.test.ts`
+
+## Network Support
+
+The Aave provider supports Base mainnet and Base Sepolia.
+
+## Notes
+
+- This provider talks to the Aave V3 `Pool` contract directly via a minimal ABI (only `supply`/`withdraw`) using `viem` — it does not depend on `@aave/contract-helpers` or `ethers`, to stay consistent with the rest of AgentKit's wallet-provider-agnostic, viem-based design.
+- Only ERC-20 reserves are supported (no native ETH via the `WETHGateway`) in this initial version.
+- For more information on the **Aave Protocol**, visit [Aave Documentation](https://docs.aave.com/).

--- a/typescript/agentkit/src/action-providers/aave/aaveActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/aave/aaveActionProvider.test.ts
@@ -1,0 +1,231 @@
+import { encodeFunctionData, parseUnits } from "viem";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { approve } from "../../utils";
+import { AaveActionProvider } from "./aaveActionProvider";
+import { AAVE_POOL_ABI, AAVE_POOL_ADDRESSES } from "./constants";
+
+const MOCK_ASSET_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const MOCK_ONBEHALFOF = "0x9876543210987654321098765432109876543210";
+const MOCK_TO = "0x9876543210987654321098765432109876543210";
+const MOCK_WHOLE_ASSETS = "1.5";
+const MOCK_TX_HASH = "0xabcdef1234567890";
+const MOCK_RECEIPT = { status: "success", blockNumber: 1234567 };
+const MOCK_DECIMALS = 6;
+
+jest.mock("../../utils");
+const mockApprove = approve as jest.MockedFunction<typeof approve>;
+
+describe("Aave Action Provider", () => {
+  const actionProvider = new AaveActionProvider();
+  let mockWallet: jest.Mocked<EvmWalletProvider>;
+
+  beforeEach(() => {
+    mockWallet = {
+      getAddress: jest.fn().mockReturnValue(MOCK_ONBEHALFOF),
+      getNetwork: jest.fn().mockReturnValue({ protocolFamily: "evm", networkId: "base-mainnet" }),
+      sendTransaction: jest.fn().mockResolvedValue(MOCK_TX_HASH as `0x${string}`),
+      waitForTransactionReceipt: jest.fn().mockResolvedValue(MOCK_RECEIPT),
+      readContract: jest.fn().mockResolvedValue(MOCK_DECIMALS),
+    } as unknown as jest.Mocked<EvmWalletProvider>;
+
+    mockApprove.mockResolvedValue("Approval successful");
+  });
+
+  describe("supply", () => {
+    it("should successfully supply to Aave V3", async () => {
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        onBehalfOf: MOCK_ONBEHALFOF,
+      };
+
+      const atomicAssets = parseUnits(MOCK_WHOLE_ASSETS, MOCK_DECIMALS);
+      const poolAddress = AAVE_POOL_ADDRESSES["base-mainnet"];
+
+      const response = await actionProvider.supply(mockWallet, args);
+
+      expect(mockApprove).toHaveBeenCalledWith(
+        mockWallet,
+        MOCK_ASSET_ADDRESS,
+        poolAddress,
+        atomicAssets,
+      );
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+        to: poolAddress,
+        data: encodeFunctionData({
+          abi: AAVE_POOL_ABI,
+          functionName: "supply",
+          args: [MOCK_ASSET_ADDRESS, atomicAssets, MOCK_ONBEHALFOF, 0],
+        }),
+      });
+
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+      expect(response).toContain(`Supplied ${MOCK_WHOLE_ASSETS}`);
+      expect(response).toContain(MOCK_TX_HASH);
+      expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+    });
+
+    it("should reject supply with zero assets amount", async () => {
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: "0",
+        onBehalfOf: MOCK_ONBEHALFOF,
+      };
+
+      const response = await actionProvider.supply(mockWallet, args);
+
+      expect(response).toBe("Error: Assets amount must be greater than 0");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should reject supply on an unsupported network", async () => {
+      mockWallet.getNetwork.mockReturnValue({ protocolFamily: "evm", networkId: "ethereum" });
+
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        onBehalfOf: MOCK_ONBEHALFOF,
+      };
+
+      const response = await actionProvider.supply(mockWallet, args);
+
+      expect(response).toBe("Error: Aave V3 is not supported on network ethereum");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should handle approval failure", async () => {
+      mockApprove.mockResolvedValue("Error: Approval failed");
+
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        onBehalfOf: MOCK_ONBEHALFOF,
+      };
+
+      const response = await actionProvider.supply(mockWallet, args);
+
+      expect(response).toContain("Error approving Aave V3 Pool as spender: Error: Approval failed");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors when supplying", async () => {
+      mockWallet.sendTransaction.mockRejectedValue(new Error("Failed to supply"));
+
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        onBehalfOf: MOCK_ONBEHALFOF,
+      };
+
+      const response = await actionProvider.supply(mockWallet, args);
+
+      expect(response).toContain("Error supplying to Aave V3: Error: Failed to supply");
+    });
+  });
+
+  describe("withdraw", () => {
+    it("should successfully withdraw from Aave V3", async () => {
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        to: MOCK_TO,
+      };
+
+      const atomicAssets = parseUnits(MOCK_WHOLE_ASSETS, MOCK_DECIMALS);
+      const poolAddress = AAVE_POOL_ADDRESSES["base-mainnet"];
+
+      const response = await actionProvider.withdraw(mockWallet, args);
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledWith({
+        to: poolAddress,
+        data: encodeFunctionData({
+          abi: AAVE_POOL_ABI,
+          functionName: "withdraw",
+          args: [MOCK_ASSET_ADDRESS, atomicAssets, MOCK_TO],
+        }),
+      });
+
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith(MOCK_TX_HASH);
+      expect(response).toContain(`Withdrew ${MOCK_WHOLE_ASSETS}`);
+      expect(response).toContain(MOCK_TX_HASH);
+      expect(response).toContain(JSON.stringify(MOCK_RECEIPT));
+    });
+
+    it("should reject withdraw with zero assets amount", async () => {
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: "0",
+        to: MOCK_TO,
+      };
+
+      const response = await actionProvider.withdraw(mockWallet, args);
+
+      expect(response).toBe("Error: Assets amount must be greater than 0");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should reject withdraw on an unsupported network", async () => {
+      mockWallet.getNetwork.mockReturnValue({ protocolFamily: "evm", networkId: "ethereum" });
+
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        to: MOCK_TO,
+      };
+
+      const response = await actionProvider.withdraw(mockWallet, args);
+
+      expect(response).toBe("Error: Aave V3 is not supported on network ethereum");
+      expect(mockWallet.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors when withdrawing", async () => {
+      mockWallet.sendTransaction.mockRejectedValue(new Error("Failed to withdraw"));
+
+      const args = {
+        assetAddress: MOCK_ASSET_ADDRESS,
+        assets: MOCK_WHOLE_ASSETS,
+        to: MOCK_TO,
+      };
+
+      const response = await actionProvider.withdraw(mockWallet, args);
+
+      expect(response).toContain("Error withdrawing from Aave V3: Error: Failed to withdraw");
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should return true for Base Mainnet", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "evm",
+        networkId: "base-mainnet",
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return true for Base Sepolia", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "evm",
+        networkId: "base-sepolia",
+      });
+      expect(result).toBe(true);
+    });
+
+    it("should return false for other EVM networks", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "evm",
+        networkId: "ethereum",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("should return false for non-EVM networks", () => {
+      const result = actionProvider.supportsNetwork({
+        protocolFamily: "bitcoin",
+        networkId: "base-mainnet",
+      });
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/aave/aaveActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/aave/aaveActionProvider.ts
@@ -1,0 +1,178 @@
+import { z } from "zod";
+import { Decimal } from "decimal.js";
+import { encodeFunctionData, erc20Abi, parseUnits } from "viem";
+
+import { ActionProvider } from "../actionProvider";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { CreateAction } from "../actionDecorator";
+import { approve } from "../../utils";
+import { Network } from "../../network";
+import { AAVE_POOL_ABI, AAVE_POOL_ADDRESSES, SUPPORTED_NETWORKS } from "./constants";
+import { SupplySchema, WithdrawSchema } from "./schemas";
+
+/**
+ * AaveActionProvider is an action provider for Aave V3 Pool interactions
+ * (supply/withdraw of ERC-20 reserves).
+ */
+export class AaveActionProvider extends ActionProvider<EvmWalletProvider> {
+  /**
+   * Constructor for the AaveActionProvider class.
+   */
+  constructor() {
+    super("aave", []);
+  }
+
+  /**
+   * Supplies an ERC-20 asset into the Aave V3 lending pool.
+   *
+   * @param wallet - The wallet instance to execute the transaction
+   * @param args - The input arguments for the action
+   * @returns A success message with transaction details or an error message
+   */
+  @CreateAction({
+    name: "supply",
+    description: `
+This tool allows supplying (depositing) an ERC-20 asset into the Aave V3 lending pool.
+
+It takes:
+- assetAddress: The address of the underlying ERC-20 asset to supply (e.g. USDC)
+- assets: The amount of assets to supply, in whole units
+  Examples for USDC:
+  - 1 USDC
+  - 0.5 USDC
+  - 100 USDC
+- onBehalfOf: The address that will receive the aTokens and own the supplied position — usually the wallet's own address
+
+Important notes:
+- Make sure to use the exact amount provided. Do not convert units for assets for this action.
+- This tool handles token approval. Do not use any other action to approve tokens before calling this one.
+- Only supported on Base mainnet and Base Sepolia.
+`,
+    schema: SupplySchema,
+  })
+  async supply(wallet: EvmWalletProvider, args: z.infer<typeof SupplySchema>): Promise<string> {
+    const assets = new Decimal(args.assets);
+
+    if (assets.comparedTo(new Decimal(0.0)) != 1) {
+      return "Error: Assets amount must be greater than 0";
+    }
+
+    const network = wallet.getNetwork();
+    const poolAddress = AAVE_POOL_ADDRESSES[network.networkId!];
+
+    if (!poolAddress) {
+      return `Error: Aave V3 is not supported on network ${network.networkId}`;
+    }
+
+    try {
+      const decimals = await wallet.readContract({
+        address: args.assetAddress as `0x${string}`,
+        abi: erc20Abi,
+        functionName: "decimals",
+        args: [],
+      });
+      const atomicAssets = parseUnits(args.assets, decimals);
+
+      const approvalResult = await approve(wallet, args.assetAddress, poolAddress, atomicAssets);
+      if (approvalResult.startsWith("Error")) {
+        return `Error approving Aave V3 Pool as spender: ${approvalResult}`;
+      }
+
+      const data = encodeFunctionData({
+        abi: AAVE_POOL_ABI,
+        functionName: "supply",
+        args: [
+          args.assetAddress as `0x${string}`,
+          atomicAssets,
+          args.onBehalfOf as `0x${string}`,
+          0,
+        ],
+      });
+
+      const txHash = await wallet.sendTransaction({ to: poolAddress, data });
+      const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+      return `Supplied ${args.assets} of ${args.assetAddress} to Aave V3 with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(
+        receipt,
+        (_, value) => (typeof value === "bigint" ? value.toString() : value),
+      )}`;
+    } catch (error) {
+      return `Error supplying to Aave V3: ${error}`;
+    }
+  }
+
+  /**
+   * Withdraws a previously supplied ERC-20 asset from the Aave V3 lending pool.
+   *
+   * @param wallet - The wallet instance to execute the transaction
+   * @param args - The input arguments for the action
+   * @returns A success message with transaction details or an error message
+   */
+  @CreateAction({
+    name: "withdraw",
+    description: `
+This tool allows withdrawing a previously supplied ERC-20 asset from the Aave V3 lending pool.
+
+It takes:
+- assetAddress: The address of the underlying ERC-20 asset to withdraw (e.g. USDC)
+- assets: The amount of assets to withdraw, in whole units. Aave treats an amount greater than the supplied balance as a request to withdraw the entire balance — use a very large number (e.g. 1000000000) to withdraw everything.
+- to: The address that will receive the withdrawn assets
+
+Important notes:
+- Make sure to use the exact amount provided. Do not convert units for assets for this action.
+- Only supported on Base mainnet and Base Sepolia.
+`,
+    schema: WithdrawSchema,
+  })
+  async withdraw(wallet: EvmWalletProvider, args: z.infer<typeof WithdrawSchema>): Promise<string> {
+    const assets = new Decimal(args.assets);
+
+    if (assets.comparedTo(new Decimal(0.0)) != 1) {
+      return "Error: Assets amount must be greater than 0";
+    }
+
+    const network = wallet.getNetwork();
+    const poolAddress = AAVE_POOL_ADDRESSES[network.networkId!];
+
+    if (!poolAddress) {
+      return `Error: Aave V3 is not supported on network ${network.networkId}`;
+    }
+
+    try {
+      const decimals = await wallet.readContract({
+        address: args.assetAddress as `0x${string}`,
+        abi: erc20Abi,
+        functionName: "decimals",
+        args: [],
+      });
+      const atomicAssets = parseUnits(args.assets, decimals);
+
+      const data = encodeFunctionData({
+        abi: AAVE_POOL_ABI,
+        functionName: "withdraw",
+        args: [args.assetAddress as `0x${string}`, atomicAssets, args.to as `0x${string}`],
+      });
+
+      const txHash = await wallet.sendTransaction({ to: poolAddress, data });
+      const receipt = await wallet.waitForTransactionReceipt(txHash);
+
+      return `Withdrew ${args.assets} of ${args.assetAddress} from Aave V3 with transaction hash: ${txHash}\nTransaction receipt: ${JSON.stringify(
+        receipt,
+        (_, value) => (typeof value === "bigint" ? value.toString() : value),
+      )}`;
+    } catch (error) {
+      return `Error withdrawing from Aave V3: ${error}`;
+    }
+  }
+
+  /**
+   * Checks if the Aave action provider supports the given network.
+   *
+   * @param network - The network to check.
+   * @returns True if the Aave action provider supports the network, false otherwise.
+   */
+  supportsNetwork = (network: Network) =>
+    network.protocolFamily === "evm" && SUPPORTED_NETWORKS.includes(network.networkId!);
+}
+
+export const aaveActionProvider = () => new AaveActionProvider();

--- a/typescript/agentkit/src/action-providers/aave/constants.ts
+++ b/typescript/agentkit/src/action-providers/aave/constants.ts
@@ -1,0 +1,44 @@
+export const SUPPORTED_NETWORKS = ["base-mainnet", "base-sepolia"];
+
+/**
+ * Aave V3 Pool proxy address per network — the entry point for supply()/withdraw().
+ *
+ * Sources:
+ * - base-mainnet: BaseScan "Aave: Pool Proxy Base" (https://basescan.org/address/0xa238dd80c259a72e81d7e4664a9801593f98d1c5),
+ *   cross-checked against AAVE_PROTOCOL_DATA_PROVIDER in bgd-labs/aave-address-book, src/AaveV3Base.sol.
+ * - base-sepolia: aave-dao/aave-address-book, src/AaveV3BaseSepolia.sol.
+ */
+export const AAVE_POOL_ADDRESSES: Record<string, `0x${string}`> = {
+  "base-mainnet": "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5",
+  "base-sepolia": "0x8bAB6d1b75f19e9eD9fCe8b9BD338844fF79aE27",
+};
+
+/**
+ * Minimal IPool interface — only the two functions this action provider needs.
+ * Full interface: https://github.com/aave/aave-v3-core/blob/master/contracts/interfaces/IPool.sol
+ */
+export const AAVE_POOL_ABI = [
+  {
+    type: "function",
+    name: "supply",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "asset", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "onBehalfOf", type: "address" },
+      { name: "referralCode", type: "uint16" },
+    ],
+    outputs: [],
+  },
+  {
+    type: "function",
+    name: "withdraw",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "asset", type: "address" },
+      { name: "amount", type: "uint256" },
+      { name: "to", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;

--- a/typescript/agentkit/src/action-providers/aave/index.ts
+++ b/typescript/agentkit/src/action-providers/aave/index.ts
@@ -1,0 +1,1 @@
+export * from "./aaveActionProvider";

--- a/typescript/agentkit/src/action-providers/aave/schemas.ts
+++ b/typescript/agentkit/src/action-providers/aave/schemas.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+/**
+ * Input schema for Aave V3 supply action.
+ */
+export const SupplySchema = z
+  .object({
+    assetAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The address of the underlying ERC-20 asset to supply (e.g. USDC)"),
+    assets: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/, "Must be a valid integer or decimal value")
+      .describe("The amount of assets to supply, in whole units"),
+    onBehalfOf: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe(
+        "The address that will receive the aTokens and own the supplied position — usually the wallet's own address",
+      ),
+  })
+  .strip()
+  .describe("Input schema for Aave V3 supply action");
+
+/**
+ * Input schema for Aave V3 withdraw action.
+ */
+export const WithdrawSchema = z
+  .object({
+    assetAddress: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The address of the underlying ERC-20 asset to withdraw (e.g. USDC)"),
+    assets: z
+      .string()
+      .regex(/^\d+(\.\d+)?$/, "Must be a valid integer or decimal value")
+      .describe(
+        "The amount of assets to withdraw, in whole units. Aave treats an amount greater than the supplied balance as a request to withdraw the entire balance.",
+      ),
+    to: z
+      .string()
+      .regex(/^0x[a-fA-F0-9]{40}$/, "Invalid Ethereum address format")
+      .describe("The address that will receive the withdrawn assets"),
+  })
+  .strip()
+  .describe("Input schema for Aave V3 withdraw action");

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -3,6 +3,7 @@ export * from "./actionProvider";
 
 export * from "./customActionProvider";
 
+export * from "./aave";
 export * from "./across";
 export * from "./alchemy";
 export * from "./baseAccount";


### PR DESCRIPTION
## Summary

Adds an `AaveActionProvider` for supplying/withdrawing ERC-20 reserves on the Aave V3 `Pool` contract, on Base mainnet and Base Sepolia. Closes #323.

A previous attempt at this (#326) got closed without merging — the reviewer's main concern was that it pulled in `@aave/contract-helpers`, which depends on `ethers-v5`, inconsistent with the rest of AgentKit's `viem`-based wallet providers (see [the PR review](https://github.com/coinbase/agentkit/pull/326#pullrequestreview-2609758048) and [the follow-up discussion on #323](https://github.com/coinbase/agentkit/issues/323#issuecomment-2660371671)).

This version talks to the `Pool` contract directly via a minimal ABI (only `supply`/`withdraw`) using `viem` — the same pattern the built-in `MorphoActionProvider` and `CompoundActionProvider` already use — so it adds **zero new dependencies**.

## What's included

- `constants.ts` — Aave V3 Pool proxy addresses per network (sourced from `bgd-labs/aave-address-book`, cross-checked against BaseScan's verified "Aave: Pool Proxy Base" contract) + a minimal `IPool` ABI
- `schemas.ts` — Zod schemas for `supply`/`withdraw`
- `aaveActionProvider.ts` — `supply` and `withdraw` actions; decimals are read dynamically from the asset's own ERC-20 contract (via `viem`'s `erc20Abi`) rather than hardcoded, so any Aave V3 reserve is supported, not just USDC
- `aaveActionProvider.test.ts` — 13 unit tests: successful supply/withdraw, zero-amount rejection, unsupported network, approval failure, transaction errors
- `README.md` for the new provider folder
- Registered in `action-providers/index.ts`
- Changeset added

## Scope

This initial version covers ERC-20 reserves only (no native ETH via `WETHGateway`) — keeping the surface area minimal and directly verifiable against the standard `IPool` interface. Happy to extend it in a follow-up if there's interest.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` (scoped to `src/action-providers/aave`) — clean
- [x] `pnpm test` (scoped to `src/action-providers/aave`) — 13/13 passing
- [x] The underlying supply/withdraw calldata (same `IPool.supply`/`IPool.withdraw` ABI) has been exercised against Base mainnet with real funds in a separate project, so the contract interaction itself is field-tested, not just unit-tested against a mock.