### PR TITLE
fix(jupiter): cap slippageBps to 0-10000 like the 0x provider

### DIFF
--- a/typescript/agentkit/src/action-providers/jupiter/schemas.ts
+++ b/typescript/agentkit/src/action-providers/jupiter/schemas.ts
@@ -11,9 +11,12 @@ export const SwapTokenSchema = z
     slippageBps: z
       .number()
       .int()
-      .positive()
+      .min(0)
+      .max(10000)
       .nullable()
       .transform(val => val ?? 50)
-      .describe("Slippage tolerance in basis points (e.g., 50 = 0.5%)"),
+      .describe(
+        "Slippage tolerance in basis points (0-10000, e.g., 50 = 0.5%; default: 50). Caps match the 0x provider.",
+      ),
   })
   .describe("Swap tokens using Jupiter DEX aggregator");


### PR DESCRIPTION
## Description

Jupiter `SwapTokenSchema` previously accepted any positive integer for `slippageBps` (no upper bound). The 0x action provider already constrains slippage to `0–10000`. This aligns Jupiter with that cap so an agent/tool cannot request unbounded slippage via schema validation.

Note: this does **not** address blind signing of the remote `VersionedTransaction` itself; that needs separate quote/tx binding checks.

## AI disclosure

Drafted with AI assistance.

## Test plan

- [ ] Existing Jupiter tests still pass with default/50 bps
- [ ] Schema rejects values `> 10000`
- [ ] CI on this PR
