### PR TITLE
fix(sushi): report executed swap when Route event is missing from receipt

### DIFF
--- a/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.test.ts
@@ -463,6 +463,50 @@ describe("Sushi Action Provider", () => {
       expect(result).toContain(`Swapped`);
     });
 
+    it("should report an executed swap when the Route event is missing from the receipt", async () => {
+      const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
+        amount: formatUnits(amountIn, tokenIn.decimals),
+        fromAssetAddress: tokenIn.address,
+        toAssetAddress: tokenOut.address,
+        maxSlippage: 0.005,
+      };
+
+      /*
+       * 1. Mock the readContract which checks the decimals of the fromAssetAddress token (18, default)
+       * 2. Mock the readContract which checks for the balance of the fromAssetAddress token (1000000, enough balance)
+       * 3. Mock the readContract which checks for the approval (1000000, approved)
+       */
+      mockWallet.readContract
+        .mockResolvedValueOnce(tokenIn.decimals)
+        .mockResolvedValueOnce(amountIn)
+        .mockResolvedValueOnce(amountIn);
+
+      mockWallet.sendTransaction.mockResolvedValue(txHash);
+
+      // Swap tx succeeds on-chain but the receipt contains no Route event log
+      mockWallet.waitForTransactionReceipt.mockResolvedValueOnce({
+        status: "success",
+        logs: [],
+      });
+
+      mockedGetSwap.mockReturnValue(
+        getSuccessfullSwapResponse({
+          tokenIn,
+          amountIn,
+          tokenOut,
+          amountOut,
+        }),
+      );
+
+      const result = await actionProvider.swap(mockWallet, args);
+
+      expect(mockWallet.sendTransaction).toHaveBeenCalledTimes(1); // Swap only
+      expect(result).toContain("Swap executed");
+      expect(result).not.toContain("Error");
+      expect(result).toContain(`Transaction hash: ${txHash}`);
+      expect(result).toContain("Do not retry this swap automatically");
+    });
+
     it("should fail if there's no route", async () => {
       const args: Parameters<(typeof actionProvider)["swap"]>[1] = {
         amount: formatUnits(amountIn, tokenIn.decimals),

--- a/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/sushi/sushiRouterActionProvider.ts
@@ -149,7 +149,7 @@ Important notes:
       }
 
       // Find the Route event log, which includes the actual amountOut
-      const [routeLog] = swapReceipt.logs
+      const [routeLog] = (swapReceipt.logs ?? [])
         .filter(
           log =>
             encodeEventTopics({
@@ -164,6 +164,18 @@ Important notes:
             topics: log.topics,
           }),
         );
+
+      if (!routeLog) {
+        // The swap succeeded on-chain, but the receipt has no Route event to
+        // decode amounts from (e.g. fills not routed through RouteProcessor9).
+        // Report this as an executed swap — returning a generic error here
+        // leads agents to retry and execute a second, unintended swap.
+        return `Swap executed on ${chain.shortName}, but the Route event was not found in the transaction receipt, so the exact output amount could not be decoded.
+ - Quoted AmountOut: ${formatUnits(BigInt(secondSwap.swap.assumedAmountOut), secondSwap.swap.tokenTo.decimals)} ${secondSwap.swap.tokenTo.symbol} (${args.toAssetAddress})
+ - Transaction hash: ${swapHash}
+ - Transaction link: ${chain.getTransactionUrl(swapHash)}
+Do not retry this swap automatically; check the transaction first.`;
+      }
 
       return `Swapped ${formatUnits(routeLog.args.amountIn, secondSwap.swap.tokenFrom.decimals)} of ${secondSwap.swap.tokenFrom.symbol} (${args.fromAssetAddress}) for ${formatUnits(routeLog.args.amountOut, secondSwap.swap.tokenTo.decimals)} of ${secondSwap.swap.tokenTo.symbol} (${args.toAssetAddress}) on ${chain.shortName}
  - Transaction hash: ${swapHash}


### PR DESCRIPTION
## Summary
In \`sushiRouterActionProvider.swap\`, after a successful on-chain swap the action decodes the RouteProcessor9 \`Route\` event to report actual amounts:

\`\`\`ts
const [routeLog] = swapReceipt.logs.filter(...).map(decodeEventLog);
return \`Swapped \${formatUnits(routeLog.args.amountIn, ...)} ...\`
\`\`\`

If the receipt contains **no \`Route\` event** — e.g. the fill was routed via a different executor, or a wallet provider returns receipts without logs — \`routeLog\` is \`undefined\`, \`routeLog.args\` throws, and the outer \`catch\` returns \`Error swapping tokens: TypeError ...\`.

**The swap executed on-chain, but the agent is told it failed.** Agent frameworks respond to that by retrying the action, executing a **second, unintended swap** (double-spend).

## Fix
- Guard the decode: \`(swapReceipt.logs ?? [])\` and an explicit \`!routeLog\` branch.
- The branch reports the swap as **executed**, includes the tx hash/link and the quoted \`AmountOut\`, and explicitly tells the agent **not to retry automatically**.

No change to the happy path (Route event present) — same message as before.

## Test plan
- [x] New jest case: receipt \`status: "success"\` with \`logs: []\` → result contains \`Swap executed\`, the tx hash, and the no-retry note; does not contain \`Error\`
- [x] Full \`sushiRouterActionProvider.test.ts\` suite passes (16/16)

Related: #1392 (x402 allowlist), #1393 (jupiter slippage cap), #1394 (zeroX Permit2 binding) — same agent-funds safety theme, distinct defect.

Made with [Cursor](https://cursor.com)