### PR TITLE
fix(x402): do not silently flip HTTP method on 404

### DIFF
--- a/typescript/agentkit/src/action-providers/x402/x402ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402/x402ActionProvider.test.ts
@@ -215,6 +215,33 @@ describe("X402ActionProvider", () => {
       expect(parsedResult.registeredServices).toBeDefined();
     });
 
+    it("should not silently flip the HTTP method on 404", async () => {
+      mockFetch.mockResolvedValue(
+        createMockResponse({
+          status: 404,
+          data: { error: "not found" },
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const result = await provider.makeHttpRequest(makeMockWalletProvider("base-sepolia"), {
+        url: "https://api.example.com/items/123",
+        method: "GET",
+        headers: null,
+        queryParams: null,
+        body: JSON.stringify({ role: "admin" }),
+      });
+
+      // Exactly one request, with the method the caller chose. A silent
+      // GET->POST retry would turn an intended read into a write.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0][1]?.method).toBe("GET");
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe(404);
+      expect(parsed.method).toBe("GET");
+      expect(parsed.hint).toContain("explicitly");
+    });
+
     it("should handle successful non-payment requests", async () => {
       mockFetch.mockResolvedValue(
         createMockResponse({

--- a/typescript/agentkit/src/action-providers/x402/x402ActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402/x402ActionProvider.ts
@@ -217,24 +217,33 @@ If you receive a 402 Payment Required response, use retry_http_request_with_x402
       }
 
       const finalUrl = buildUrlWithParams(args.url, args.queryParams);
-      let method = args.method;
-      let canHaveBody = ["POST", "PUT", "PATCH"].includes(method);
+      const method = args.method;
+      const canHaveBody = ["POST", "PUT", "PATCH"].includes(method);
 
-      let response = await fetch(finalUrl, {
+      const response = await fetch(finalUrl, {
         method,
         headers: args.headers ?? undefined,
         body: canHaveBody && args.body ? JSON.stringify(args.body) : undefined,
       });
 
-      // Retry with other http method for 404 status code
+      // Never silently retry with a different HTTP method: flipping GET to
+      // POST turns an intended read into a possible write on services that
+      // map both methods to the same path. Surface the 404 with a hint and
+      // let the agent choose explicitly.
       if (response.status === 404) {
-        method = method === "GET" ? "POST" : "GET";
-        canHaveBody = ["POST", "PUT", "PATCH"].includes(method);
-        response = await fetch(finalUrl, {
-          method,
-          headers: args.headers ?? undefined,
-          body: canHaveBody && args.body ? JSON.stringify(args.body) : undefined,
-        });
+        const data = await this.parseResponseData(response);
+        return JSON.stringify(
+          {
+            success: false,
+            url: finalUrl,
+            method,
+            status: 404,
+            data,
+            hint: `The service returned 404 for ${method}. If it expects a different method, call this action again with that method explicitly.`,
+          },
+          null,
+          2,
+        );
       }
 
       if (response.status !== 402) {


### PR DESCRIPTION
## Summary

`make_http_request` retried a 404 with the HTTP method flipped (GET becomes POST, POST becomes GET) and the caller's body attached. On services that map both methods to one path (common in REST APIs, e.g. `GET /items/123` vs `POST /items`), that silently converts an intended read into a write the agent never chose to make. For an agent framework, silent method mutation is an integrity hazard: the model asked for a read, the tool executed a write.

## Fix

Return the 404 with a hint naming the method tried, so switching methods becomes an explicit agent decision:

```
The service returned 404 for GET. If it expects a different method, call this action again with that method explicitly.
```

## Test plan

- [x] New regression test: 404 on GET produces exactly one request, method unchanged, hint returned
- [x] Full x402 suite passes (22/22); `tsc --noEmit`, eslint, prettier clean

Made with [Cursor](https://cursor.com)