### PR TITLE
fix: handle rejected analytics request in WalletProvider.trackInitialization

### DIFF
--- a/typescript/.changeset/quiet-pugs-repeat.md
+++ b/typescript/.changeset/quiet-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Fixed a crash on wallet provider initialization when the analytics request fails

--- a/typescript/agentkit/src/wallet-providers/walletProvider.test.ts
+++ b/typescript/agentkit/src/wallet-providers/walletProvider.test.ts
@@ -140,6 +140,32 @@ describe("WalletProvider", () => {
     );
   });
 
+  it("should handle tracking rejections gracefully", () => {
+    (sendAnalyticsEvent as jest.Mock).mockImplementationOnce(() =>
+      Promise.reject(new Error("HTTP error! status: 400")),
+    );
+
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const unhandledRejectionSpy = jest.fn();
+    process.on("unhandledRejection", unhandledRejectionSpy);
+
+    new MockWalletProvider();
+
+    return new Promise(resolve =>
+      setTimeout(() => {
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          "Failed to track wallet provider initialization:",
+          expect.any(Error),
+        );
+        expect(unhandledRejectionSpy).not.toHaveBeenCalled();
+
+        process.off("unhandledRejection", unhandledRejectionSpy);
+        consoleWarnSpy.mockRestore();
+        resolve(null);
+      }, 0),
+    );
+  });
+
   it("should convert wallet provider to signer", () => {
     const provider = new MockWalletProvider();
     const signer = provider.toSigner();

--- a/typescript/agentkit/src/wallet-providers/walletProvider.ts
+++ b/typescript/agentkit/src/wallet-providers/walletProvider.ts
@@ -21,7 +21,14 @@ export abstract class WalletProvider {
    * Tracks the initialization of the wallet provider.
    */
   private trackInitialization() {
+    const onError = (error: unknown) =>
+      console.warn("Failed to track wallet provider initialization:", error);
+
     try {
+      // `sendAnalyticsEvent` is async and rejects on a non-ok response or a
+      // network failure. The surrounding try/catch only catches synchronous
+      // throws, so the rejection has to be handled here. Otherwise it becomes
+      // an unhandled rejection, which terminates the host process on Node 15+.
       sendAnalyticsEvent({
         name: "agent_initialization",
         action: "initialize_wallet_provider",
@@ -31,9 +38,9 @@ export abstract class WalletProvider {
         network_id: this.getNetwork().networkId,
         chain_id: this.getNetwork().chainId,
         protocol_family: this.getNetwork().protocolFamily,
-      });
+      }).catch(onError);
     } catch (error) {
-      console.warn("Failed to track wallet provider initialization:", error);
+      onError(error);
     }
   }
 


### PR DESCRIPTION
## Description

`WalletProvider.trackInitialization()` wraps `sendAnalyticsEvent()` in a try/catch, but the call isn't awaited. `sendAnalyticsEvent` is `async` and throws on a non-ok response:

```ts
if (!response.ok) {
  throw new Error(`HTTP error! status: ${response.status}`);
}
```

A synchronous try/catch can't see that rejection, so it escapes to the top level. Node has terminated the process on unhandled rejections by default since v15, so a failed analytics request takes the host application down about a second after the wallet provider is constructed.

It only shows up when the analytics request actually fails, which is probably why it hasn't come up on the usual CDP/Base setups. I ran into it on a custom EVM chain, where `cca-lite.coinbase.com` returns 400 for the unrecognised `network_id`. Anyone running offline or behind a firewall that blocks the endpoint should hit the same thing, since `fetch` rejects there too.

Observed on 0.10.4 in an MCP server built on AgentKit. The server finishes startup and answers `initialize`, then exits with:

```
Error: HTTP error! status: 400
    at sendAnalyticsEvent (.../analytics/sendAnalyticsEvent.js:50:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

Running the same binary with `NODE_OPTIONS=--unhandled-rejections=warn` keeps it alive, which confirms the rejection is what kills it.

The fix attaches `.catch()` so the existing warn-and-continue path actually runs. I kept the synchronous try/catch because `getName()`, `getAddress()` and `getNetwork()` are still called synchronously and can throw.

The Python implementation isn't affected. `send_analytics_event` is synchronous there, so its `try/except` already works.

## Tests

Added `should handle tracking rejections gracefully` to `walletProvider.test.ts`. It mocks `sendAnalyticsEvent` to reject, then checks that the warning is logged and that no `unhandledRejection` fires.

Reverting the source change makes the new test fail, so it covers the actual regression:

```
✕ should handle tracking rejections gracefully   (without the fix)
✓ should handle tracking rejections gracefully   (with the fix)
```

The file's suite passes 5/5. `eslint`, `tsc --noEmit` and `prettier --check` are clean on the touched files.
