### PR TITLE
fix(vaultsfyi): bind execute_step network to the wallet chain

### DIFF
--- a/typescript/agentkit/src/action-providers/vaultsfyi/vaultsfyiActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/vaultsfyi/vaultsfyiActionProvider.test.ts
@@ -291,6 +291,7 @@ describe("VaultsfyiActionProvider", () => {
       getNetwork: jest.fn().mockReturnValue({
         protocolFamily: "evm",
         networkId: "test-network",
+        chainId: "1",
       }),
       nativeTransfer: jest.fn(),
       readContract: jest.fn(() => Promise.resolve(18)), // token decimals
@@ -460,6 +461,40 @@ describe("VaultsfyiActionProvider", () => {
       expect(await provider.executeStep(mockWalletProvider, args)).toBe(
         "Failed to execute step: some more info",
       );
+    });
+
+    it("should reject when args.network does not match the wallet chain", async () => {
+      const args = {
+        vaultAddress: "0x123",
+        assetAddress: "0x456",
+        network: "base",
+        amount: 1n,
+        action: "deposit",
+      } as const;
+      mockedFetch.mockClear();
+      expect(await provider.executeStep(mockWalletProvider, args)).toBe(
+        "Error: You're trying to execute a step on a different network. Agent network is mainnet.",
+      );
+      expect(mockedFetch).not.toHaveBeenCalled();
+      expect(mockWalletProvider.sendTransaction).not.toHaveBeenCalled();
+    });
+
+    it("should reject when the wallet network is missing a chainId", async () => {
+      mockWalletProvider.getNetwork.mockReturnValue({
+        protocolFamily: "evm",
+        networkId: "test-network",
+      });
+      const args = {
+        vaultAddress: "0x123",
+        assetAddress: "0x456",
+        network: "mainnet",
+        amount: 1n,
+        action: "deposit",
+      } as const;
+      mockedFetch.mockClear();
+      expect(await provider.executeStep(mockWalletProvider, args)).toBe("Invalid network");
+      expect(mockedFetch).not.toHaveBeenCalled();
+      expect(mockWalletProvider.sendTransaction).not.toHaveBeenCalled();
     });
   });
 

--- a/typescript/agentkit/src/action-providers/vaultsfyi/vaultsfyiActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/vaultsfyi/vaultsfyiActionProvider.ts
@@ -282,6 +282,13 @@ export class VaultsfyiActionProvider extends ActionProvider<EvmWalletProvider> {
     wallet: EvmWalletProvider,
     args: z.infer<typeof executeStepActionSchema>,
   ): Promise<string> {
+    const chainId = wallet.getNetwork().chainId;
+    if (!chainId) return "Invalid network";
+    const networkName = getNetworkNameFromChainId(chainId);
+    if (!networkName) return "Invalid network";
+    if (args.network !== networkName) {
+      return `Error: You're trying to execute a step on a different network. Agent network is ${networkName}.`;
+    }
     try {
       const sdk = getVaultsSdk(this.apiKey);
       const amount = args.amount === "all" ? 0 : args.amount;


### PR DESCRIPTION
## Summary
- `execute_step` accepted an agent-chosen `network` and fetched/executed vaults.fyi actions without checking the connected wallet chain. Sibling `claim_rewards` already rejects cross-network claims.
- This PR mirrors that guard: require a supported wallet `chainId`, and reject when `args.network` does not match it (before any API call or `sendTransaction`).

Sibling of #1409 (CDP Permit2 / swap-submit retry). Same dogfood pass, different provider and root. Does not reopen that PR's findings.

## Test plan
- [x] `pnpm exec jest --testPathPattern='vaultsfyi/vaultsfyiActionProvider' --coverage=false` (28/28)
- [x] Regression: mismatched `args.network` vs wallet chain returns the claim_rewards-style error and does not call fetch/`sendTransaction`
- [x] Regression: missing wallet `chainId` returns `Invalid network`

Made with [Cursor](https://cursor.com)