### PR TITLE
fix(baseAccount): wait for spend/revoke receipt before success

### DIFF
--- a/typescript/agentkit/src/action-providers/baseAccount/baseAccountActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/baseAccount/baseAccountActionProvider.test.ts
@@ -189,7 +189,7 @@ describe("BaseAccountActionProvider", () => {
         networkId: "base-mainnet",
       }),
       sendTransaction: jest.fn().mockResolvedValue("0xmockTransactionHash"),
-      waitForTransactionReceipt: jest.fn(),
+      waitForTransactionReceipt: jest.fn().mockResolvedValue({ status: "success" }),
     } as unknown as jest.Mocked<EvmWalletProvider>;
 
     // Reset mocks before each test
@@ -322,6 +322,36 @@ describe("BaseAccountActionProvider", () => {
         data: "0xspendCallData",
         value: BigInt("0x0"),
       });
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith("0xmockTransactionHash");
+    });
+
+    it("should not report success when spend receipt reverts", async () => {
+      mockFetchPermissions.mockResolvedValue([mockPermission]);
+      mockGetPermissionStatus.mockResolvedValue(mockPermissionStatus);
+      mockGetTokenDetails.mockResolvedValue(mockTokenDetails);
+      mockPrepareSpendCallData.mockResolvedValue([
+        {
+          to: "0xSpendContract",
+          data: "0xspendCallData",
+          value: "0x0",
+        },
+      ]);
+      mockWallet.waitForTransactionReceipt.mockResolvedValue({ status: "reverted" });
+
+      const args = {
+        baseAccount: MOCK_BASE_ACCOUNT,
+        amount: 10.5,
+        tokenAddress: null,
+        permissionIndex: null,
+      };
+
+      const response = await actionProvider.spendFromBaseAccountPermission(mockWallet, args);
+      const parsedResponse = JSON.parse(response);
+
+      expect(parsedResponse.success).toBe(false);
+      expect(parsedResponse.error).toContain("failed or was reverted");
+      expect(parsedResponse.transactionHash).toBe("0xmockTransactionHash");
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith("0xmockTransactionHash");
     });
 
     it("should handle insufficient allowance", async () => {
@@ -395,6 +425,30 @@ describe("BaseAccountActionProvider", () => {
         data: "0xrevokeCallData",
         value: BigInt("0x0"),
       });
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith("0xmockTransactionHash");
+    });
+
+    it("should not report success when revoke receipt reverts", async () => {
+      mockFetchPermissions.mockResolvedValue([mockPermission]);
+      mockPrepareRevokeCallData.mockResolvedValue({
+        to: "0xRevokeContract",
+        data: "0xrevokeCallData",
+        value: "0x0",
+      });
+      mockWallet.waitForTransactionReceipt.mockResolvedValue({ status: "reverted" });
+
+      const args = {
+        baseAccount: MOCK_BASE_ACCOUNT,
+        permissionIndex: 1,
+      };
+
+      const response = await actionProvider.revokeBaseAccountSpendPermission(mockWallet, args);
+      const parsedResponse = JSON.parse(response);
+
+      expect(parsedResponse.success).toBe(false);
+      expect(parsedResponse.error).toContain("failed or was reverted");
+      expect(parsedResponse.transactionHash).toBe("0xmockTransactionHash");
+      expect(mockWallet.waitForTransactionReceipt).toHaveBeenCalledWith("0xmockTransactionHash");
     });
 
     it("should handle out of range permission index", async () => {

--- a/typescript/agentkit/src/action-providers/baseAccount/baseAccountActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/baseAccount/baseAccountActionProvider.ts
@@ -312,6 +312,23 @@ Important notes:
         value: BigInt(callData.value || "0x0"),
       });
 
+      // Wait for confirmation before reporting success. Returning success on
+      // broadcast alone lets agents/frameworks retry on later revert, which can
+      // double-spend against remaining allowance (same class as sushi #1401).
+      const receipt = await walletProvider.waitForTransactionReceipt(txHash);
+      if (receipt.status !== "complete" && receipt.status !== "success") {
+        return JSON.stringify({
+          success: false,
+          transactionHash: txHash,
+          error: "Spend transaction failed or was reverted",
+          baseAccount: baseAccount,
+          spender: spenderAddress,
+          tokenAddress: permissionTokenAddress,
+          tokenName: tokenDetails.name,
+          permissionIndex: permissionIndex,
+        });
+      }
+
       const amountSpentFormatted = formatUnits(amountInAtomicUnits, tokenDetails.decimals);
 
       return JSON.stringify({
@@ -416,6 +433,18 @@ Important notes:
         data: revokeCall.data,
         value: BigInt(revokeCall.value || "0x0"),
       });
+
+      const receipt = await walletProvider.waitForTransactionReceipt(txHash);
+      if (receipt.status !== "complete" && receipt.status !== "success") {
+        return JSON.stringify({
+          success: false,
+          transactionHash: txHash,
+          error: "Revoke transaction failed or was reverted",
+          revokedPermissionIndex: permissionIndex,
+          baseAccount: baseAccount,
+          spender: spenderAddress,
+        });
+      }
 
       return JSON.stringify({
         success: true,


### PR DESCRIPTION
Agents were treating Base Account spend (and revoke) as done as soon as `sendTransaction` returned a hash. If that transaction later reverts, a framework retry can spend again against the remaining allowance.

This waits for `waitForTransactionReceipt` and only returns `success: true` when the receipt status is `success` or `complete`, matching the confirmation pattern used by zeroX/sushi in this repo.

Sibling of #1409 (CDP Permit2 / swap-submit retry) and #1410 (vaultsfyi network bind). Same dogfood pass, different provider and root. Does not reopen those PRs' findings.

## Test plan
- [x] `pnpm exec jest --testPathPattern='baseAccount/baseAccountActionProvider' --coverage=false` (22/22)
- [x] Regression: spend receipt `reverted` returns `success: false` and still surfaces the tx hash
- [x] Regression: revoke receipt `reverted` returns `success: false`
- [x] Happy paths call `waitForTransactionReceipt` before success

Made with [Cursor](https://cursor.com)