### PR TITLE
fix(flaunch): exact Permit2 amountIn and short deadline

### DIFF
--- a/typescript/agentkit/src/action-providers/flaunch/flaunchActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/flaunch/flaunchActionProvider.test.ts
@@ -7,8 +7,7 @@ import {
   SellCoinSchema,
 } from "./schemas";
 import { EvmWalletProvider } from "../../wallet-providers";
-import { Hex } from "viem";
-import { formatEther } from "viem";
+import { Hex, formatEther, maxUint160, parseEther } from "viem";
 import * as swapUtils from "./swap_utils";
 
 // Mock the actual contract calls with Jest
@@ -431,6 +430,62 @@ describe("FlaunchActionProvider", () => {
       const result = await provider.sellCoin(mockWalletProvider, args);
       expect(result).toContain("Sold");
       expect(mockWalletProvider.signTypedData).toHaveBeenCalled();
+    });
+
+    it("should permit only amountIn with a short deadline (not maxUint160 / multi-year)", async () => {
+      const nowMs = 1_700_000_000_000;
+      const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(nowMs);
+
+      const args = {
+        coinAddress: "0x1234567890123456789012345678901234567890",
+        amountIn: "1000",
+        slippagePercent: 3,
+      };
+
+      try {
+        await provider.sellCoin(mockWalletProvider, args);
+
+        expect(mockWalletProvider.signTypedData).toHaveBeenCalled();
+        const typedData = mockWalletProvider.signTypedData.mock.calls[0][0] as {
+          message: {
+            details: { amount: bigint; expiration: number };
+            sigDeadline: bigint;
+          };
+        };
+
+        const expectedAmount = parseEther(args.amountIn);
+        const expectedDeadline = BigInt(Math.floor(nowMs / 1000) + 30 * 60);
+
+        expect(typedData.message.details.amount).toBe(expectedAmount);
+        expect(typedData.message.details.amount).not.toBe(maxUint160);
+        expect(typedData.message.details.expiration).toBe(Number(expectedDeadline));
+        expect(typedData.message.sigDeadline).toBe(expectedDeadline);
+        // Guard against regressing to the prior ~10-year window.
+        expect(Number(typedData.message.sigDeadline) - Math.floor(nowMs / 1000)).toBeLessThan(
+          60 * 60,
+        );
+      } finally {
+        dateNowSpy.mockRestore();
+      }
+    });
+
+    it("should skip permit2 signing when allowance already covers amountIn", async () => {
+      const covered = parseEther("1000");
+      mockWalletProvider.readContract.mockImplementation(({ functionName }) => {
+        if (functionName === "symbol") return "TEST";
+        if (functionName === "allowance") return [covered, BigInt(0)];
+        return undefined;
+      });
+
+      const args = {
+        coinAddress: "0x1234567890123456789012345678901234567890",
+        amountIn: "1000",
+        slippagePercent: 3,
+      };
+
+      const result = await provider.sellCoin(mockWalletProvider, args);
+      expect(result).toContain("Sold");
+      expect(mockWalletProvider.signTypedData).not.toHaveBeenCalled();
     });
 
     it("should handle errors in sellCoin", async () => {

--- a/typescript/agentkit/src/action-providers/flaunch/flaunchActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/flaunch/flaunchActionProvider.ts
@@ -9,7 +9,6 @@ import {
   zeroAddress,
   Address,
   formatEther,
-  maxUint160,
   Hex,
   zeroHash,
   parseUnits,
@@ -405,10 +404,11 @@ It takes:
       let signature: Hex | undefined;
       let permitSingle: PermitSingle | undefined;
 
-      // approve
+      // Permit2 AllowanceTransfer: approve only this sell's amountIn for a short
+      // window. Never maxUint160 / multi-year deadlines (leftover spender rights).
       if (allowance < amountIn) {
-        // 10 years in seconds
-        const defaultDeadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365 * 10);
+        const PERMIT2_DEADLINE_SECONDS = 30 * 60; // 30 minutes
+        const permitDeadline = BigInt(Math.floor(Date.now() / 1000) + PERMIT2_DEADLINE_SECONDS);
 
         const domain = {
           name: "Permit2",
@@ -419,12 +419,12 @@ It takes:
         const message = {
           details: {
             token: args.coinAddress as Address,
-            amount: maxUint160,
-            expiration: Number(defaultDeadline),
+            amount: amountIn,
+            expiration: Number(permitDeadline),
             nonce,
           },
           spender: UniversalRouterAddress[chainId],
-          sigDeadline: defaultDeadline,
+          sigDeadline: permitDeadline,
         } as PermitSingle;
 
         const typedData = {


### PR DESCRIPTION
Flaunch sellCoin was signing a Permit2 AllowanceTransfer for `maxUint160` with a ~10-year expiration and sigDeadline whenever the current allowance was too low. That leaves the UniversalRouter with unbounded, long-lived rights to the memecoin after (or instead of) the intended sell.

This permits only the sell `amountIn` for 30 minutes. Same over-approval hygiene as the CDP exact Permit2 path in #1409, different provider and Permit2 surface (local typed data on Flaunch, not ERC-20 approve to Permit2). Sibling of #1409/#1410/#1411. Does not reopen those PRs' findings.

## Test plan
- [x] `pnpm exec jest --testPathPattern='flaunch/flaunchActionProvider' --coverage=false` (20/20)
- [x] Regression: typed-data amount equals `amountIn` and is not `maxUint160`
- [x] Regression: expiration/sigDeadline are 30 minutes (not multi-year)
- [x] Regression: sufficient existing allowance skips `signTypedData`

Made with [Cursor](https://cursor.com)