### PR TITLE
fix(enso): cap route slippage to 0-10000 bps

### DIFF
--- a/typescript/agentkit/src/action-providers/enso/README.md
+++ b/typescript/agentkit/src/action-providers/enso/README.md
@@ -25,7 +25,7 @@ enso/
 - `tokenIn`: Address of the token to swap from (for ETH, use `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`)
 - `tokenOut`: Address of the token to swap to (for ETH, use `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`)
 - `amountIn`: Amount of tokenIn to swap in whole units (e.g., "100 USDC")
-- `slippage`: Optional slippage tolerance in basis points (1/10000). Default is 50 (0.5%)
+- `slippage`: Optional slippage tolerance in basis points (0-10000). Default is 50 (0.5%). Values above 10000 are rejected.
 
 ## Network Support
 

--- a/typescript/agentkit/src/action-providers/enso/ensoActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/enso/ensoActionProvider.test.ts
@@ -46,6 +46,68 @@ describe("Enso Route Schema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("should accept null slippage (API/default path)", () => {
+    const result = EnsoRouteSchema.safeParse({
+      tokenIn: USDC,
+      tokenOut: WETH,
+      amountIn: "100",
+      slippage: null,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.slippage).toBeNull();
+    }
+  });
+
+  it("should accept boundary slippage 0 and 10000", () => {
+    for (const slippage of [0, 10000]) {
+      const result = EnsoRouteSchema.safeParse({
+        tokenIn: USDC,
+        tokenOut: WETH,
+        amountIn: "100",
+        slippage,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.slippage).toBe(slippage);
+      }
+    }
+  });
+
+  it("should reject slippage above 10000 bps", () => {
+    const result = EnsoRouteSchema.safeParse({
+      tokenIn: USDC,
+      tokenOut: WETH,
+      amountIn: "100",
+      slippage: 10001,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject negative slippage", () => {
+    const result = EnsoRouteSchema.safeParse({
+      tokenIn: USDC,
+      tokenOut: WETH,
+      amountIn: "100",
+      slippage: -1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject non-integer slippage", () => {
+    const result = EnsoRouteSchema.safeParse({
+      tokenIn: USDC,
+      tokenOut: WETH,
+      amountIn: "100",
+      slippage: 50.5,
+    });
+
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("Enso Route Action", () => {

--- a/typescript/agentkit/src/action-providers/enso/schemas.ts
+++ b/typescript/agentkit/src/action-providers/enso/schemas.ts
@@ -22,6 +22,14 @@ export const EnsoRouteSchema = z
         "Address of the token to swap to, For ETH, use 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       ),
     amountIn: z.string().describe("Amount of tokenIn to swap in whole units (e.g. 100 USDC)"),
-    slippage: z.number().nullable().describe("Slippage in basis points (1/10000). Default - 50"),
+    slippage: z
+      .number()
+      .int()
+      .min(0)
+      .max(10000)
+      .nullable()
+      .describe(
+        "Slippage in basis points (0-10000, 1/10000 units). Default 50 (0.5%). Caps match Jupiter/0x.",
+      ),
   })
   .describe("Instructions for routing through Enso API");


### PR DESCRIPTION
Enso route schema accepted any numeric slippage (including values above 100%), so an agent or tool could request unbounded slippage on swaps. Cap `slippage` to 0-10000 bps (100%), matching Jupiter (#1393) and the 0x provider. Null still means omit (Enso API default / documented 50 bps). Sibling of #1409-#1412; does not reopen those findings.

## Cap
- Schema: `.int().min(0).max(10000).nullable()`
- Units: basis points (1/10000). Max 10000 = 100%.
- Default remains documented as 50 (0.5%) when the field is omitted/null.

## Test plan
- [x] `pnpm exec jest --testPathPattern='enso/ensoActionProvider' --coverage=false` (13/13)
- [x] Regression: rejects slippage `10001`, negative, and non-integer
- [x] Regression: accepts `0`, `10000`, `50`, and `null`

Made with [Cursor](https://cursor.com)