### PR TITLE
feat: add read-only TaskMarket action provider

### DIFF
--- a/typescript/.changeset/quiet-taskmarket.md
+++ b/typescript/.changeset/quiet-taskmarket.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Add a read-only TaskMarket action provider for discovering and inspecting escrowed Base tasks without signing transactions or spending wallet funds.

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -26,6 +26,7 @@ export * from "./opensea";
 export * from "./spl";
 export * from "./superfluid";
 export * from "./sushi";
+export * from "./taskmarket";
 export * from "./truemarkets";
 export * from "./twitter";
 export * from "./wallet";

--- a/typescript/agentkit/src/action-providers/taskmarket/README.md
+++ b/typescript/agentkit/src/action-providers/taskmarket/README.md
@@ -1,0 +1,16 @@
+# TaskMarket Action Provider
+
+`TaskMarketActionProvider` gives AgentKit agents a read-only way to discover and inspect escrowed USDC tasks on TaskMarket’s Base marketplace.
+
+## Usage
+
+```ts
+import { taskMarketActionProvider } from "@coinbase/agentkit";
+
+const provider = taskMarketActionProvider();
+const actions = provider.getActions(walletProvider);
+```
+
+The provider exposes `discover_tasks` and `get_task`. Both actions use TaskMarket’s public API and return structured JSON. They never create or claim work, submit a result, sign a transaction, or spend wallet funds. An application can present the returned task record to a user for review before adding any separately authorized write flow.
+
+Set `TASKMARKET_API_URL` to point at a compatible API in tests or a self-hosted development environment. The default is `https://api.taskmarket.dev`.

--- a/typescript/agentkit/src/action-providers/taskmarket/index.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/index.ts
@@ -1,0 +1,2 @@
+export * from "./schemas";
+export * from "./taskmarketActionProvider";

--- a/typescript/agentkit/src/action-providers/taskmarket/schemas.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/schemas.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+const TaskIdSchema = z
+  .string()
+  .regex(/^0x[a-fA-F0-9]{64}$/, "Task ID must be a 0x-prefixed 32-byte hex value")
+  .describe("TaskMarket task ID (0x-prefixed 32-byte hex value)");
+
+export const DiscoverTaskMarketTasksSchema = z
+  .object({
+    keyword: z
+      .string()
+      .trim()
+      .min(1)
+      .nullable()
+      .describe("Optional case-insensitive text filter for task descriptions and tags"),
+    maxRewardUsdc: z
+      .number()
+      .finite()
+      .nonnegative()
+      .nullable()
+      .describe("Optional maximum gross reward in USDC"),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .nullable()
+      .describe("Maximum number of tasks to return; defaults to 20"),
+  })
+  .describe("Filters for discovering open TaskMarket tasks");
+
+export const GetTaskMarketTaskSchema = z
+  .object({
+    taskId: TaskIdSchema,
+  })
+  .describe("The exact TaskMarket task to inspect");
+
+export type DiscoverTaskMarketTasks = z.infer<typeof DiscoverTaskMarketTasksSchema>;

--- a/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.test.ts
@@ -1,0 +1,73 @@
+import { TaskMarketActionProvider } from "./taskmarketActionProvider";
+
+describe("TaskMarketActionProvider", () => {
+  const fetchMock = jest.fn();
+  global.fetch = fetchMock;
+  const provider = new TaskMarketActionProvider();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("discovers and filters open tasks without wallet interaction", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([
+        {
+          id: `0x${"1".repeat(64)}`,
+          description: "Build an MCP adapter",
+          reward: "2000000",
+          netReward: "1850000",
+          status: "open",
+          mode: "bounty",
+          tags: ["mcp"],
+          escrowTxHash: `0x${"2".repeat(64)}`,
+        },
+        {
+          id: `0x${"3".repeat(64)}`,
+          description: "Write documentation",
+          reward: "500000",
+          status: "open",
+          tags: ["docs"],
+        },
+      ]),
+    });
+
+    const result = JSON.parse(
+      await provider.discoverTasks({ keyword: "mcp", maxRewardUsdc: 2, limit: 10 }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.readOnly).toBe(true);
+    expect(result.totalReturned).toBe(1);
+    expect(result.tasks[0]).toMatchObject({
+      rewardUsdc: 2,
+      netRewardUsdc: 1.85,
+      escrowTxHash: `0x${"2".repeat(64)}`,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.taskmarket.dev/api/tasks?status=open&limit=10",
+    );
+  });
+
+  it("returns a complete task record read-only", async () => {
+    const task = { id: `0x${"a".repeat(64)}`, description: "A task", reward: "1000000" };
+    fetchMock.mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue(task) });
+
+    const result = JSON.parse(await provider.getTask({ taskId: task.id }));
+
+    expect(result).toEqual({ success: true, readOnly: true, task });
+    expect(fetchMock).toHaveBeenCalledWith(`https://api.taskmarket.dev/api/tasks/${task.id}`);
+  });
+
+  it("surfaces API failures as structured errors", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+
+    const result = JSON.parse(
+      await provider.discoverTasks({ keyword: null, maxRewardUsdc: null, limit: null }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("HTTP 503");
+  });
+});

--- a/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.ts
@@ -1,0 +1,156 @@
+import { z } from "zod";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import {
+  DiscoverTaskMarketTasksSchema,
+  GetTaskMarketTaskSchema,
+  type DiscoverTaskMarketTasks,
+} from "./schemas";
+
+const TASKMARKET_API_URL =
+  process.env.TASKMARKET_API_URL?.replace(/\/$/, "") ?? "https://api.taskmarket.dev";
+
+type TaskRecord = {
+  id?: string;
+  description?: string;
+  title?: string;
+  reward?: string | number;
+  netReward?: string | number;
+  status?: string;
+  mode?: string;
+  expiryTime?: string;
+  createdAt?: string;
+  tags?: string[];
+  escrowTxHash?: string | null;
+  submissionCount?: number;
+  awardCount?: number;
+  [key: string]: unknown;
+};
+
+function asUsdc(value: string | number | undefined): number | null {
+  if (value === undefined) return null;
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric / 1_000_000 : null;
+}
+
+function taskText(task: TaskRecord): string {
+  return [task.title, task.description, ...(task.tags ?? [])].filter(Boolean).join(" ").toLowerCase();
+}
+
+function summarizeTask(task: TaskRecord): Record<string, unknown> {
+  return {
+    id: task.id,
+    title: task.title ?? task.description?.split("\n").find(Boolean)?.replace(/^#\s*/, ""),
+    description: task.description,
+    rewardUsdc: asUsdc(task.reward),
+    netRewardUsdc: asUsdc(task.netReward),
+    status: task.status,
+    mode: task.mode,
+    expiryTime: task.expiryTime,
+    createdAt: task.createdAt,
+    tags: task.tags ?? [],
+    escrowTxHash: task.escrowTxHash ?? null,
+    submissionCount: task.submissionCount ?? 0,
+    awardCount: task.awardCount ?? 0,
+  };
+}
+
+async function getJson(path: string): Promise<unknown> {
+  const response = await fetch(`${TASKMARKET_API_URL}${path}`);
+  if (!response.ok) {
+    throw new Error(`TaskMarket API returned HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+function asTaskRecords(value: unknown): TaskRecord[] {
+  const records = Array.isArray(value)
+    ? value
+    : value && typeof value === "object" && Array.isArray((value as { tasks?: unknown }).tasks)
+      ? (value as { tasks: unknown[] }).tasks
+      : null;
+  if (!records || !records.every(record => record && typeof record === "object")) {
+    throw new Error("TaskMarket API returned an unexpected task list");
+  }
+  return records as TaskRecord[];
+}
+
+/** Read-only discovery actions for the TaskMarket agent-work marketplace. */
+export class TaskMarketActionProvider extends ActionProvider {
+  constructor() {
+    super("taskmarket", []);
+  }
+
+  @CreateAction({
+    name: "discover_tasks",
+    description: `
+Discover open tasks on TaskMarket, an escrowed USDC marketplace on Base.
+
+This action is read-only: it never creates, claims, bids on, submits, or accepts work and never spends wallet funds. Use it to find work that may be better delegated to an external worker. Results include the task ID, gross/net reward, expiry, escrow transaction, competition counts, and tags. Optionally filter by keyword, maximum gross reward, and result limit.
+`,
+    schema: DiscoverTaskMarketTasksSchema,
+  })
+  async discoverTasks(args: z.infer<typeof DiscoverTaskMarketTasksSchema>): Promise<string> {
+    try {
+      const options: DiscoverTaskMarketTasks = {
+        keyword: args.keyword ?? null,
+        maxRewardUsdc: args.maxRewardUsdc ?? null,
+        limit: args.limit ?? 20,
+      };
+      const tasks = asTaskRecords(
+        await getJson(`/api/tasks?status=open&limit=${options.limit}`),
+      ).filter(task => {
+        const reward = asUsdc(task.reward);
+        return (
+          (!options.keyword || taskText(task).includes(options.keyword.toLowerCase())) &&
+          (options.maxRewardUsdc === null || (reward !== null && reward <= options.maxRewardUsdc))
+        );
+      });
+
+      return JSON.stringify(
+        {
+          success: true,
+          readOnly: true,
+          network: "Base",
+          totalReturned: tasks.length,
+          tasks: tasks.map(summarizeTask),
+        },
+        null,
+        2,
+      );
+    } catch (error) {
+      return JSON.stringify({
+        success: false,
+        error: `Error discovering TaskMarket tasks: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+
+  @CreateAction({
+    name: "get_task",
+    description: `
+Fetch the complete public record for one exact TaskMarket task by its 0x-prefixed 32-byte ID.
+
+This action is read-only and does not claim the task, submit work, sign a transaction, or spend funds. Inspect the record before any separately authorized marketplace action.
+`,
+    schema: GetTaskMarketTaskSchema,
+  })
+  async getTask(args: z.infer<typeof GetTaskMarketTaskSchema>): Promise<string> {
+    try {
+      const task = await getJson(`/api/tasks/${args.taskId}`);
+      if (!task || typeof task !== "object") throw new Error("TaskMarket returned an invalid task");
+      return JSON.stringify({ success: true, readOnly: true, task }, null, 2);
+    } catch (error) {
+      return JSON.stringify({
+        success: false,
+        error: `Error fetching TaskMarket task: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+
+  supportsNetwork(): boolean {
+    return true;
+  }
+}
+
+export const taskMarketActionProvider = () => new TaskMarketActionProvider();


### PR DESCRIPTION
## Summary

Add a read-only `TaskMarketActionProvider` for discovering open escrowed tasks and fetching an exact public task record from TaskMarket on Base.

## Scope and safety

- Adds `discover_tasks` with keyword, reward, and limit filters.
- Adds `get_task` for exact task inspection.
- Returns structured JSON with reward, expiry, escrow transaction, tags, and competition counts.
- Performs no wallet writes, signatures, claims, bids, submissions, task creation, or fund transfers.
- Uses `TASKMARKET_API_URL` for compatible test/development endpoints and defaults to the public API.

## Tests

- Added focused mocked-fetch Jest coverage for filtering, task retrieval, and API errors.
- Added package export, README usage, and a patch changeset.
- `git diff --check` passes.
- Full package install/test execution was attempted, but this checkout's existing Solana/x402 peer ranges prevented npm resolution and the monorepo pnpm link phase could not complete in the available environment.

This is an independently developed contribution; no TaskMarket account credentials or private keys are included.
