### PR TITLE
feat(x402): optional beforePayment hook to screen the recipient before paying

### DIFF
--- a/typescript/agentkit/src/action-providers/x402/README.md
+++ b/typescript/agentkit/src/action-providers/x402/README.md
@@ -39,7 +39,18 @@ const config: X402Config = {
   
   // Maximum payment per request in USDC
   // Default: 1.0 (or X402_MAX_PAYMENT_USDC env var)
-  maxPaymentUsdc: 0.5
+  maxPaymentUsdc: 0.5,
+
+  // Optional buyer-side pre-payment hook. Runs in retry_http_request_with_x402
+  // after amount + network validation and immediately before signing/settlement,
+  // receiving the recipient (payTo) and payment context. Return { abort: true }
+  // to refuse the payment without paying. Provider-neutral: plug in any recipient
+  // screening (sanctions / reputation / allowlist).
+  beforePayment: async ({ payTo }) => {
+    if (payTo && (await isSanctioned(payTo))) {
+      return { abort: true, reason: "recipient flagged" };
+    }
+  }
 };
 
 const provider = x402ActionProvider(config);
@@ -49,6 +60,27 @@ const provider = x402ActionProvider(config);
 - **USDC-Only Payments**: All payments are restricted to USDC assets only
 - **Payment Limits**: Enforces maximum payment amount per request (default: 1.0 USDC)
 - **Dynamic Registration Control**: Optional runtime service registration via agent
+- **Recipient screening (optional)**: `beforePayment` gates the recipient before any signing/settlement — see below
+
+### Screening the recipient before paying (`beforePayment`)
+
+`registeredServices` whitelists *where* the agent can pay and `maxPaymentUsdc` caps *how much*, but neither checks *who* the recipient is. The optional `beforePayment` hook fills that gap: it fires in the recommended two-step flow (`make_http_request` → `retry_http_request_with_x402`) after amount/network validation and just before payment is signed, with the selected option's `payTo`. Returning `{ abort: true, reason }` refuses the payment — no signature, no settlement.
+
+It's deliberately provider-neutral (no screening backend is bundled). Any implementation plugs in — for example [`anchor-x402-safe-pay`](https://github.com/hypeprinter007-stack/anchor-x402-safe-pay), which returns an `allow` / `review` / `block` verdict:
+
+```typescript
+import { screenAllows } from "anchor-x402-safe-pay";
+
+const config: X402Config = {
+  registeredServices: ["https://api.example.com"],
+  beforePayment: async ({ payTo }) => {
+    const { ok, verdict } = await screenAllows(payTo, { fetchImpl: paidFetch });
+    return ok ? undefined : { abort: true, reason: verdict.recommendation };
+  },
+};
+```
+
+> Note: the hook covers the two-step flow (which exposes `payTo` before paying). The one-shot `make_http_request_with_x402` action auto-settles a `402` inside the payment wrapper and does not expose the recipient pre-settlement, so it is not gated by this hook.
 
 ## Actions
 

--- a/typescript/agentkit/src/action-providers/x402/schemas.ts
+++ b/typescript/agentkit/src/action-providers/x402/schemas.ts
@@ -32,6 +32,43 @@ export interface X402Config {
    * Default: 1.0 (or X402_MAX_PAYMENT_USDC env var)
    */
   maxPaymentUsdc?: number;
+
+  /**
+   * Optional buyer-side pre-payment hook. Runs in `retry_http_request_with_x402`
+   * after amount + network validation and immediately before any signing or
+   * settlement, receiving the payment context (including the recipient `payTo`).
+   * Return `{ abort: true, reason }` to refuse the payment without paying — the
+   * neutral seat for sanctions / reputation / allowlist screening of the
+   * recipient. Provider-neutral: no screening backend is imported here, so any
+   * implementation can plug in (e.g. `anchor-x402-safe-pay`'s `screenAllows`).
+   */
+  beforePayment?: (
+    context: X402BeforePaymentContext,
+  ) => Promise<X402BeforePaymentDecision | void> | X402BeforePaymentDecision | void;
+}
+
+/** Context passed to the optional {@link X402Config.beforePayment} hook. */
+export interface X402BeforePaymentContext {
+  /** The service URL being paid. */
+  url: string;
+  /** Recipient address (v2 `payTo`), or `null` if the selected option did not declare one. */
+  payTo: string | null;
+  /** CAIP-2 network of the selected payment option. */
+  network: string;
+  /** Asset address / identifier being paid. */
+  asset: string;
+  /** Amount to be paid, as the option declared it (atomic or whole-unit string). */
+  amount: string;
+  /** HTTP method of the request being paid for. */
+  method: string;
+}
+
+/** Decision returned by the optional {@link X402Config.beforePayment} hook. */
+export interface X402BeforePaymentDecision {
+  /** When `true`, the payment is refused and never signed or settled. */
+  abort: boolean;
+  /** Optional human-readable reason surfaced in the action result. */
+  reason?: string;
 }
 
 /**

--- a/typescript/agentkit/src/action-providers/x402/x402ActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/x402/x402ActionProvider.test.ts
@@ -519,6 +519,88 @@ describe("X402ActionProvider", () => {
       expect(parsedResult.details.paymentProof).toEqual(MOCK_PAYMENT_PROOF);
     });
 
+    it("should abort payment when the beforePayment hook returns { abort: true }", async () => {
+      mockGetX402Networks.mockReturnValue(["base-sepolia"]);
+      const beforePayment = jest
+        .fn()
+        .mockResolvedValue({ abort: true, reason: "flagged recipient" });
+      const guarded = new X402ActionProvider({
+        registeredServices: ["https://www.x402.org"],
+        beforePayment,
+      });
+
+      const result = await guarded.retryWithX402(makeMockWalletProvider("base-sepolia"), {
+        url: "https://www.x402.org/protected",
+        method: "GET",
+        headers: null,
+        queryParams: null,
+        body: null,
+        selectedPaymentOption: {
+          scheme: "exact",
+          network: "base-sepolia",
+          maxAmountRequired: "10000",
+          asset: "0x456",
+          amount: null,
+          price: null,
+          payTo: "0xSanctionedRecipient",
+        },
+      });
+
+      // Hook saw the recipient + context...
+      expect(beforePayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://www.x402.org/protected",
+          payTo: "0xSanctionedRecipient",
+          network: "base-sepolia",
+          method: "GET",
+        }),
+      );
+      // ...and no payment was ever signed/settled.
+      expect(wrapFetchWithPayment).not.toHaveBeenCalled();
+      const parsedResult = JSON.parse(result);
+      expect(parsedResult.error).toBe(true);
+      expect(parsedResult.message).toBe("Payment aborted by beforePayment hook");
+      expect(parsedResult.details).toContain("flagged recipient");
+    });
+
+    it("should proceed with payment when the beforePayment hook allows", async () => {
+      mockGetX402Networks.mockReturnValue(["base-sepolia"]);
+      const beforePayment = jest.fn().mockResolvedValue(undefined);
+      const guarded = new X402ActionProvider({
+        registeredServices: ["https://www.x402.org"],
+        beforePayment,
+      });
+      mockFetchWithPayment.mockResolvedValue(
+        createMockResponse({
+          status: 200,
+          data: { message: "Paid content" },
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      const result = await guarded.retryWithX402(makeMockWalletProvider("base-sepolia"), {
+        url: "https://www.x402.org/protected",
+        method: "GET",
+        headers: null,
+        queryParams: null,
+        body: null,
+        selectedPaymentOption: {
+          scheme: "exact",
+          network: "base-sepolia",
+          maxAmountRequired: "10000",
+          asset: "0x456",
+          amount: null,
+          price: null,
+          payTo: "0xCleanRecipient",
+        },
+      });
+
+      expect(beforePayment).toHaveBeenCalledTimes(1);
+      expect(wrapFetchWithPayment).toHaveBeenCalled();
+      const parsedResult = JSON.parse(result);
+      expect(parsedResult.status).toBe("success");
+    });
+
     it("should handle network errors during payment", async () => {
       const error = new TypeError("fetch failed");
       mockGetX402Networks.mockReturnValue(["base-sepolia"]);

--- a/typescript/agentkit/src/action-providers/x402/x402ActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/x402/x402ActionProvider.ts
@@ -41,6 +41,7 @@ interface ResolvedX402Config {
   allowDynamicServiceRegistration: boolean;
   registeredFacilitators: Record<string, string>;
   maxPaymentUsdc: number;
+  beforePayment?: X402Config["beforePayment"];
 }
 
 /**
@@ -66,6 +67,7 @@ export class X402ActionProvider extends ActionProvider<WalletProvider> {
       registeredFacilitators: config.registeredFacilitators ?? {},
       maxPaymentUsdc:
         config.maxPaymentUsdc ?? parseFloat(process.env.X402_MAX_PAYMENT_USDC ?? "1.0"),
+      beforePayment: config.beforePayment,
     };
     this.registeredServices = new Set(this.config.registeredServices);
   }
@@ -458,6 +460,34 @@ DO NOT use this action directly without first trying make_http_request!`,
           null,
           2,
         );
+      }
+
+      // Optional buyer-side pre-payment gate. Runs after amount + network
+      // validation and immediately before any signing or settlement, so an
+      // integrator can screen the recipient (payTo) — sanctions, reputation,
+      // allowlist — and abort without paying. Provider-neutral: it receives the
+      // payment context and nothing vendor-specific, so any backend can plug in.
+      if (this.config.beforePayment) {
+        const decision = await this.config.beforePayment({
+          url: args.url,
+          payTo: args.selectedPaymentOption.payTo ?? null,
+          network: selectedNetwork,
+          asset: args.selectedPaymentOption.asset,
+          amount: paymentAmount,
+          method: args.method,
+        });
+        if (decision && decision.abort) {
+          return JSON.stringify(
+            {
+              error: true,
+              message: "Payment aborted by beforePayment hook",
+              details: decision.reason ?? "The pre-payment check refused this recipient.",
+              payTo: args.selectedPaymentOption.payTo,
+            },
+            null,
+            2,
+          );
+        }
       }
 
       // Create x402 client with appropriate signer


### PR DESCRIPTION
## What & why

Implements the neutral pre-payment hook proposed in #1402.

Today the x402 action provider gates **where** the agent can pay (`registeredServices`) and **how much** (`maxPaymentUsdc`), but nothing checks **who** the recipient is. A compromised or mistaken agent can pay a sanctioned / drainer / phishing address that passes both existing gates. This adds the missing seat: an optional recipient check at the pre-payment chokepoint.

## The change

A new optional `beforePayment` config hook:

```ts
const config: X402Config = {
  registeredServices: ["https://api.example.com"],
  beforePayment: async ({ payTo, url, network, asset, amount, method }) => {
    if (payTo && (await isSanctioned(payTo))) return { abort: true, reason: "recipient flagged" };
  },
};
```

- Runs in `retry_http_request_with_x402` **after** amount + network validation and **immediately before** any signing/settlement.
- Receives the payment context including the selected option's `payTo`.
- Returning `{ abort: true, reason }` refuses the payment — no signature, no settlement; the action returns a structured error.
- **Provider-neutral by design**: no screening backend is imported. Any implementation plugs in (sanctions / reputation / allowlist). The README shows [`anchor-x402-safe-pay`](https://github.com/hypeprinter007-stack/anchor-x402-safe-pay)'s `allow`/`review`/`block` verdict as one example.

This matches the design discussion on #1402 (three-state-friendly: the hook returns a decision + reason and is agnostic to how the verdict was reached).

## Scope & compatibility

- **Backward compatible** — no behavior change unless `beforePayment` is set.
- Covers the recommended two-step flow (`make_http_request` → `retry_http_request_with_x402`), which exposes `payTo` before paying. The one-shot `make_http_request_with_x402` auto-settles a `402` inside `wrapFetchWithPayment` and does **not** expose the recipient pre-settlement, so it is intentionally not gated (documented in the README). Gating it would need a larger refactor of that path.

## Tests

Two cases added mirroring the existing `retryWithX402` tests:
- `beforePayment` returns `{ abort: true }` → hook sees the `payTo`/context, `wrapFetchWithPayment` is never called, action returns the abort error.
- `beforePayment` allows → payment proceeds normally.

## Notes for reviewers

- Files: `schemas.ts` (config field + `X402BeforePaymentContext` / `X402BeforePaymentDecision` types), `x402ActionProvider.ts` (resolve + call site), `x402ActionProvider.test.ts` (2 tests), `README.md` (docs + example).
- I wasn't able to run the full TypeScript monorepo suite in my environment; the added tests mirror the existing retry tests exactly and the types are consistent by construction — please let CI validate.
- Happy to add **Python parity** in the same PR (or a follow-up) if you'd like it here — kept this TS-first to get a read on the shape before duplicating.

Closes #1402 (or partially addresses, if you'd prefer to keep it open for the Python side).
