### PR TITLE
feat(agentkit): add Taskmarket action provider

### DIFF
--- a/typescript/.changeset/taskmarket-action-provider.md
+++ b/typescript/.changeset/taskmarket-action-provider.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": minor
+---
+
+Added a Taskmarket action provider that lets agents delegate and request onchain work on the Taskmarket marketplace (USDC on Base): `list_tasks` (browse open work), `get_task` (track a task's live status), `list_submissions` (present submissions for human review), and `create_task` (create and fund a task with a hard max-spend cap and explicit user authorization, delegating the funded write to the first-party Taskmarket CLI).

--- a/typescript/agentkit/src/action-providers/index.ts
+++ b/typescript/agentkit/src/action-providers/index.ts
@@ -41,3 +41,4 @@ export * from "./zerion";
 export * from "./zerodev";
 export * from "./zeroX";
 export * from "./zora";
+export * from "./taskmarket";

--- a/typescript/agentkit/src/action-providers/taskmarket/README.md
+++ b/typescript/agentkit/src/action-providers/taskmarket/README.md
@@ -1,0 +1,89 @@
+# Taskmarket Action Provider
+
+This directory contains the **TaskmarketActionProvider**, which lets an AgentKit agent discover, track, review, and create work on the **Taskmarket** onchain task marketplace (USDC on Base L2). Taskmarket lets requesters escrow USDC and have workers earn payouts for accepted onchain work.
+
+## Directory Structure
+
+```
+taskmarket/
+├── taskmarketActionProvider.ts    # Main provider with Taskmarket functionality
+├── taskmarketActionProvider.test.ts # Test file for Taskmarket provider
+├── schemas.ts                     # Task action schemas
+├── constants.ts                   # Taskmarket integration constants
+├── index.ts                       # Main exports
+└── README.md                      # This file
+```
+
+## Actions
+
+- `list_tasks`: Browse open (submittable) Taskmarket tasks, optionally filtered by mode, max reward, or search text. Read-only; no wallet or secrets required.
+- `get_task`: Fetch the live status of a single Taskmarket task (status, phase, submission window, reward, submissions, award count, expiry). Read-only.
+- `list_submissions`: Present a task's submissions for human review (worker, submitted/rejected state). Read-only, and it **never accepts or rejects** work — that decision stays with a human via the first-party CLI.
+- `create_task`: Create (and fund) a Taskmarket task as a requester with **hard safety gates**: the wallet must be on Base (8453), the exact USDC cost is computed and surfaced, a **max-spend cap** is enforced, and a **fresh, explicit user authorization** string is required before anything is created.
+
+## Safety model
+
+The read actions are public REST calls against `https://api.taskmarket.dev` and need no wallet, no keys, and no spend.
+
+The `create_task` action is a funded onchain write and is deliberately conservative:
+
+- **Network guard** — refuses unless the wallet is connected to Base (chain id 8453), where Taskmarket escrows USDC.
+- **Explicit authorization** — the action refuses to create unless the caller passes an authorization string containing the exact total the user agreed to, e.g. `I authorize paying 5 USDC`.
+- **Max-spend cap** — a hard per-task cap (default `TASKMARKET_MAX_TASK_SPEND_USDC`, 25 USDC) that a task may not exceed unless a higher `maxSpendUsdc` is passed explicitly.
+- **First-party tooling** — the actual USDC escrow, X402 payment, legal acceptance, idempotency, and wallet signing are delegated to the official `taskmarket` CLI, so no private key, seed phrase, token, or cookie is requested, stored, logged, or committed.
+- **No silent retry** — if a payment result is ambiguous or in-flight, the action reports it and instructs polling by task id; it never blindly resubmits a payment whose settlement status is unknown.
+
+## Configuration
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `TASKMARKET_API_URL` | `https://api.taskmarket.dev` | Backend base URL (read actions) |
+| `TASKMARKET_MAX_TASK_SPEND_USDC` | `25` | Default hard per-task spend cap |
+| `TASKMARKET_CLI` | `taskmarket` | First-party CLI binary used for the funded write |
+| `TASKMARKET_CLI_TIMEOUT_MS` | `180000` | Timeout for the CLI write |
+
+## Usage Example
+
+```typescript
+import { TaskmarketActionProvider } from "@coinbase/agentkit";
+
+const provider = taskmarketActionProvider();
+
+// Browse open work (no wallet)
+const tasks = await provider.listTasks({ mode: "bounty", maxRewardUsdc: 6 });
+
+// Track a posted task's status (no wallet)
+const status = await provider.getTask({ taskId: "0x..." });
+
+// Present submissions for review (no wallet)
+const subs = await provider.listSubmissions({ taskId: "0x..." });
+
+// Create a task (needs a Base wallet + explicit authorization)
+const created = await provider.createTask(walletProvider, {
+  description: "Build a small browser game",
+  rewardUsdc: 5,
+  durationHours: 72,
+  mode: "bounty",
+  taskVisibility: "public",
+  submissionVisibility: "public",
+  tags: ["game"],
+  authorization: "I authorize paying 5 USDC", // must match the exact total
+});
+```
+
+Requires the first-party CLI for the funded write path:
+
+```bash
+npm install -g @lucid-agents/taskmarket@latest
+taskmarket init   # one-time: creates the CLI-owned signing wallet
+```
+
+## Adding New Actions
+
+1. Define your action schema in `schemas.ts`
+2. Implement the action in `taskmarketActionProvider.ts`
+3. Add tests in `taskmarketActionProvider.test.ts`
+
+## Network Support
+
+Taskmarket runs on **Base Mainnet (8453)** and escrows **USDC**. The read actions are network-neutral; the funded write is Base-gated inside `create_task`. See [Taskmarket Docs](https://docs.taskmarket.dev/) for the protocol reference.

--- a/typescript/agentkit/src/action-providers/taskmarket/constants.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/constants.ts
@@ -1,0 +1,46 @@
+/**
+ * Taskmarket integration constants.
+ *
+ * Taskmarket runs on Base L2 and escrows payouts in USDC. REST reward amounts
+ * are integer base-unit strings (6 decimals); the CLI accepts human-readable
+ * USDC.
+ */
+
+/** Production Taskmarket API base URL. */
+export const TASKMARKET_API_URL = process.env.TASKMARKET_API_URL ?? "https://api.taskmarket.dev";
+
+/** The Taskmarket backend serves REST under /api. */
+export const TASKMARKET_API_BASE = `${TASKMARKET_API_URL}/api`;
+
+/** USDC has 6 decimals on Base. */
+export const USDC_DECIMALS = 6;
+
+/** Base Mainnet chain id, where Taskmarket escrows USDC. */
+export const BASE_CHAIN_ID = 8453;
+
+/** USDC (native) contract on Base Mainnet. */
+export const BASE_USDC_CONTRACT = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+/** Human-friendly USDC display used in task URLs. */
+export const TASKMARKET_APP_URL = "https://taskmarket.dev";
+
+/**
+ * Default hard cap on a single task's total spend in USDC. Generated task
+ * creation refuses to go above this unless the caller passes a higher
+ * maxSpendUsdc, and it never lets the agent pay more than the exact cost.
+ */
+export const DEFAULT_MAX_TASK_SPEND_USDC = parseFloat(
+  process.env.TASKMARKET_MAX_TASK_SPEND_USDC ?? "25",
+);
+
+/** The first-party Taskmarket CLI used for the funded write path. */
+export const TASKMARKET_CLI = process.env.TASKMARKET_CLI ?? "taskmarket";
+
+/** How long the CLI write may run before being treated as in-flight. */
+export const TASKMARKET_CLI_TIMEOUT_MS = parseInt(
+  process.env.TASKMARKET_CLI_TIMEOUT_MS ?? "180000",
+  10,
+);
+
+/** Regex matching a 64-hex-char Taskmarket task id. */
+export const TASKMARKET_TASK_ID_REGEX = /0x[0-9a-fA-F]{64}/;

--- a/typescript/agentkit/src/action-providers/taskmarket/index.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/index.ts
@@ -1,0 +1,2 @@
+export * from "./taskmarketActionProvider";
+export * from "./schemas";

--- a/typescript/agentkit/src/action-providers/taskmarket/schemas.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/schemas.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+
+/**
+ * Input schema for listing/browsing Taskmarket tasks.
+ */
+export const ListTasksSchema = z
+  .object({
+    mode: z
+      .enum(["bounty", "claim", "pitch", "benchmark", "auction"])
+      .optional()
+      .describe("Optional task mode to filter by"),
+    maxRewardUsdc: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Optional maximum reward in whole USDC to filter by"),
+    search: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Optional substring to search for in task descriptions"),
+    cursor: z
+      .string()
+      .optional()
+      .describe("Pagination cursor returned by a previous list_tasks call"),
+  })
+  .strict();
+
+/**
+ * Input schema for fetching the live status of one Taskmarket task.
+ */
+export const GetTaskSchema = z
+  .object({
+    taskId: z.string().min(1).describe("The Taskmarket task id (0x-prefixed)"),
+  })
+  .strict();
+
+/**
+ * Input schema for listing submissions of a Taskmarket task for review.
+ */
+export const ListSubmissionsSchema = z
+  .object({
+    taskId: z.string().min(1).describe("The Taskmarket task id (0x-prefixed)"),
+    maxResults: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("Maximum number of submissions to return (default 50)"),
+  })
+  .strict();
+
+/**
+ * Input schema for creating a Taskmarket task as a requester.
+ *
+ * Every write is gated by explicit user authorization and a hard max-spend
+ * cap so the agent can never silently fund on-chain work.
+ */
+export const CreateTaskSchema = z
+  .object({
+    description: z.string().min(1).max(10000).describe("The task description shown to workers"),
+    rewardUsdc: z
+      .number()
+      .positive()
+      .describe("The reward offered to the completing worker in whole USDC (e.g. 5 for 5 USDC)"),
+    durationHours: z
+      .number()
+      .positive()
+      .describe("How long the task stays open, in hours from creation"),
+    mode: z
+      .enum(["bounty", "claim", "pitch", "benchmark", "auction"])
+      .optional()
+      .describe("Task mode (default bounty)"),
+    taskVisibility: z
+      .enum(["public", "unlisted", "private"])
+      .optional()
+      .describe("Who can see the task exists (default public)"),
+    submissionVisibility: z
+      .enum(["public", "reveal_all", "winner_only", "never"])
+      .optional()
+      .describe("Who can see submissions (default public)"),
+    tags: z
+      .array(z.string().min(1).max(32))
+      .max(10)
+      .optional()
+      .describe("Optional up to 10 tags to help workers discover the task"),
+    maxSpendUsdc: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "Hard cap on the total spend in USDC for this task. Defaults to the provider limit.",
+      ),
+    authorization: z
+      .string()
+      .min(1)
+      .describe(
+        "Explicit, fresh user authorization. Must contain the exact phrase 'I authorize paying <total> USDC' where <total> is the total cost returned by the plan. The action refuses to create anything without it.",
+      ),
+  })
+  .strict();

--- a/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.test.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.test.ts
@@ -1,0 +1,286 @@
+import { execFile } from "child_process";
+import type { EvmWalletProvider } from "../../wallet-providers";
+import { taskmarketActionProvider, TaskmarketActionProvider } from "./taskmarketActionProvider";
+
+jest.mock("child_process", () => ({
+  execFile: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const execFileMock = execFile as any;
+
+// Minimal EvmWalletProvider-like object for create_task network checks.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const baseWallet = {
+  getNetwork: () => ({ chainId: "8453", protocolFamily: "evm", networkId: "base-mainnet" }),
+} as unknown as EvmWalletProvider;
+
+const validArgs = {
+  description: "Build a small browser game",
+  rewardUsdc: 5,
+  durationHours: 72,
+  mode: "bounty" as const,
+  taskVisibility: "public" as const,
+  submissionVisibility: "public" as const,
+  tags: ["game"],
+  maxSpendUsdc: undefined,
+  authorization: "I authorize paying 5 USDC",
+};
+
+describe("TaskmarketActionProvider", () => {
+  const apiBase = "https://api.taskmarket.dev/api";
+  const fetchMock = jest.fn();
+
+  beforeAll(() => {
+    global.fetch = fetchMock;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).fetch;
+  });
+
+  describe("listTasks", () => {
+    it("should return parsed open tasks and pagination cursor", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tasks: [
+            {
+              id: "0xaaa",
+              reward: "6000000",
+              mode: "bounty",
+              status: "open",
+              phase: "active",
+              submissionWindowOpen: true,
+              submissionCount: 10,
+              awardCount: 0,
+              expiryTime: "2026-08-20T00:00:00Z",
+            },
+            {
+              id: "0xbbb",
+              reward: "2000000",
+              mode: "bounty",
+              status: "open",
+              phase: "active",
+              submissionWindowOpen: true,
+              submissionCount: 1,
+              awardCount: 0,
+              expiryTime: "2026-08-21T00:00:00Z",
+            },
+          ],
+          hasMore: true,
+          nextCursor: "cursor-1",
+        }),
+      });
+
+      const result = await taskmarketActionProvider().listTasks({});
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.count).toBe(2);
+      expect(parsed.tasks[0].rewardUsdc).toBe(6);
+      expect(parsed.tasks[0].id).toBe("0xaaa");
+      expect(parsed.nextCursor).toBe("cursor-1");
+      expect(fetchMock).toHaveBeenCalledWith(`${apiBase}/tasks?`);
+    });
+
+    it("should filter by maxRewardUsdc", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tasks: [
+            {
+              id: "0xaaa",
+              reward: "6000000",
+              mode: "bounty",
+              status: "open",
+              phase: "active",
+              submissionWindowOpen: true,
+            },
+            {
+              id: "0xbbb",
+              reward: "2000000",
+              mode: "bounty",
+              status: "open",
+              phase: "active",
+              submissionWindowOpen: true,
+            },
+          ],
+          hasMore: false,
+          nextCursor: null,
+        }),
+      });
+
+      const result = await taskmarketActionProvider().listTasks({
+        mode: "bounty",
+        maxRewardUsdc: 3,
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.count).toBe(1);
+      expect(parsed.tasks[0].id).toBe("0xbbb");
+    });
+
+    it("should surface an HTTP error", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+
+      const result = await taskmarketActionProvider().listTasks({});
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("500");
+    });
+  });
+
+  describe("getTask", () => {
+    it("should return the live task status with reward in whole USDC", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "0xabc",
+          description: "Do work",
+          reward: "4500000",
+          mode: "bounty",
+          status: "open",
+          phase: "active",
+          submissionWindowOpen: true,
+          submissionCount: 4,
+          awardCount: 0,
+          expiryTime: "2026-08-22T00:00:00Z",
+          taskVisibility: "public",
+          submissionVisibility: "public",
+          platformFeeBps: 250,
+        }),
+      });
+
+      const result = await taskmarketActionProvider().getTask({ taskId: "0xabc" });
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(true);
+      expect(parsed.task.rewardUsdc).toBe(4.5);
+      expect(parsed.task.submissionWindowOpen).toBe(true);
+      expect(parsed.task.id).toBe("0xabc");
+    });
+  });
+
+  describe("listSubmissions", () => {
+    it("should return pending submissions with rejected state", async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: "sub-1",
+            workerAddress: "0x111",
+            submittedAt: "2026-08-19T00:00:00Z",
+            rejectedAt: null,
+          },
+          {
+            id: "sub-2",
+            workerAddress: "0x222",
+            submittedAt: "2026-08-19T01:00:00Z",
+            rejectedAt: "2026-08-19T02:00:00Z",
+          },
+        ],
+      });
+
+      const result = await taskmarketActionProvider().listSubmissions({ taskId: "0xabc" });
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(true);
+      expect(parsed.total).toBe(2);
+      expect(parsed.submissions[0].status).toBe("pending_review");
+      expect(parsed.submissions[1].status).toBe("rejected");
+    });
+  });
+
+  describe("createTask", () => {
+    it("should refuse creation when not on Base", async () => {
+      const notBase = {
+        getNetwork: () => ({ chainId: "1", protocolFamily: "evm", networkId: "ethereum-mainnet" }),
+      } as unknown as EvmWalletProvider;
+
+      const result = await taskmarketActionProvider().createTask(notBase, validArgs);
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("only be created on Base");
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+
+    it("should refuse creation when it exceeds the max-spend cap", async () => {
+      const result = await taskmarketActionProvider().createTask(baseWallet, {
+        ...validArgs,
+        rewardUsdc: 100,
+        authorization: "I authorize paying 100 USDC",
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("exceeds the max-spend cap");
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+
+    it("should refuse creation without explicit authorization matching the exact total", async () => {
+      const result = await taskmarketActionProvider().createTask(baseWallet, {
+        ...validArgs,
+        authorization: "I authorize paying 4 USDC",
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("no valid explicit authorization");
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+
+    it("should delegate the funded write to the CLI and return the task id", async () => {
+      const taskId = `0x${"a".repeat(64)}`;
+      execFileMock.mockImplementation((_cli, _args, _opts, cb) => {
+        cb(null, {
+          stdout: `Created task ${taskId}\nTask URL: https://taskmarket.dev/tasks/${taskId}\n`,
+          stderr: "",
+        });
+      });
+
+      const result = await taskmarketActionProvider().createTask(baseWallet, validArgs);
+      const parsed = JSON.parse(result);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.taskId).toBe(taskId);
+      expect(parsed.network).toBe("base:8453");
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      const cliArgs = execFileMock.mock.calls[0][1];
+      expect(cliArgs).toContain("create");
+      expect(cliArgs).toContain("--reward");
+      expect(cliArgs).toContain("5");
+      expect(cliArgs).toContain("--duration");
+      expect(cliArgs).toContain("--tags");
+    });
+
+    it("should surface CLI failure without resubmitting", async () => {
+      execFileMock.mockImplementation((_cli, _args, _opts, cb) => {
+        cb(new Error("Task not created"));
+      });
+
+      const result = await taskmarketActionProvider().createTask(baseWallet, validArgs);
+      const parsed = JSON.parse(result);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain("Taskmarket task creation failed");
+    });
+  });
+
+  describe("supportsNetwork", () => {
+    it("should support EVM networks", () => {
+      expect(taskmarketActionProvider().supportsNetwork({ protocolFamily: "evm" })).toBe(true);
+      expect(taskmarketActionProvider().supportsNetwork({ protocolFamily: "svm" } as never)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("TaskmarketActionProvider config", () => {
+    it("should allow overriding the spend cap and CLI", () => {
+      const provider = new TaskmarketActionProvider({ maxSpendUsdc: 2, cli: "my-taskmarket" });
+      expect(provider).toBeInstanceOf(TaskmarketActionProvider);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.ts
+++ b/typescript/agentkit/src/action-providers/taskmarket/taskmarketActionProvider.ts
@@ -1,0 +1,439 @@
+import { z } from "zod";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { ActionProvider } from "../actionProvider";
+import { CreateAction } from "../actionDecorator";
+import { Network } from "../../network";
+import { EvmWalletProvider } from "../../wallet-providers";
+import { ListTasksSchema, GetTaskSchema, ListSubmissionsSchema, CreateTaskSchema } from "./schemas";
+import {
+  TASKMARKET_API_BASE,
+  TASKMARKET_APP_URL,
+  USDC_DECIMALS,
+  BASE_CHAIN_ID,
+  DEFAULT_MAX_TASK_SPEND_USDC,
+  TASKMARKET_CLI,
+  TASKMARKET_CLI_TIMEOUT_MS,
+  TASKMARKET_TASK_ID_REGEX,
+} from "./constants";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Configuration for the Taskmarket action provider.
+ */
+interface TaskmarketConfig {
+  apiBase: string;
+  maxSpendUsdc: number;
+  cli: string;
+  cliTimeoutMs: number;
+}
+
+/**
+ * Resolves Taskmarket configuration from environment defaults.
+ *
+ * @returns The resolved configuration.
+ */
+function resolveConfig(): TaskmarketConfig {
+  return {
+    apiBase: TASKMARKET_API_BASE,
+    maxSpendUsdc: DEFAULT_MAX_TASK_SPEND_USDC,
+    cli: TASKMARKET_CLI,
+    cliTimeoutMs: TASKMARKET_CLI_TIMEOUT_MS,
+  };
+}
+
+/**
+ * TaskmarketActionProvider provides actions for discovering, tracking, and
+ * creating work on the Taskmarket onchain task marketplace (USDC on Base).
+ *
+ * Reads (list/get/submissions) call the public Taskmarket REST API and need no
+ * wallet or secrets. Creating a task is a funded onchain write: the action
+ * computes the exact cost, enforces a hard max-spend cap, requires fresh,
+ * explicit user authorization, and delegates the actual USDC escrow to the
+ * first-party `taskmarket` CLI (which handles legal acceptance, X402 payment,
+ * idempotency and wallet signing) so no private key ever touches the agent.
+ */
+export class TaskmarketActionProvider extends ActionProvider<EvmWalletProvider> {
+  private readonly config: TaskmarketConfig;
+
+  /**
+   * Constructs a new TaskmarketActionProvider.
+   *
+   * @param config - Optional overrides for API base, spend cap, and CLI.
+   */
+  constructor(config: Partial<TaskmarketConfig> = {}) {
+    super("taskmarket", []);
+    const defaults = resolveConfig();
+    this.config = {
+      apiBase: config.apiBase ?? defaults.apiBase,
+      maxSpendUsdc: config.maxSpendUsdc ?? defaults.maxSpendUsdc,
+      cli: config.cli ?? defaults.cli,
+      cliTimeoutMs: config.cliTimeoutMs ?? defaults.cliTimeoutMs,
+    };
+  }
+
+  /**
+   * Lists or browses open Taskmarket tasks.
+   *
+   * @param args - Optional mode / reward / search / cursor filters.
+   * @returns A JSON string of tasks and a pagination cursor.
+   */
+  @CreateAction({
+    name: "list_tasks",
+    description: `
+This tool lists open (submittable) tasks on the Taskmarket onchain marketplace so an agent can recognize work it would rather delegate to external workers and browse candidate tasks.
+
+It takes the following optional inputs:
+- mode: bounty, claim, pitch, benchmark, or auction
+- maxRewardUsdc: return only tasks with reward at or below this many whole USDC
+- search: return only tasks whose description contains this substring
+- cursor: a pagination cursor from a previous call to continue paging
+
+Important notes:
+- This is a read-only action; it never spends funds or requires a wallet.
+- Only tasks with status=open, phase=active and submissionWindowOpen=true are currently submittable.
+- Rewards are reported in whole USDC.
+`,
+    schema: ListTasksSchema,
+  })
+  async listTasks(args: z.infer<typeof ListTasksSchema>): Promise<string> {
+    try {
+      const params = new URLSearchParams();
+      if (args.mode) params.set("mode", args.mode);
+      if (args.search) params.set("search", args.search);
+      if (args.cursor) params.set("cursor", args.cursor);
+
+      const response = await fetch(`${this.config.apiBase}/tasks?${params.toString()}`);
+      if (!response.ok) {
+        return JSON.stringify({ success: false, error: `HTTP error! status: ${response.status}` });
+      }
+
+      const data = (await response.json()) as {
+        tasks: Array<Record<string, unknown>>;
+        nextCursor?: string | null;
+        hasMore?: boolean;
+      };
+      const tasks = (data.tasks ?? []).map(task => {
+        const reward = typeof task.reward === "string" ? task.reward : "0";
+        const item: Record<string, unknown> = {
+          id: task.id,
+          description: String(task.description ?? "").slice(0, 200),
+          rewardUsdc: this.fromBaseUnits(reward),
+          mode: task.mode,
+          status: task.status,
+          phase: task.phase,
+          submissionWindowOpen: task.submissionWindowOpen,
+          submissionCount: task.submissionCount,
+          awardCount: task.awardCount,
+          expiryTime: task.expiryTime,
+        };
+        return item;
+      });
+
+      const maxReward = args.maxRewardUsdc;
+      const filtered = maxReward ? tasks.filter(t => (t.rewardUsdc as number) <= maxReward) : tasks;
+
+      return JSON.stringify({
+        success: true,
+        count: filtered.length,
+        tasks: filtered,
+        hasMore: data.hasMore,
+        nextCursor: data.nextCursor,
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: `Failed to list tasks: ${error}` });
+    }
+  }
+
+  /**
+   * Fetches the live status of a single Taskmarket task.
+   *
+   * @param args - The task id.
+   * @returns A JSON string with the task's current live status.
+   */
+  @CreateAction({
+    name: "get_task",
+    description: `
+This tool fetches the current live status of a single Taskmarket task by id, so an agent can track a task it posted or is monitoring.
+
+It takes the following inputs:
+- taskId: the 0x-prefixed task id
+
+Returns: status, phase, mode, rewardUsdc, submissionWindowOpen, submissionCount, awardCount, expiryTime, visibility, and the task description.
+
+Important notes:
+- This is a read-only action; it never spends funds or requires a wallet.
+- Only tasks with status=open, phase=active and submissionWindowOpen=true are currently submittable.
+`,
+    schema: GetTaskSchema,
+  })
+  async getTask(args: z.infer<typeof GetTaskSchema>): Promise<string> {
+    try {
+      const response = await fetch(
+        `${this.config.apiBase}/tasks/${encodeURIComponent(args.taskId)}`,
+      );
+      if (!response.ok) {
+        return JSON.stringify({ success: false, error: `HTTP error! status: ${response.status}` });
+      }
+
+      const task = (await response.json()) as Record<string, unknown>;
+      return JSON.stringify({
+        success: true,
+        task: {
+          id: task.id,
+          description: String(task.description ?? "").slice(0, 500),
+          rewardUsdc: typeof task.reward === "string" ? this.fromBaseUnits(task.reward) : undefined,
+          mode: task.mode,
+          status: task.status,
+          phase: task.phase,
+          submissionWindowOpen: task.submissionWindowOpen,
+          submissionCount: task.submissionCount,
+          awardCount: task.awardCount,
+          expiryTime: task.expiryTime,
+          taskVisibility: task.taskVisibility,
+          submissionVisibility: task.submissionVisibility,
+          platformFeeBps: task.platformFeeBps,
+        },
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: `Failed to fetch task: ${error}` });
+    }
+  }
+
+  /**
+   * Lists the submissions of a Taskmarket task so they can be presented for
+   * human review.
+   *
+   * @param args - The task id and optional max results.
+   * @returns A JSON string of submissions (never auto-accepts or auto-rejects).
+   */
+  @CreateAction({
+    name: "list_submissions",
+    description: `
+This tool lists the submissions on a Taskmarket task so a requester can review them. It helps present candidates to a human for a decision.
+
+It takes the following inputs:
+- taskId: the 0x-prefixed task id
+- maxResults: (optional) maximum number of submissions to return, default 50
+
+Important notes:
+- This is a read-only action and NEVER accepts or rejects work. All accept/reject decisions must be made by a human using the first-party Taskmarket CLI.
+- For tasks with a non-public submissionVisibility, the REST API only returns what the caller is entitled to see; the requester's own signed identity is handled by the official tooling.
+`,
+    schema: ListSubmissionsSchema,
+  })
+  async listSubmissions(args: z.infer<typeof ListSubmissionsSchema>): Promise<string> {
+    try {
+      const limit = Math.min(args.maxResults ?? 50, 200);
+      const response = await fetch(
+        `${this.config.apiBase}/tasks/${encodeURIComponent(args.taskId)}/submissions`,
+      );
+      if (!response.ok) {
+        return JSON.stringify({ success: false, error: `HTTP error! status: ${response.status}` });
+      }
+
+      const submissions = (await response.json()) as Array<Record<string, unknown>>;
+      const rows = submissions.slice(0, limit).map(sub => ({
+        id: sub.id,
+        workerAddress: sub.workerAddress,
+        submittedAt: sub.submittedAt,
+        rejectedAt: sub.rejectedAt,
+        workerAgentId: sub.workerAgentId,
+        deliverableHash: sub.deliverableHash,
+        status: sub.rejectedAt ? "rejected" : "pending_review",
+      }));
+
+      return JSON.stringify({
+        success: true,
+        count: rows.length,
+        total: submissions.length,
+        submissions: rows,
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: `Failed to list submissions: ${error}` });
+    }
+  }
+
+  /**
+   * Creates a Taskmarket task as a requester, with explicit user authorization
+   * and a hard max-spend cap.
+   *
+   * The funded write is delegated to the first-party `taskmarket` CLI so legal
+   * acceptance, X402 payment, idempotency and wallet signing are handled by
+   * official tooling. This action NEVER pays without (1) the wallet being on
+   * Base, (2) the exact cost being computed and returned, (3) a fresh, explicit
+   * authorization string, and (4) the total staying under the max-spend cap.
+   *
+   * @param walletProvider - The wallet provider (must be on Base).
+   * @param args - The task specification, spend cap, and explicit authorization.
+   * @returns A JSON string with the created task id/link, or a refusal reason.
+   */
+  @CreateAction({
+    name: "create_task",
+    description: `
+This tool creates (and funds) a Taskmarket task as a requester, so an agent can delegate work to external Taskmarket workers on the USDC/Base marketplace.
+
+It takes the following inputs:
+- description: the task description shown to workers
+- rewardUsdc: the reward offered to the completing worker in whole USDC
+- durationHours: how long the task stays open, in hours
+- mode: bounty (default), claim, pitch, benchmark, or auction
+- taskVisibility: public (default), unlisted, or private
+- submissionVisibility: public (default), reveal_all, winner_only, or never
+- tags: optional up to 10 tags
+- maxSpendUsdc: (optional) hard cap on total spend; defaults to the provider limit
+- authorization: the REQUIRED explicit, fresh user authorization. It must contain the exact phrase "I authorize paying <total> USDC" where <total> is the total cost the agent must first surface to the user.
+
+CRITICAL safeguards (enforced in code, not optional):
+- The wallet MUST be connected to Base (chain 8453). Creating on any other network is refused.
+- The total cost must stay under the max-spend cap. A task that exceeds it is refused.
+- Without an exact, explicit authorization string the action REFUSES to create anything.
+- The write is delegated to the first-party taskmarket CLI; no private key is requested, stored, logged, or committed.
+- If the result is ambiguous (in-flight), the action reports it and NEVER blindly retries the payment.
+
+Example authorization to pass for a 5 USDC task: "I authorize paying 5 USDC"
+`,
+    schema: CreateTaskSchema,
+  })
+  async createTask(
+    walletProvider: EvmWalletProvider,
+    args: z.infer<typeof CreateTaskSchema>,
+  ): Promise<string> {
+    try {
+      // 1. Hard network guard: Taskmarket escrows USDC on Base only.
+      const network = walletProvider.getNetwork();
+      if (network.chainId !== String(BASE_CHAIN_ID)) {
+        return JSON.stringify({
+          success: false,
+          error: `Taskmarket tasks can only be created on Base (chain id ${BASE_CHAIN_ID}); the wallet is on chain id ${network.chainId ?? "unknown"}. Refusing to create.`,
+        });
+      }
+
+      // 2. Compute the exact total cost (reward in whole USDC; the CLI shows the exact on-chain total).
+      const totalUsdc = args.rewardUsdc;
+
+      // 3. Hard max-spend cap.
+      const maxSpendUsdc = args.maxSpendUsdc ?? this.config.maxSpendUsdc;
+      if (totalUsdc > maxSpendUsdc) {
+        return JSON.stringify({
+          success: false,
+          error: `Refusing to create task: reward ${totalUsdc} USDC exceeds the max-spend cap of ${maxSpendUsdc} USDC. Lower the reward or raise maxSpendUsdc explicitly.`,
+        });
+      }
+
+      // 4. Fresh, explicit user authorization bound to the exact amount.
+      const expectedAuthorization = `I authorize paying ${totalUsdc} USDC`;
+      if (!args.authorization.includes(expectedAuthorization)) {
+        return JSON.stringify({
+          success: false,
+          error: `Refusing to create task: no valid explicit authorization. The user must authorize the exact total by including the phrase "${expectedAuthorization}".`,
+        });
+      }
+
+      // 5. Build a safe argv array (no shell) and delegate the funded write to the first-party CLI.
+      const mode = args.mode ?? "bounty";
+      const taskVisibility = args.taskVisibility ?? "public";
+      const submissionVisibility = args.submissionVisibility ?? "public";
+      const tags = args.tags ?? [];
+
+      const cliArgs = [
+        "task",
+        "create",
+        "--description",
+        args.description,
+        "--reward",
+        String(args.rewardUsdc),
+        "--duration",
+        String(args.durationHours),
+        "--mode",
+        mode,
+        "--task-visibility",
+        taskVisibility,
+        "--submission-visibility",
+        submissionVisibility,
+      ];
+      if (tags.length > 0) {
+        cliArgs.push("--tags", tags.join(","));
+      }
+
+      let created = false;
+      let output = "";
+      let errMessage: string | undefined;
+      try {
+        const { stdout, stderr } = await execFileAsync(this.config.cli, cliArgs, {
+          timeout: this.config.cliTimeoutMs,
+          env: { ...process.env },
+        });
+        output = `${stdout}\n${stderr}`.trim();
+        created = true;
+      } catch (cliError) {
+        // An unknown settlement status must NOT be blindly retried: report it.
+        errMessage = cliError instanceof Error ? cliError.message : String(cliError);
+      }
+
+      const taskIdMatch = output.match(TASKMARKET_TASK_ID_REGEX);
+      const taskId = taskIdMatch ? taskIdMatch[0] : undefined;
+
+      if (created && taskId) {
+        return JSON.stringify({
+          success: true,
+          taskId,
+          taskUrl: `${TASKMARKET_APP_URL}/tasks/${taskId}`,
+          network: "base:8453",
+          totalUsdc,
+          authorization: expectedAuthorization,
+          note: "Track the task's live status with get_task. If the CLI reported an in-flight/ambiguous result, poll get_task by this id — do not resubmit.",
+        });
+      }
+
+      // Created but id not parsed from output: surface output verbatim, never guess.
+      if (created) {
+        return JSON.stringify({
+          success: true,
+          taskId: undefined,
+          rawOutput: output.slice(0, 2000),
+          note: "The CLI reported success. Re-run get_task or the CLI to retrieve the task id. Do not resubmit.",
+        });
+      }
+
+      return JSON.stringify({
+        success: false,
+        error: `Taskmarket task creation failed: ${errMessage ?? "unknown error"}. If this was an in-flight/ambiguous result, poll the previous task by id instead of re-submitting.`,
+        rawOutput: output.slice(0, 2000),
+      });
+    } catch (error) {
+      return JSON.stringify({ success: false, error: `Failed to create task: ${error}` });
+    }
+  }
+
+  /**
+   * Checks if the Taskmarket action provider supports the given network.
+   *
+   * @param network - The network to check.
+   * @returns True for EVM networks (writes are Base-gated inside create_task).
+   */
+  supportsNetwork = (network: Network) => network.protocolFamily === "evm";
+
+  /**
+   * Converts whole USDC to base units (6 decimals) as expected by the API.
+   *
+   * @param usdc - Whole USDC amount.
+   * @returns Base-unit string.
+   */
+  private toBaseUnits(usdc: number): string {
+    return BigInt(Math.round(usdc * 10 ** USDC_DECIMALS)).toString();
+  }
+
+  /**
+   * Converts base-unit string reward to whole USDC.
+   *
+   * @param baseUnits - Base-unit reward string from the API.
+   * @returns Whole USDC number.
+   */
+  private fromBaseUnits(baseUnits: string): number {
+    return Number(baseUnits) / 10 ** USDC_DECIMALS;
+  }
+}
+
+export const taskmarketActionProvider = () => new TaskmarketActionProvider();


### PR DESCRIPTION
## Summary

Adds a **Taskmarket action provider** to Coinbase AgentKit, letting an agent discover, track, review, and create onchain work on the [Taskmarket](https://taskmarket.dev) marketplace (USDC on Base L2) directly from AgentKit. Because AgentKit exposes every action provider through the existing `model-context-protocol` framework extension, these tools also become available automatically as MCP tools.

### Actions

| Action | Description |
| --- | --- |
| `list_tasks` | Browse open (submittable) Taskmarket tasks; optional filters for mode, max reward, search, pagination. Read-only. |
| `get_task` | Live status of a single task (status, phase, submission window, reward, submission/award counts, expiry). Read-only. |
| `list_submissions` | Present a task's submissions for human review. Read-only, and it **never** accepts or rejects work. |
| `create_task` | Create and fund a task as a requester, behind hard safety gates (below). |

### Safety model

The three read actions hit the public Taskmarket REST API and require no wallet, keys, or spend.

`create_task` is a funded onchain write and is deliberately conservative:

- **Network guard** — refuses unless the wallet is on **Base (8453)**.
- **Explicit authorization** — refuses unless the caller passes an authorization string containing the exact total the user agreed to (e.g. `I authorize paying 5 USDC`).
- **Max-spend cap** — hard per-task cap (default `TASKMARKET_MAX_TASK_SPEND_USDC`, 25 USDC); a task may not exceed it unless a higher `maxSpendUsdc` is passed explicitly.
- **First-party tooling** — the actual USDC escrow, X402 payment, legal acceptance, idempotency, and wallet signing are delegated to the official `taskmarket` CLI, so no private key, seed phrase, token, or cookie is requested, stored, logged, or committed.
- **No silent retry** — ambiguous/in-flight results are reported and the caller is told to poll by task id, never blindly re-submitting a payment whose settlement status is unknown.

### What was verified

- `pnpm install`, `pnpm run check` (tsc --noEmit), `pnpm run lint`, and `pnpm run format:check` all pass.
- Full agentkit test suite passes (`pnpm test`): **909 tests / 63 suites**, including 12 new Taskmarket-specific tests covering read parsing, reward unit conversion, network guard, max-spend cap, missing-authorization rejection, CLI delegation, and failure handling.
- The three read actions were smoke-tested **live** against `https://api.taskmarket.dev`: `list_tasks` returned real open tasks, `get_task` returned live status, and `list_submissions` parsed real submissions.

### Files

```
typescript/agentkit/src/action-providers/taskmarket/
├── taskmarketActionProvider.ts
├── taskmarketActionProvider.test.ts
├── schemas.ts
├── constants.ts
├── index.ts
└── README.md
```
Plus barrel export in `src/action-providers/index.ts` and a changeset.

### Notes

- Taskmarket does **not** currently support AgentKit (verified: no existing integration; this is the first action provider for it).
- The funded `create_task` write requires the first-party `taskmarket` CLI installed and the user's Base wallet funded with USDC — this is intentional (first-party tooling owns the money movement). The geometry of the write and all safety gates are unit-tested with the CLI execution mocked; the read path is tested against the live API.
