### PR TITLE
fix(x402): read v2 discovery resource description from top-level field

### DIFF
--- a/python/coinbase-agentkit/changelog.d/fix-x402-v2-discovery-description.bugfix.md
+++ b/python/coinbase-agentkit/changelog.d/fix-x402-v2-discovery-description.bugfix.md
@@ -1,0 +1,1 @@
+Fixed x402 discovery filtering to read the description of v2 resources from the discovery API's top-level `description` field, falling back to `metadata.description` and then `accepts[].description`

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/constants.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/constants.py
@@ -58,6 +58,8 @@ class DiscoveryResource(TypedDict, total=False):
     url: str
     resource: str
     type: str
+    # v2: the discovery API returns description as a top-level field on the resource.
+    description: str
     metadata: dict
     accepts: list[PaymentOption]
     x402_version: int

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/utils.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/x402/utils.py
@@ -196,7 +196,10 @@ def _get_resource_description(resource: DiscoveryResource) -> str:
     """Extract description from a resource based on its x402 version.
 
     - v1: description is in accepts[].description
-    - v2: description is in metadata.description
+    - v2: the discovery API returns description as a top-level field on the
+      resource; metadata.description and accepts[].description are checked
+      as fallbacks for resources published under an older or non-standard
+      v2 shape.
 
     Args:
         resource: The discovery resource
@@ -207,9 +210,21 @@ def _get_resource_description(resource: DiscoveryResource) -> str:
     """
     x402_version = resource.get("x402_version", resource.get("x402Version"))
     if x402_version == 2:
+        top_level_desc = resource.get("description")
+        if isinstance(top_level_desc, str) and top_level_desc.strip():
+            return top_level_desc
+
         metadata = resource.get("metadata", {})
         metadata_desc = metadata.get("description") if metadata else None
-        return metadata_desc if isinstance(metadata_desc, str) else ""
+        if isinstance(metadata_desc, str) and metadata_desc.strip():
+            return metadata_desc
+
+        accepts = resource.get("accepts", [])
+        for option in accepts:
+            desc = option.get("description", "")
+            if desc and desc.strip():
+                return desc
+        return ""
 
     # v1: look in accepts[].description
     accepts = resource.get("accepts", [])
@@ -224,7 +239,8 @@ def filter_by_description(resources: list[DiscoveryResource]) -> list[DiscoveryR
     """Filter resources by having a valid description.
 
     Removes resources with empty or default descriptions.
-    Supports both v1 (accepts[].description) and v2 (metadata.description) formats.
+    Supports both v1 (accepts[].description) and v2 (description, with
+    metadata.description and accepts[].description as fallbacks) formats.
 
     Args:
         resources: Array of discovery resources
@@ -278,7 +294,8 @@ def filter_by_keyword(
     """Filter resources by keyword appearing in description or URL.
 
     Case-insensitive search.
-    Supports both v1 (accepts[].description) and v2 (metadata.description) formats.
+    Supports both v1 (accepts[].description) and v2 (description, with
+    metadata.description and accepts[].description as fallbacks) formats.
 
     Args:
         resources: Array of discovery resources

--- a/python/coinbase-agentkit/tests/action_providers/x402/test_utils.py
+++ b/python/coinbase-agentkit/tests/action_providers/x402/test_utils.py
@@ -1,0 +1,89 @@
+"""Tests for x402 action provider utility functions."""
+
+from coinbase_agentkit.action_providers.x402.utils import filter_by_description
+
+
+def test_filter_by_description_keeps_v2_top_level_description():
+    """A v2 resource with a top-level description is kept."""
+    resources = [
+        {
+            "resource": "https://example.com/feed",
+            "x402_version": 2,
+            "description": "Live agent-index data",
+        }
+    ]
+
+    assert filter_by_description(resources) == resources
+
+
+def test_filter_by_description_keeps_v2_metadata_only_description():
+    """A v2 resource that only has metadata.description is kept."""
+    resources = [
+        {
+            "resource": "https://example.com/feed",
+            "x402_version": 2,
+            "metadata": {"description": "Legacy metadata-only description"},
+        }
+    ]
+
+    assert filter_by_description(resources) == resources
+
+
+def test_filter_by_description_prefers_top_level_over_metadata():
+    """The top-level description wins when both are present."""
+    resources = [
+        {
+            "resource": "https://example.com/feed",
+            "x402_version": 2,
+            "description": "Top-level wins",
+            "metadata": {"description": "Should be ignored"},
+        }
+    ]
+
+    assert len(filter_by_description(resources)) == 1
+
+
+def test_filter_by_description_drops_v2_with_no_description():
+    """A v2 resource with no description anywhere is dropped."""
+    resources = [
+        {
+            "resource": "https://example.com/feed",
+            "x402_version": 2,
+        }
+    ]
+
+    assert filter_by_description(resources) == []
+
+
+def test_filter_by_description_leaves_v1_accepts_path_unchanged():
+    """The v1 accepts[].description path is unaffected by the v2 fix."""
+    resources = [
+        {
+            "resource": "https://example.com/v1-feed",
+            "x402_version": 1,
+            "accepts": [
+                {
+                    "scheme": "exact",
+                    "network": "base",
+                    "asset": "0xusdc",
+                    "max_amount_required": "1000",
+                    "description": "v1 accepts description",
+                }
+            ],
+        }
+    ]
+
+    assert filter_by_description(resources) == resources
+
+
+def test_filter_by_description_drops_default_placeholder():
+    """Resources whose description is the discovery API's default placeholder are dropped."""
+    resources = [
+        {
+            "resource": "https://example.com/placeholder",
+            "x402_version": 2,
+            "description": "Access to protected content",
+        }
+    ]
+
+    assert filter_by_description(resources) == []

--- a/typescript/.changeset/fix-x402-v2-discovery-description.md
+++ b/typescript/.changeset/fix-x402-v2-discovery-description.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/agentkit": patch
+---
+
+Fixed x402 discovery filtering to read the description of v2 resources from the discovery API's top-level `description` field, falling back to `metadata.description` and then `accepts[].description`. Previously only `metadata.description` was checked, so `filterByDescription` and `filterByKeyword` silently dropped every v2 resource that used the top-level field, which is the shape the live Bazaar discovery API returns.

--- a/typescript/agentkit/src/action-providers/x402/constants.ts
+++ b/typescript/agentkit/src/action-providers/x402/constants.ts
@@ -67,6 +67,8 @@ export interface DiscoveryResource {
   url?: string;
   resource?: string;
   type?: string;
+  // v2: the discovery API returns description as a top-level field on the resource.
+  description?: string;
   metadata?: {
     [key: string]: unknown;
     description?: string;

--- a/typescript/agentkit/src/action-providers/x402/utils.test.ts
+++ b/typescript/agentkit/src/action-providers/x402/utils.test.ts
@@ -1,0 +1,87 @@
+import { filterByDescription } from "./utils";
+import { DiscoveryResource } from "./constants";
+
+describe("x402 Utilities", () => {
+  describe("filterByDescription", () => {
+    it("keeps a v2 resource with a top-level description", () => {
+      const resources: DiscoveryResource[] = [
+        {
+          resource: "https://example.com/feed",
+          x402Version: 2,
+          description: "Live agent-index data",
+        },
+      ];
+
+      expect(filterByDescription(resources)).toEqual(resources);
+    });
+
+    it("keeps a v2 resource that only has metadata.description", () => {
+      const resources: DiscoveryResource[] = [
+        {
+          resource: "https://example.com/feed",
+          x402Version: 2,
+          metadata: { description: "Legacy metadata-only description" },
+        },
+      ];
+
+      expect(filterByDescription(resources)).toEqual(resources);
+    });
+
+    it("prefers the top-level description over metadata.description when both are present", () => {
+      const resources: DiscoveryResource[] = [
+        {
+          resource: "https://example.com/feed",
+          x402Version: 2,
+          description: "Top-level wins",
+          metadata: { description: "Should be ignored" },
+        },
+      ];
+
+      const result = filterByDescription(resources);
+      expect(result).toHaveLength(1);
+    });
+
+    it("drops a v2 resource with no description anywhere", () => {
+      const resources: DiscoveryResource[] = [
+        {
+          resource: "https://example.com/feed",
+          x402Version: 2,
+        },
+      ];
+
+      expect(filterByDescription(resources)).toEqual([]);
+    });
+
+    it("leaves the v1 accepts[].description path unchanged", () => {
+      const resources: DiscoveryResource[] = [
+        {
+          resource: "https://example.com/v1-feed",
+          x402Version: 1,
+          accepts: [
+            {
+              scheme: "exact",
+              network: "base",
+              asset: "0xusdc",
+              maxAmountRequired: "1000",
+              description: "v1 accepts description",
+            },
+          ],
+        },
+      ];
+
+      expect(filterByDescription(resources)).toEqual(resources);
+    });
+
+    it("drops resources whose description is the discovery API's default placeholder", () => {
+      const resources: DiscoveryResource[] = [
+        {
+          resource: "https://example.com/placeholder",
+          x402Version: 2,
+          description: "Access to protected content",
+        },
+      ];
+
+      expect(filterByDescription(resources)).toEqual([]);
+    });
+  });
+});

--- a/typescript/agentkit/src/action-providers/x402/utils.ts
+++ b/typescript/agentkit/src/action-providers/x402/utils.ts
@@ -180,15 +180,31 @@ export function filterByNetwork(
 /**
  * Extracts description from a resource based on its x402 version.
  * - v1: description is in accepts[].description
- * - v2: description is in metadata.description
+ * - v2: the discovery API returns description as a top-level field on the resource;
+ *   metadata.description and accepts[].description are checked as fallbacks for
+ *   resources published under an older or non-standard v2 shape.
  *
  * @param resource - The discovery resource
  * @returns The description string or empty string if not found
  */
 function getResourceDescription(resource: DiscoveryResource): string {
   if (resource.x402Version === 2) {
+    if (typeof resource.description === "string" && resource.description.trim()) {
+      return resource.description;
+    }
+
     const metadataDesc = resource.metadata?.description;
-    return typeof metadataDesc === "string" ? metadataDesc : "";
+    if (typeof metadataDesc === "string" && metadataDesc.trim()) {
+      return metadataDesc;
+    }
+
+    const accepts = resource.accepts ?? [];
+    for (const option of accepts) {
+      if (option.description?.trim()) {
+        return option.description;
+      }
+    }
+    return "";
   }
 
   // v1: look in accepts[].description
@@ -204,7 +220,8 @@ function getResourceDescription(resource: DiscoveryResource): string {
 /**
  * Filters resources by having a valid description.
  * Removes resources with empty or default descriptions.
- * Supports both v1 (accepts[].description) and v2 (metadata.description) formats.
+ * Supports both v1 (accepts[].description) and v2 (description, with metadata.description
+ * and accepts[].description as fallbacks) formats.
  *
  * @param resources - Array of discovery resources
  * @returns Filtered array of resources with valid descriptions
@@ -240,7 +257,8 @@ export function filterByX402Version(
 /**
  * Filters resources by keyword appearing in description or URL.
  * Case-insensitive search.
- * Supports both v1 (accepts[].description) and v2 (metadata.description) formats.
+ * Supports both v1 (accepts[].description) and v2 (description, with metadata.description
+ * and accepts[].description as fallbacks) formats.
  *
  * @param resources - Array of discovery resources
  * @param keyword - The keyword to search for in descriptions and URLs


### PR DESCRIPTION
## Description

The x402 Bazaar discovery API (`https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources`)
returns v2 resources with `description` as a **top-level field on the resource**
(`resource.description`), not under `metadata.description`.

Context/disclosure: we are BYTEDev Inc, operator of PayPerByte — an x402 seller listed in the CDP
Bazaar — and noticed that our, and nearly all v2, resources never surface through
`discover_x402_services`. The defect and the fix are ecosystem-wide, not specific to any seller.

`getResourceDescription()` (TypeScript) and `_get_resource_description()` (Python) only checked
`metadata.description` for v2 resources. As a result, `filterByDescription()` /
`filter_by_description()` — and `filterByKeyword()` / `filter_by_keyword()`, which use the same
helper — discard the large majority of v2 resources returned by the live discovery API today,
since essentially none of them populate `metadata.description`.

### Scope of the defect (full-corpus verification, not a sample)

Verified by paging the entire discovery API (`limit=1000&offset=N`), reproducible the same way:

| Metric | Value |
|---|---|
| `pagination.total` | 15,155 (15,157 items actually observed across pages) |
| x402Version 2 | 14,766 |
| x402Version 1 | 391 |
| Rows with a `metadata` object at all | **0** — it is `null` on every single row |
| Rows with a non-empty top-level `description` | 15,072 |

Simulating the default discovery chain an agent actually runs (`x402Versions: [1, 2]`, a
base-mainnet wallet, no keyword/price filter): of 14,917 base-network resources, **366 survive
the current description filter (2.5%)** — those are the v1 remainder plus a handful of edge
shapes. With this fix, **14,832 survive** instead. This is not a case of the filter returning
nothing; it discards roughly 97.5% of base-network resources that would otherwise be discoverable.

This affects the published package too, not just `main`: the latest `@coinbase/agentkit` on npm
(`0.10.4`, 2025-12-19) carries the same `metadata.description`-only check at
`dist/action-providers/x402/utils.js:129-142` — the defect is already in the installable artifact,
not just in-progress work on the default branch.

### Fix

For v2 resources, both `getResourceDescription()`/`_get_resource_description()` now check, in
order:
1. `resource.description` (top-level — the live API's actual shape)
2. `resource.metadata.description` (fallback, for any resource still using the older/documented shape)
3. `accepts[].description` (fallback, mirroring the v1 path)

The v1 path (`accepts[].description` only) is unchanged. `DiscoveryResource` (TypeScript interface
/ Python `TypedDict`) gained an optional top-level `description` field to match.

This isn't a trivial one-liner: 47 insertions across the 4 changed logic files
(`utils.ts`+`constants.ts`, `utils.py`+`constants.py`), not counting the new test files, the
changeset, or the changelog entry — the fallback chain and its ordering matter, and each layer is
covered by its own test case below.

## Tests

Being upfront about the nature of this testing: I verified this with **unit tests plus live API
shape evidence**, not by running an actual chatbot/agent example end-to-end. I don't have CDP
credentials configured (intentionally, to keep this change unit-test-only), so I could not
exercise the full `discoverX402Services` action against a live wallet. The full-corpus numbers
above are from our own verification run against the live discovery API (paging the whole
corpus, not a sample) — reproducible by anyone with `limit=1000&offset=N` against the URL in the
Description section.

**TypeScript** (`typescript/agentkit/src/action-providers/x402/utils.test.ts`, new file):
- v2 resource with a top-level `description` is kept
- v2 resource with only `metadata.description` is kept (fallback still works)
- top-level `description` wins when both are present
- v2 resource with no description anywhere is dropped
- v1 `accepts[].description` path is unchanged
- the discovery API's default placeholder (`"Access to protected content"`) is still dropped

Ran via `pnpm --filter @coinbase/agentkit test` (whole package, not just this file): **903/903
passed**, including the 6 new cases. `pnpm --filter @coinbase/agentkit lint` and `tsc --noEmit`
both clean.

**Python** (`python/coinbase-agentkit/tests/action_providers/x402/test_utils.py`, new file):
same 6 cases, mirrored. Ran via `uv run pytest -m "not (e2e or integration)"` (whole package):
**669 passed** (35 e2e/integration tests correctly deselected — no credentials configured).
`uv run ruff check .` and `uv run ruff format . --check` both clean.

Also confirmed neither test run makes any live network request: the wallet-provider test suites
mock `sendAnalyticsEvent` (and `global.fetch`, on the TS side) at the module level, and this
change doesn't touch analytics/telemetry code at all — no CDP keys were configured anywhere in
either test run.

## Checklist

- [x] Added a changeset (TypeScript: `typescript/.changeset/fix-x402-v2-discovery-description.md`)
- [x] Added a changelog entry (Python: `python/coinbase-agentkit/changelog.d/fix-x402-v2-discovery-description.bugfix.md`)
- [ ] README.md — not updated. Checked `typescript/agentkit/src/action-providers/x402/README.md`;
      it doesn't document the specific location of the `description` field (v1 vs v2), so there
      was nothing inaccurate to correct. Flag in review if a maintainer wants it documented
      explicitly now that the shape is pinned down.
